### PR TITLE
Update lnf-webui.agent.md to remove metadata

### DIFF
--- a/.github/agents/lnf-webui.agent.md
+++ b/.github/agents/lnf-webui.agent.md
@@ -4,10 +4,6 @@ description: Implements and maintains the web UI/frontend for LNF, including HTM
 target: github-copilot
 infer: true
 tools: ["read", "search", "edit", "web", "execute", "github/*", "playwright/*", "agent", "todo"]
-metadata:
-  project: "LNF"
-  role: "webui"
-  scope: "frontend"
 ---
 
 You are the **Web UI/Frontend Specialist** for LangGraph Notebook Foundry (LNF). Your responsibility is the web-based user interface that enables users to generate multi-agent systems through an interactive browser experience.


### PR DESCRIPTION
Removed metadata section from the web UI agent documentation.