### PR TITLE
test: add generator node intake tests

### DIFF
--- a/tests/unit/test_generator_nodes.py
+++ b/tests/unit/test_generator_nodes.py
@@ -1,0 +1,57 @@
+"""Tests for generator graph nodes and requirement analysis."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from langgraph_system_generator.generator.agents.requirements_analyst import (
+    RequirementsAnalyst,
+)
+from langgraph_system_generator.generator.nodes import intake_node
+from langgraph_system_generator.generator.state import Constraint
+
+
+@pytest.mark.asyncio
+async def test_intake_node_returns_constraints():
+    constraints = [
+        Constraint(type="goal", value="Build a router workflow", priority=5),
+        Constraint(type="tone", value="technical", priority=3),
+    ]
+
+    with patch(
+        "langgraph_system_generator.generator.agents.requirements_analyst.ChatOpenAI",
+        return_value=MagicMock(),
+    ):
+        with patch.object(
+            RequirementsAnalyst,
+            "analyze",
+            new=AsyncMock(return_value=constraints),
+        ) as mock_analyze:
+            result = await intake_node({"user_prompt": "Build a router workflow"})
+
+    assert result == {"constraints": constraints}
+    mock_analyze.assert_awaited_once_with("Build a router workflow")
+
+
+@pytest.mark.asyncio
+async def test_requirements_analyst_fallback_truncates_prompt_on_bad_json():
+    long_prompt = "Build a workflow " + ("with a long prompt " * 15)
+    assert len(long_prompt) > 200
+
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock()
+    mock_llm.ainvoke.return_value.content = "not-json"
+
+    with patch(
+        "langgraph_system_generator.generator.agents.requirements_analyst.ChatOpenAI",
+        return_value=mock_llm,
+    ):
+        analyst = RequirementsAnalyst(model="test-model")
+        constraints = await analyst.analyze(long_prompt)
+
+    assert len(constraints) == 1
+    constraint = constraints[0]
+    assert constraint.type == "goal"
+    assert constraint.priority == 5
+    assert constraint.value == long_prompt[:200]
+    assert len(constraint.value) == 200


### PR DESCRIPTION
### Motivation
- Add unit coverage to verify the `intake_node` returns analyzer constraints and that `RequirementsAnalyst.analyze` falls back to a default `goal` constraint (priority 5) and truncates long prompts when the LLM returns malformed JSON.

### Description
- Add new tests in `tests/unit/test_generator_nodes.py` containing two async tests: one that patches `RequirementsAnalyst.analyze` (and patches `ChatOpenAI` to avoid real API calls) to assert `intake_node` returns `{"constraints": ...}`, and another that patches `generator.agents.requirements_analyst.ChatOpenAI` to return malformed JSON and asserts the fallback `Constraint` is created with `type == "goal"`, `priority == 5`, and `value` truncated to 200 characters.

### Testing
- Ran `pytest -q tests/unit/test_generator_nodes.py` and both tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69814b8055cc8327802b1d3a78f61f3e)