### PR TITLE
test: add generator agent fallback coverage

### DIFF
--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -78,8 +78,9 @@ async def test_architecture_selector_parsing(payload, expected_arch, monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_graph_designer_fallback_router(monkeypatch):
-    """GraphDesigner falls back to router design when parsing fails."""
+@pytest.mark.parametrize("arch_type", ["router", "subagents"])
+async def test_graph_designer_fallback(arch_type, monkeypatch):
+    """GraphDesigner falls back to the correct design when parsing fails."""
     monkeypatch.setattr(
         graph_designer,
         "ChatOpenAI",
@@ -87,24 +88,8 @@ async def test_graph_designer_fallback_router(monkeypatch):
     )
     designer = graph_designer.GraphDesigner()
     constraints = [Constraint(type="goal", value="x", priority=5)]
-    architecture = {"architecture_type": "router", "justification": "x"}
-    expected = designer._fallback_design("router")
-    result = await designer.design_workflow(architecture, constraints)
-    assert result == expected
-
-
-@pytest.mark.asyncio
-async def test_graph_designer_fallback_subagents(monkeypatch):
-    """GraphDesigner falls back to subagents design when parsing fails."""
-    monkeypatch.setattr(
-        graph_designer,
-        "ChatOpenAI",
-        make_stub_llm("invalid"),
-    )
-    designer = graph_designer.GraphDesigner()
-    constraints = [Constraint(type="goal", value="x", priority=5)]
-    architecture = {"architecture_type": "subagents", "justification": "x"}
-    expected = designer._fallback_design("subagents")
+    architecture = {"architecture_type": arch_type, "justification": "x"}
+    expected = designer._fallback_design(arch_type)
     result = await designer.design_workflow(architecture, constraints)
     assert result == expected
 


### PR DESCRIPTION
### Motivation
- Add unit coverage for generator agents' resilience when LLM responses cannot be parsed as JSON.
- Ensure each agent falls back to a safe default rather than raising on malformed LLM payloads.
- Validate behavior by stubbing the LLM responses to deterministic `.content` payloads so parsing and fallback logic can be exercised in isolation.

### Description
- Add `tests/unit/test_generator_agents.py` which introduces a `DummyResponse` and `make_stub_llm` to stub `ChatOpenAI` and its `ainvoke` to return objects with a `.content` string.
- Add tests that assert `RequirementsAnalyst.analyze` returns a parsed `Constraint` when JSON is provided and a fallback `Constraint` when parsing fails using minimal prompt strings.
- Add tests that assert `ArchitectureSelector.select_architecture` returns the parsed architecture on valid JSON and the router fallback on parse failure.
- Add tests that assert `GraphDesigner.design_workflow` falls back to `._fallback_design` for both `router` and `subagents`, and that `ToolchainEngineer.plan_tools` returns `[]` on parse failure.

### Testing
- Ran `pytest tests/unit/test_generator_agents.py` which executed the new test module.
- All tests passed: `8 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69814bba143883278585988fef74fe71)