### PR TITLE
Make advanced generation options truthful (#259)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Then open your browser to `http://localhost:8000` to access the web UI.
 
 - **Interactive Form**: Enter your system requirements in natural language
 - **Mode Selection**: Choose between stub mode (fast, no API key) or live mode (full LLM generation)
-- **Advanced Options**: Customize model, temperature, max tokens, agent type, and memory configuration
+- **Advanced Options**: Customize the OpenAI-compatible model, temperature, max tokens, agent type, and custom endpoint used for live generation
 - **Theme Toggle**: Switch between dark and light themes
 - **Progress Tracking**: Real-time progress bar with detailed generation steps
 - **Generation History**: Track and reuse previous configurations

--- a/src/langgraph_system_generator/api/server.py
+++ b/src/langgraph_system_generator/api/server.py
@@ -39,6 +39,19 @@ _DEFAULT_API_OUTPUT = (_BASE_OUTPUT / "api").resolve()
 # Concurrency limit for async generation (prevent resource exhaustion)
 _MAX_CONCURRENT_GENERATIONS = int(os.getenv("LNF_MAX_CONCURRENT_GENERATIONS", "5"))
 _generation_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_GENERATIONS)
+_SUPPORTED_OPENAI_MODELS = {
+    "gpt-5.2",
+    "gpt-5-mini",
+    "gpt-5-nano",
+    "gpt-5.1",
+}
+_UNSUPPORTED_ADVANCED_FIELDS = (
+    "memory_config",
+    "preset",
+    "graph_style",
+    "retriever_type",
+    "document_loader",
+)
 
 
 def _resolve_output_dir(path: str | os.PathLike[str] | None) -> Path:
@@ -84,6 +97,46 @@ def _resolve_artifact_path(path: str | os.PathLike[str]) -> Path:
     return artifact_path
 
 
+def _validate_advanced_options(request: "GenerationRequest") -> None:
+    """Reject unsupported advanced options and invalid model/provider combinations."""
+
+    unsupported_fields = [
+        field_name
+        for field_name in _UNSUPPORTED_ADVANCED_FIELDS
+        if getattr(request, field_name) not in (None, "")
+    ]
+    if unsupported_fields:
+        supported_fields = "model, temperature, max_tokens, custom_endpoint, agent_type"
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported advanced options: {', '.join(unsupported_fields)}. "
+                f"Currently supported options are: {supported_fields}."
+            ),
+        )
+
+    if request.custom_endpoint and request.model in (None, "", "custom"):
+        raise HTTPException(
+            status_code=400,
+            detail="custom_endpoint requires an explicit OpenAI-compatible model identifier.",
+        )
+
+    if request.model == "custom":
+        raise HTTPException(
+            status_code=400,
+            detail="Provide an explicit model identifier instead of the placeholder value 'custom'.",
+        )
+
+    if request.model and not request.custom_endpoint and request.model not in _SUPPORTED_OPENAI_MODELS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Unsupported model for the built-in provider. Choose an OpenAI-compatible model "
+                "or set custom_endpoint with an explicit model identifier."
+            ),
+        )
+
+
 class GenerationRequest(BaseModel):
     prompt: str = Field(
         ...,
@@ -105,15 +158,15 @@ class GenerationRequest(BaseModel):
     # Advanced options
     model: Optional[str] = Field(
         default=None,
-        description="LLM model to use (e.g., gpt-4, gpt-3.5-turbo, claude-3-opus, etc.). Uses default if not specified.",
+        description="OpenAI-compatible model to use for generation. Uses the default OpenAI-compatible model if not specified.",
     )
     custom_endpoint: Optional[str] = Field(
         default=None,
-        description="Custom API endpoint URL for self-hosted or alternative LLM providers.",
+        description="Custom OpenAI-compatible API endpoint URL for self-hosted or proxy deployments.",
     )
     preset: Optional[str] = Field(
         default=None,
-        description="Task preset (code-generation, data-analysis, customer-support, etc.) for optimized settings.",
+        description="Reserved for future support; currently rejected when set.",
     )
     temperature: Optional[float] = Field(
         default=None,
@@ -139,19 +192,19 @@ class GenerationRequest(BaseModel):
     )
     memory_config: Optional[str] = Field(
         default=None,
-        description="Memory configuration for the agent (none, short, long, full).",
+        description="Reserved for future support; currently rejected when set.",
     )
     graph_style: Optional[str] = Field(
         default=None,
-        description="Graph execution style (sequential, parallel, conditional, cyclic).",
+        description="Reserved for future support; currently rejected when set.",
     )
     retriever_type: Optional[str] = Field(
         default=None,
-        description="Document retriever type for RAG (vector, keyword, hybrid, mmr).",
+        description="Reserved for future support; currently rejected when set.",
     )
     document_loader: Optional[str] = Field(
         default=None,
-        description="Document loader type (text, pdf, web, markdown, json, csv).",
+        description="Reserved for future support; currently rejected when set.",
     )
 
 
@@ -222,6 +275,8 @@ async def chrome_devtools_endpoint():
 async def generate_notebook(request: GenerationRequest) -> GenerationResponse:
     """Generate notebook artifacts via the generator pipeline."""
 
+    _validate_advanced_options(request)
+
     # Use the secure path resolution function
     output_path = _resolve_output_dir(request.output_dir)
 
@@ -277,6 +332,8 @@ async def start_async_generation(
     Raises:
         HTTPException 503: When concurrent generation limit is reached
     """
+    _validate_advanced_options(request)
+
     # Validate output directory
     output_path = _resolve_output_dir(request.output_dir)
 

--- a/src/langgraph_system_generator/api/static/app.js
+++ b/src/langgraph_system_generator/api/static/app.js
@@ -30,6 +30,7 @@ const temperatureSlider = document.getElementById('temperature');
 const tempValue = document.getElementById('tempValue');
 const modelSelect = document.getElementById('model');
 const customEndpointGroup = document.getElementById('customEndpointGroup');
+const customModelInput = document.getElementById('customModel');
 
 // Theme toggle
 const themeToggle = document.getElementById('themeToggle');
@@ -72,9 +73,11 @@ temperatureSlider.addEventListener('input', (e) => {
 modelSelect.addEventListener('change', (e) => {
     if (e.target.value === 'custom') {
         customEndpointGroup.style.display = 'block';
+        customModelInput.required = true;
         document.getElementById('customEndpoint').required = true;
     } else {
         customEndpointGroup.style.display = 'none';
+        customModelInput.required = false;
         document.getElementById('customEndpoint').required = false;
     }
 });
@@ -639,13 +642,14 @@ form.addEventListener('submit', async (e) => {
     
     // Add advanced options if specified
     const model = formData.get('model');
-    if (model) data.model = model;
-    
     const customEndpoint = formData.get('customEndpoint');
-    if (customEndpoint && model === 'custom') data.custom_endpoint = customEndpoint;
-    
-    const preset = formData.get('preset');
-    if (preset) data.preset = preset;
+    const customModel = formData.get('customModel');
+    if (model === 'custom') {
+        if (customModel) data.model = customModel;
+        if (customEndpoint) data.custom_endpoint = customEndpoint;
+    } else if (model) {
+        data.model = model;
+    }
     
     const temperature = parseFloat(formData.get('temperature'));
     // Only send temperature if it differs from default (0.7)
@@ -656,18 +660,6 @@ form.addEventListener('submit', async (e) => {
     
     const agentType = formData.get('agentType');
     if (agentType) data.agent_type = agentType;
-    
-    const memoryConfig = formData.get('memoryConfig');
-    if (memoryConfig) data.memory_config = memoryConfig;
-    
-    const graphStyle = formData.get('graphStyle');
-    if (graphStyle) data.graph_style = graphStyle;
-    
-    const retrieverType = formData.get('retrieverType');
-    if (retrieverType) data.retriever_type = retrieverType;
-    
-    const documentLoader = formData.get('documentLoader');
-    if (documentLoader) data.document_loader = documentLoader;
     
     // Validate prompt length (using Unicode code points)
     if (getCharacterCount(data.prompt) > CHAR_COUNT_MAX) {
@@ -989,17 +981,18 @@ function rerunFromHistory(entry) {
     document.getElementById('outputDir').value = data.output_dir || './output/web_generated';
     
     if (data.model) {
-        document.getElementById('model').value = data.model;
-        // Trigger change event to show/hide custom endpoint
-        document.getElementById('model').dispatchEvent(new Event('change'));
+        const modelSelectElement = document.getElementById('model');
+        const optionExists = Array.from(modelSelectElement.options).some((option) => option.value === data.model);
+        modelSelectElement.value = optionExists ? data.model : 'custom';
+        modelSelectElement.dispatchEvent(new Event('change'));
+
+        if (!optionExists && customModelInput) {
+            customModelInput.value = data.model;
+        }
     }
     
     if (data.custom_endpoint) {
         document.getElementById('customEndpoint').value = data.custom_endpoint;
-    }
-    
-    if (data.preset) {
-        document.getElementById('preset').value = data.preset;
     }
     
     if (data.temperature !== undefined) {
@@ -1014,22 +1007,6 @@ function rerunFromHistory(entry) {
     
     if (data.agent_type) {
         document.getElementById('agentType').value = data.agent_type;
-    }
-    
-    if (data.memory_config) {
-        document.getElementById('memoryConfig').value = data.memory_config;
-    }
-    
-    if (data.graph_style) {
-        document.getElementById('graphStyle').value = data.graph_style;
-    }
-    
-    if (data.retriever_type) {
-        document.getElementById('retrieverType').value = data.retriever_type;
-    }
-    
-    if (data.document_loader) {
-        document.getElementById('documentLoader').value = data.document_loader;
     }
     
     // Restore output formats from history, if available

--- a/src/langgraph_system_generator/api/static/index.html
+++ b/src/langgraph_system_generator/api/static/index.html
@@ -62,11 +62,11 @@
                             <label for="mode">Generation Mode: <span class="required" aria-label="required">*</span></label>
                             <select id="mode" name="mode" aria-describedby="modeHelpText" required>
                                 <option value="stub">Stub Mode (Fast, No API Key Required)</option>
-                                <option value="live">Live Mode (Requires OpenAI API Key)</option>
+                                <option value="live">Live Mode (Requires OpenAI-Compatible Model Access)</option>
                             </select>
                             <small class="help-text" id="modeHelpText">
                                 Stub mode generates a basic scaffold without external API calls. 
-                                Live mode creates a fully customized system using LLM.
+                                Live mode creates a fully customized system using an OpenAI-compatible model or custom endpoint.
                             </small>
                         </div>
 
@@ -99,34 +99,41 @@
                                 <div class="form-group">
                                     <label for="model">
                                         Model
-                                        <span class="tooltip" tabindex="0" role="button" aria-label="Help: Select the LLM model to use for generation. Different models have different capabilities, speeds, and costs." data-tooltip="Select the LLM model to use for generation">i</span>
+                                        <span class="tooltip" tabindex="0" role="button" aria-label="Help: Select the OpenAI-compatible model to use for generation." data-tooltip="Select the OpenAI-compatible model to use for generation">i</span>
                                     </label>
                                     <select id="model" name="model">
-                                        <option value="">Default (gpt-5-nano)</option>
+                                        <option value="">Default (gpt-5-mini)</option>
                                         <optgroup label="OpenAI">
                                             <option value="gpt-5.2">GPT-5.2 (Latest, Multimodal)</option>
                                             <option value="gpt-5-mini">GPT-5 Mini (Fast, Cost-effective)</option>
                                             <option value="gpt-5-nano">GPT-5 Nano (Fastest, Cost-effective)</option>
                                             <option value="gpt-5.1">GPT-5.1</option>
                                         </optgroup>
-                                        <optgroup label="Anthropic Claude">
-                                            <option value="claude-3-opus-20240229">Claude 3 Opus (Most Capable)</option>
-                                            <option value="claude-3-5-sonnet-20241022">Claude 3.5 Sonnet (Latest)</option>
-                                            <option value="claude-3-sonnet-20240229">Claude 3 Sonnet</option>
-                                            <option value="claude-3-haiku-20240307">Claude 3 Haiku (Fastest)</option>
-                                        </optgroup>
-                                        <optgroup label="Google Gemini">
-                                            <option value="gemini-3.0-flash-exp">Gemini 3.0 Flash (Experimental)</option>
-                                            <option value="gemini-3.0-pro">Gemini 3.0 Pro</option>
-                                        </optgroup>
                                         <optgroup label="Custom">
-                                            <option value="custom">Custom Endpoint (Configure Below)</option>
+                                            <option value="custom">Custom OpenAI-Compatible Endpoint</option>
                                         </optgroup>
                                     </select>
+                                    <small class="help-text">
+                                        Live generation currently supports OpenAI-compatible models only.
+                                    </small>
                                 </div>
 
                                 <!-- Custom Endpoint Override -->
                                 <div class="form-group form-group-full" id="customEndpointGroup" style="display: none;">
+                                    <label for="customModel">
+                                        Custom Model Identifier
+                                        <span class="tooltip" tabindex="0" role="button" aria-label="Help: Enter the model name exposed by your custom endpoint" data-tooltip="Enter the model name exposed by your custom endpoint">i</span>
+                                    </label>
+                                    <input 
+                                        type="text" 
+                                        id="customModel" 
+                                        name="customModel" 
+                                        placeholder="gpt-oss-120b"
+                                        aria-describedby="customModelHelp"
+                                    >
+                                    <small class="help-text" id="customModelHelp">
+                                        Required when using a custom endpoint so the server can call a real model name instead of a placeholder.
+                                    </small>
                                     <label for="customEndpoint">
                                         Custom API Endpoint
                                         <span class="tooltip" tabindex="0" role="button" aria-label="Help: Enter custom API endpoint URL (e.g., http://localhost:8000/v1 for local models)" data-tooltip="Enter custom API endpoint URL">i</span>
@@ -149,7 +156,7 @@
                                         Task Preset
                                         <span class="tooltip" tabindex="0" role="button" aria-label="Help: Choose a preset optimized for specific use cases" data-tooltip="Choose a preset optimized for specific use cases">i</span>
                                     </label>
-                                    <select id="preset" name="preset">
+                                    <select id="preset" name="preset" disabled aria-disabled="true">
                                         <option value="">None (Custom)</option>
                                         <option value="code-generation">Code Generation</option>
                                         <option value="data-analysis">Data Analysis</option>
@@ -158,6 +165,7 @@
                                         <option value="research-assistant">Research Assistant</option>
                                         <option value="workflow-automation">Workflow Automation</option>
                                     </select>
+                                    <small class="help-text">Not yet supported by live generation.</small>
                                 </div>
 
                                 <!-- Temperature -->
@@ -215,12 +223,13 @@
                                         Memory Configuration
                                         <span class="tooltip" tabindex="0" role="button" aria-label="Help: How much context the agent should retain" data-tooltip="How much context the agent should retain">i</span>
                                     </label>
-                                    <select id="memoryConfig" name="memoryConfig">
+                                    <select id="memoryConfig" name="memoryConfig" disabled aria-disabled="true">
                                         <option value="">None</option>
                                         <option value="short">Short-term</option>
                                         <option value="long">Long-term</option>
                                         <option value="full">Full History</option>
                                     </select>
+                                    <small class="help-text">Not yet supported by live generation.</small>
                                 </div>
 
                                 <!-- Graph Style -->
@@ -229,13 +238,14 @@
                                         Graph Style
                                         <span class="tooltip" tabindex="0" role="button" aria-label="Help: Visual and execution style for the LangGraph workflow" data-tooltip="Visual and execution style for the workflow">i</span>
                                     </label>
-                                    <select id="graphStyle" name="graphStyle">
+                                    <select id="graphStyle" name="graphStyle" disabled aria-disabled="true">
                                         <option value="">Default (Auto)</option>
                                         <option value="sequential">Sequential (Linear)</option>
                                         <option value="parallel">Parallel (Concurrent)</option>
                                         <option value="conditional">Conditional (Branching)</option>
                                         <option value="cyclic">Cyclic (Loop-based)</option>
                                     </select>
+                                    <small class="help-text">Not yet supported by live generation.</small>
                                 </div>
 
                                 <!-- Retriever Options -->
@@ -244,13 +254,14 @@
                                         Retriever Type
                                         <span class="tooltip" tabindex="0" role="button" aria-label="Help: Document retrieval method for RAG-based agents" data-tooltip="Document retrieval method for RAG">i</span>
                                     </label>
-                                    <select id="retrieverType" name="retrieverType">
+                                    <select id="retrieverType" name="retrieverType" disabled aria-disabled="true">
                                         <option value="">None</option>
                                         <option value="vector">Vector Similarity (Default)</option>
                                         <option value="keyword">Keyword/BM25</option>
                                         <option value="hybrid">Hybrid (Vector + Keyword)</option>
                                         <option value="mmr">MMR (Diverse Results)</option>
                                     </select>
+                                    <small class="help-text">Not yet supported by live generation.</small>
                                 </div>
 
                                 <!-- Document Loader -->
@@ -259,7 +270,7 @@
                                         Document Loader
                                         <span class="tooltip" tabindex="0" role="button" aria-label="Help: Source types for loading documents into the system" data-tooltip="Source types for loading documents">i</span>
                                     </label>
-                                    <select id="documentLoader" name="documentLoader">
+                                    <select id="documentLoader" name="documentLoader" disabled aria-disabled="true">
                                         <option value="">Auto-detect</option>
                                         <option value="text">Plain Text</option>
                                         <option value="pdf">PDF</option>
@@ -268,6 +279,7 @@
                                         <option value="json">JSON</option>
                                         <option value="csv">CSV</option>
                                     </select>
+                                    <small class="help-text">Not yet supported by live generation.</small>
                                 </div>
 
                                 <!-- Output Formats -->
@@ -286,7 +298,7 @@
                                             <span>HTML (.html)</span>
                                         </label>
                                         <label class="checkbox-label">
-                                            <input type="checkbox" name="formats" value="markdown">
+                                            <input type="checkbox" name="formats" value="markdown" checked>
                                             <span>Markdown (.md)</span>
                                         </label>
                                         <label class="checkbox-label">

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Literal, TypedDict
 
 from langgraph_system_generator.generator.state import CellSpec, Constraint, NotebookPlan
-from langgraph_system_generator.utils.config import settings
+from langgraph_system_generator.utils.config import GenerationConfig, settings
 from langgraph_system_generator.utils.optional_deps import (
     OptionalDependencyError,
     require_optional_module,
@@ -38,7 +38,10 @@ class GenerationArtifacts(TypedDict):
     result: Dict[str, Any]
 
 
-def _default_state(prompt: str) -> Dict[str, Any]:
+def _default_state(
+    prompt: str,
+    generation_config: GenerationConfig | None = None,
+) -> Dict[str, Any]:
     """Return a baseline GeneratorState payload."""
 
     return {
@@ -58,6 +61,7 @@ def _default_state(prompt: str) -> Dict[str, Any]:
         "artifacts_manifest": {},
         "generation_complete": False,
         "error_message": None,
+        "generation_config": generation_config,
     }
 
 
@@ -121,11 +125,19 @@ def _load_generator_graph() -> Any:
     return graph_module.create_generator_graph
 
 
-def _build_stub_result(prompt: str) -> Dict[str, Any]:
+def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, Any]:
     """Create a deterministic, offline-friendly generation result."""
 
     RouterPattern, SubagentsPattern = _load_patterns()
-    architecture_type, justification = _infer_stub_architecture(prompt)
+    normalized_agent_type = (agent_type or "").strip().lower()
+    if normalized_agent_type in {"router", "subagents", "hybrid"}:
+        architecture_type = normalized_agent_type
+        justification = (
+            f"{normalized_agent_type.title()} pattern selected from the requested "
+            "agent_type override."
+        )
+    else:
+        architecture_type, justification = _infer_stub_architecture(prompt)
 
     constraints = [
         Constraint(type="goal", value=f"Deliver a notebook for: {prompt}", priority=5),
@@ -326,6 +338,14 @@ async def generate_artifacts(
     from langgraph_system_generator.notebook.composer import NotebookComposer
     from langgraph_system_generator.notebook.exporters import NotebookExporter
 
+    generation_config = GenerationConfig(
+        model=model,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        api_base=custom_endpoint,
+        agent_type=agent_type,
+    )
+
     def _report_progress(node: str, percentage: int, message: str) -> None:
         """Helper to report progress if callback is provided."""
         if progress_callback:
@@ -345,16 +365,16 @@ async def generate_artifacts(
 
     if mode == "live":
         create_generator_graph = _load_generator_graph()
-        if not os.environ.get("OPENAI_API_KEY"):
+        if not custom_endpoint and not os.environ.get("OPENAI_API_KEY"):
             raise RuntimeError("LLM API credentials are required for live generation mode.")
         _report_progress("graph_init", 10, "Creating generator graph...")
-        graph = create_generator_graph()
+        graph = create_generator_graph(generation_config=generation_config)
         _report_progress("graph_invoke", 15, "Invoking generator graph...")
-        result = await graph.ainvoke(_default_state(prompt))
+        result = await graph.ainvoke(_default_state(prompt, generation_config))
         _report_progress("graph_complete", 60, "Generator graph completed")
     else:
         _report_progress("stub", 30, "Building stub result...")
-        result = _build_stub_result(prompt)
+        result = _build_stub_result(prompt, agent_type=agent_type)
         _report_progress("stub_complete", 60, "Stub generation complete")
 
     _report_progress("serialize", 62, "Serializing results...")
@@ -375,12 +395,7 @@ async def generate_artifacts(
         "plan_title": plan_title,
     }
     
-    # Add advanced options to manifest if provided.
-    # NOTE: These parameters are currently stored as metadata for tracking and
-    # reproducibility purposes. They do not directly affect the generation pipeline
-    # in the current implementation. In live mode, the generation uses the configured
-    # LLM settings from the generator graph, not these UI-provided values.
-    # Future enhancements could integrate these parameters into the generation process.
+    # Persist request metadata for reproducibility and downstream consumers.
     if model:
         manifest["model"] = model
     if temperature is not None:

--- a/src/langgraph_system_generator/generator/agents/architecture_selector.py
+++ b/src/langgraph_system_generator/generator/agents/architecture_selector.py
@@ -11,16 +11,25 @@ from langchain_openai import ChatOpenAI
 from langgraph_system_generator.generator.state import Constraint, DocSnippet
 from langgraph_system_generator.generator.utils import extract_json_from_llm_response
 from langgraph_system_generator.rag.retriever import DocsRetriever
-from langgraph_system_generator.utils.config import settings
+from langgraph_system_generator.utils.config import ModelConfig, settings
 
 
 class ArchitectureSelector:
     """Chooses optimal LangGraph pattern architecture."""
 
     def __init__(
-        self, docs_retriever: DocsRetriever | None = None, model: str | None = None
+        self,
+        docs_retriever: DocsRetriever | None = None,
+        model: str | None = None,
+        model_config: ModelConfig | None = None,
     ):
-        self.llm = ChatOpenAI(model=model or settings.default_model, temperature=0)
+        config = model_config or ModelConfig(model=model or settings.default_model, temperature=0.0)
+        llm_kwargs = {"model": config.model, "temperature": config.temperature}
+        if config.api_base:
+            llm_kwargs["base_url"] = config.api_base
+        if config.max_tokens is not None:
+            llm_kwargs["max_tokens"] = config.max_tokens
+        self.llm = ChatOpenAI(**llm_kwargs)
         self.docs_retriever = docs_retriever
 
     async def select_architecture(

--- a/src/langgraph_system_generator/generator/agents/graph_designer.py
+++ b/src/langgraph_system_generator/generator/agents/graph_designer.py
@@ -9,14 +9,24 @@ from langchain_openai import ChatOpenAI
 
 from langgraph_system_generator.generator.state import Constraint
 from langgraph_system_generator.generator.utils import extract_json_from_llm_response
-from langgraph_system_generator.utils.config import settings
+from langgraph_system_generator.utils.config import ModelConfig, settings
 
 
 class GraphDesigner:
     """Designs the inner workflow state, nodes, and edges."""
 
-    def __init__(self, model: str | None = None):
-        self.llm = ChatOpenAI(model=model or settings.default_model, temperature=0)
+    def __init__(
+        self,
+        model: str | None = None,
+        model_config: ModelConfig | None = None,
+    ):
+        config = model_config or ModelConfig(model=model or settings.default_model, temperature=0.0)
+        llm_kwargs = {"model": config.model, "temperature": config.temperature}
+        if config.api_base:
+            llm_kwargs["base_url"] = config.api_base
+        if config.max_tokens is not None:
+            llm_kwargs["max_tokens"] = config.max_tokens
+        self.llm = ChatOpenAI(**llm_kwargs)
 
     async def design_workflow(
         self, architecture: Dict[str, Any], constraints: List[Constraint]

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -6,7 +6,6 @@ import json
 import keyword
 import re
 from typing import Any, Dict, List
-import re
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
@@ -29,8 +28,18 @@ class NotebookComposer:
     stub and offline workflows.
     """
 
-    def __init__(self, model: str | None = None):
-        self.llm = ChatOpenAI(model=model or settings.default_model, temperature=0)
+    def __init__(
+        self,
+        model: str | None = None,
+        model_config: ModelConfig | None = None,
+    ):
+        config = model_config or ModelConfig(model=model or settings.default_model, temperature=0.0)
+        llm_kwargs = {"model": config.model, "temperature": config.temperature}
+        if config.api_base:
+            llm_kwargs["base_url"] = config.api_base
+        if config.max_tokens is not None:
+            llm_kwargs["max_tokens"] = config.max_tokens
+        self.llm = ChatOpenAI(**llm_kwargs)
 
     @staticmethod
     def _safe_identifier(value: Any, fallback: str) -> str:

--- a/src/langgraph_system_generator/generator/agents/qa_repair_agent.py
+++ b/src/langgraph_system_generator/generator/agents/qa_repair_agent.py
@@ -8,14 +8,24 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from langgraph_system_generator.generator.state import CellSpec, QAReport
-from langgraph_system_generator.utils.config import settings
+from langgraph_system_generator.utils.config import ModelConfig, settings
 
 
 class QARepairAgent:
     """Validates and repairs generated notebooks."""
 
-    def __init__(self, model: str | None = None):
-        self.llm = ChatOpenAI(model=model or settings.default_model, temperature=0)
+    def __init__(
+        self,
+        model: str | None = None,
+        model_config: ModelConfig | None = None,
+    ):
+        config = model_config or ModelConfig(model=model or settings.default_model, temperature=0.0)
+        llm_kwargs = {"model": config.model, "temperature": config.temperature}
+        if config.api_base:
+            llm_kwargs["base_url"] = config.api_base
+        if config.max_tokens is not None:
+            llm_kwargs["max_tokens"] = config.max_tokens
+        self.llm = ChatOpenAI(**llm_kwargs)
 
     async def validate(self, cells: List[CellSpec]) -> List[QAReport]:
         """Run all quality checks on generated cells.

--- a/src/langgraph_system_generator/generator/agents/requirements_analyst.py
+++ b/src/langgraph_system_generator/generator/agents/requirements_analyst.py
@@ -9,14 +9,24 @@ from langchain_openai import ChatOpenAI
 
 from langgraph_system_generator.generator.state import Constraint
 from langgraph_system_generator.generator.utils import extract_json_from_llm_response
-from langgraph_system_generator.utils.config import settings
+from langgraph_system_generator.utils.config import ModelConfig, settings
 
 
 class RequirementsAnalyst:
     """Extracts structured constraints from user prompt."""
 
-    def __init__(self, model: str | None = None):
-        self.llm = ChatOpenAI(model=model or settings.default_model, temperature=0)
+    def __init__(
+        self,
+        model: str | None = None,
+        model_config: ModelConfig | None = None,
+    ):
+        config = model_config or ModelConfig(model=model or settings.default_model, temperature=0.0)
+        llm_kwargs = {"model": config.model, "temperature": config.temperature}
+        if config.api_base:
+            llm_kwargs["base_url"] = config.api_base
+        if config.max_tokens is not None:
+            llm_kwargs["max_tokens"] = config.max_tokens
+        self.llm = ChatOpenAI(**llm_kwargs)
 
     async def analyze(self, prompt: str) -> List[Constraint]:
         """Extract constraints from prompt.

--- a/src/langgraph_system_generator/generator/agents/toolchain_engineer.py
+++ b/src/langgraph_system_generator/generator/agents/toolchain_engineer.py
@@ -9,14 +9,24 @@ from langchain_openai import ChatOpenAI
 
 from langgraph_system_generator.generator.state import Constraint
 from langgraph_system_generator.generator.utils import extract_json_from_llm_response
-from langgraph_system_generator.utils.config import settings
+from langgraph_system_generator.utils.config import ModelConfig, settings
 
 
 class ToolchainEngineer:
     """Selects and configures tools for the workflow."""
 
-    def __init__(self, model: str | None = None):
-        self.llm = ChatOpenAI(model=model or settings.default_model, temperature=0)
+    def __init__(
+        self,
+        model: str | None = None,
+        model_config: ModelConfig | None = None,
+    ):
+        config = model_config or ModelConfig(model=model or settings.default_model, temperature=0.0)
+        llm_kwargs = {"model": config.model, "temperature": config.temperature}
+        if config.api_base:
+            llm_kwargs["base_url"] = config.api_base
+        if config.max_tokens is not None:
+            llm_kwargs["max_tokens"] = config.max_tokens
+        self.llm = ChatOpenAI(**llm_kwargs)
 
     async def plan_tools(
         self, workflow_design: Dict[str, Any], constraints: List[Constraint]

--- a/src/langgraph_system_generator/generator/graph.py
+++ b/src/langgraph_system_generator/generator/graph.py
@@ -70,7 +70,7 @@ def should_retry_after_repair(
     return "fail"
 
 
-def create_generator_graph() -> StateGraph:
+def create_generator_graph(*, generation_config=None) -> StateGraph:
     """Build the outer generator graph.
 
     Returns:

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List
 
-import asyncio
 import nbformat
 
 from langgraph_system_generator.generator.agents import (
@@ -39,6 +38,28 @@ from langgraph_system_generator.rag.retriever import DocsRetriever
 from langgraph_system_generator.utils.config import settings
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_model_config(state: GeneratorState):
+    """Build a per-request model config for live agent construction."""
+
+    generation_config = state.get("generation_config")
+    if generation_config is None:
+        return None
+    return generation_config.to_model_config(settings.default_model)
+
+
+def _requested_architecture_type(state: GeneratorState) -> str | None:
+    """Return an explicit architecture override when provided."""
+
+    generation_config = state.get("generation_config")
+    if generation_config is None:
+        return None
+
+    requested = (generation_config.agent_type or "").strip().lower()
+    if requested in {"router", "subagents", "hybrid"}:
+        return requested
+    return None
 
 
 def _runtime_qa_suggestions(message: str) -> List[str]:
@@ -76,7 +97,7 @@ async def intake_node(state: GeneratorState) -> Dict[str, Any]:
     Returns:
         Updated state with extracted constraints
     """
-    analyst = RequirementsAnalyst()
+    analyst = RequirementsAnalyst(model_config=_resolve_model_config(state))
     constraints = await analyst.analyze(state["user_prompt"])
 
     return {"constraints": constraints}
@@ -128,6 +149,16 @@ async def architecture_selection_node(state: GeneratorState) -> Dict[str, Any]:
     Returns:
         Updated state with architecture selection and justification
     """
+    requested_architecture = _requested_architecture_type(state)
+    if requested_architecture:
+        return {
+            "selected_patterns": {"primary": requested_architecture, "secondary": []},
+            "architecture_type": requested_architecture,
+            "architecture_justification": (
+                f"Architecture forced by request-scoped agent_type override: {requested_architecture}."
+            ),
+        }
+
     try:
         vector_store_manager = VectorStoreManager(settings.vector_store_path)
         retriever = DocsRetriever(vector_store_manager)
@@ -137,7 +168,10 @@ async def architecture_selection_node(state: GeneratorState) -> Dict[str, Any]:
         logging.warning(f"Failed to load vector store for architecture selection: {e}")
         retriever = None
 
-    selector = ArchitectureSelector(docs_retriever=retriever)
+    selector = ArchitectureSelector(
+        docs_retriever=retriever,
+        model_config=_resolve_model_config(state),
+    )
 
     architecture = await selector.select_architecture(
         state["constraints"], state["docs_context"]
@@ -162,7 +196,7 @@ async def graph_design_node(state: GeneratorState) -> Dict[str, Any]:
     Returns:
         Updated state with workflow design and notebook plan
     """
-    designer = GraphDesigner()
+    designer = GraphDesigner(model_config=_resolve_model_config(state))
 
     selected_patterns = state.get("selected_patterns", {}) or {}
     architecture_type = state.get("architecture_type")
@@ -206,7 +240,7 @@ async def tooling_plan_node(state: GeneratorState) -> Dict[str, Any]:
     Returns:
         Updated state with tools plan
     """
-    engineer = ToolchainEngineer()
+    engineer = ToolchainEngineer(model_config=_resolve_model_config(state))
 
     workflow_design = state.get("workflow_design", {})
     tools = await engineer.plan_tools(workflow_design, state["constraints"])
@@ -223,14 +257,15 @@ async def notebook_assembly_node(state: GeneratorState) -> Dict[str, Any]:
     Returns:
         Updated state with generated cells
     """
-    composer = NotebookComposer()
+    composer = NotebookComposer(model_config=_resolve_model_config(state))
 
     notebook_plan = state.get("notebook_plan")
     workflow_design = state.get("workflow_design", {})
     tools_plan = state.get("tools_plan", [])
 
     architecture = {
-        "architecture_type": state.get("selected_patterns", {}).get("primary", "router"),
+        "architecture_type": state.get("architecture_type")
+        or state.get("selected_patterns", {}).get("primary", "router"),
         "justification": state["architecture_justification"],
     }
 

--- a/src/langgraph_system_generator/generator/state.py
+++ b/src/langgraph_system_generator/generator/state.py
@@ -8,6 +8,8 @@ from typing import Annotated, Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
+from langgraph_system_generator.utils.config import GenerationConfig
+
 
 class Constraint(BaseModel):
     """User constraint specification."""
@@ -88,6 +90,7 @@ class GeneratorState(TypedDict):
     # Workflow design (added for graph designer)
     workflow_design: Optional[Dict[str, Any]]
     tools_plan: Optional[List[Dict[str, Any]]]
+    generation_config: Optional[GenerationConfig]
 
     # Generation
     # NOTE: `generated_cells` is intentionally *not* annotated with `operator.add`.

--- a/src/langgraph_system_generator/utils/config.py
+++ b/src/langgraph_system_generator/utils/config.py
@@ -56,6 +56,41 @@ class ModelConfig(BaseModel):
         return cls(**filtered)
 
 
+class GenerationConfig(BaseModel):
+    """Request-scoped live generation settings."""
+
+    model: Optional[str] = Field(default=None, description="Optional model override")
+    temperature: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=2.0,
+        description="Optional temperature override",
+    )
+    max_tokens: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Optional max_tokens override",
+    )
+    api_base: Optional[str] = Field(
+        default=None,
+        description="Optional OpenAI-compatible base URL override",
+    )
+    agent_type: Optional[str] = Field(
+        default=None,
+        description="Optional architecture override",
+    )
+
+    def to_model_config(self, default_model: str) -> ModelConfig:
+        """Resolve a per-request model configuration for live agents."""
+
+        return ModelConfig(
+            model=self.model or default_model,
+            temperature=0.0 if self.temperature is None else self.temperature,
+            api_base=self.api_base,
+            max_tokens=self.max_tokens,
+        )
+
+
 class Settings(BaseSettings):
     """Project settings loaded from environment or a `.env` file."""
 

--- a/src/langgraph_system_generator/utils/config.py
+++ b/src/langgraph_system_generator/utils/config.py
@@ -83,12 +83,16 @@ class GenerationConfig(BaseModel):
     def to_model_config(self, default_model: str) -> ModelConfig:
         """Resolve a per-request model configuration for live agents."""
 
-        return ModelConfig(
-            model=self.model or default_model,
-            temperature=0.0 if self.temperature is None else self.temperature,
-            api_base=self.api_base,
-            max_tokens=self.max_tokens,
-        )
+        config_kwargs = {
+            "model": self.model or default_model,
+            "api_base": self.api_base,
+            "max_tokens": self.max_tokens,
+        }
+        if self.temperature is not None:
+            config_kwargs["temperature"] = self.temperature
+
+        return ModelConfig(**config_kwargs)
+
 
 
 class Settings(BaseSettings):

--- a/tests/unit/test_advanced_options_ui.py
+++ b/tests/unit/test_advanced_options_ui.py
@@ -39,7 +39,7 @@ def test_advanced_options_html_structure():
     
     # Check all advanced form fields exist
     required_fields = [
-        "model", "customEndpoint", "preset", "temperature", "maxTokens", 
+        "model", "customModel", "customEndpoint", "preset", "temperature", "maxTokens",
         "agentType", "memoryConfig", "graphStyle", "retrieverType", "documentLoader"
     ]
     for field_id in required_fields:
@@ -58,11 +58,16 @@ def test_advanced_options_html_structure():
     optgroups = model_select.find_all("optgroup")
     assert len(optgroups) > 0, "Model select should have optgroups for organization"
     
-    # Verify key optgroups exist
+    # Verify supported optgroups exist
     optgroup_labels = [og.get("label") for og in optgroups]
     assert "OpenAI" in optgroup_labels, "Missing OpenAI optgroup"
-    assert "Anthropic Claude" in optgroup_labels, "Missing Anthropic Claude optgroup"
-    assert "Google Gemini" in optgroup_labels, "Missing Google Gemini optgroup"
+    assert "Custom" in optgroup_labels, "Missing Custom optgroup"
+
+    unsupported_field_ids = ["preset", "memoryConfig", "graphStyle", "retrieverType", "documentLoader"]
+    for field_id in unsupported_field_ids:
+        field = soup.find(id=field_id)
+        assert field is not None, f"Missing unsupported field with id={field_id}"
+        assert field.has_attr("disabled"), f"{field_id} should be disabled until supported"
     
     # Check JavaScript is loaded
     scripts = soup.find_all("script")
@@ -104,6 +109,8 @@ def test_advanced_options_javascript():
         "Missing change event listener for model select"
     assert "customEndpointGroup.style.display" in content, \
         "Missing logic to show/hide custom endpoint group"
+    assert "customModelInput.required = true" in content, \
+        "Missing logic to require a custom model identifier"
 
 
 def test_advanced_options_css():

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -107,6 +107,34 @@ async def test_api_generate_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 
 
 @pytest.mark.asyncio
+async def test_api_rejects_unsupported_advanced_options(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_api_unsupported_options")
+
+    import importlib
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.api.server as server_module
+
+    importlib.reload(constants_module)
+    importlib.reload(server_module)
+
+    transport = httpx.ASGITransport(app=server_module.app)
+    output_dir = constants_module._BASE_OUTPUT / tmp_path.name
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/generate",
+            json={
+                "prompt": "API prompt",
+                "mode": "stub",
+                "output_dir": str(output_dir),
+                "memory_config": "short",
+            },
+        )
+
+    assert response.status_code == 400
+    assert "Unsupported advanced options" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
 async def test_api_generate_with_formats(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -11,6 +11,7 @@ from langgraph_system_generator.generator.agents import (
     toolchain_engineer,
 )
 from langgraph_system_generator.generator.state import Constraint
+from langgraph_system_generator.utils.config import ModelConfig
 
 
 class DummyResponse:
@@ -31,6 +32,19 @@ def make_stub_llm(content: str):
             return DummyResponse(self._content)
 
     return StubLLM
+
+
+def make_capturing_llm(captured_kwargs: dict):
+    """Create a ChatOpenAI stub that records constructor kwargs."""
+
+    class CapturingLLM:
+        def __init__(self, *_args, **kwargs):
+            captured_kwargs.update(kwargs)
+
+        async def ainvoke(self, _messages):
+            return DummyResponse("[]")
+
+    return CapturingLLM
 
 
 @pytest.mark.asyncio
@@ -113,3 +127,53 @@ async def test_toolchain_engineer_parsing(payload, expected_count, monkeypatch):
     constraints = [Constraint(type="goal", value="x", priority=5)]
     result = await engineer.plan_tools({"nodes": []}, constraints)
     assert len(result) == expected_count
+
+
+def test_requirements_analyst_uses_request_scoped_model_config(monkeypatch):
+    """RequirementsAnalyst should pass request-scoped model settings to ChatOpenAI."""
+
+    captured_kwargs = {}
+
+    monkeypatch.setattr(
+        requirements_analyst,
+        "ChatOpenAI",
+        make_capturing_llm(captured_kwargs),
+    )
+
+    requirements_analyst.RequirementsAnalyst(
+        model_config=ModelConfig(
+            model="gpt-5.2",
+            temperature=0.4,
+            api_base="https://example.test/v1",
+            max_tokens=2048,
+        )
+    )
+
+    assert captured_kwargs == {
+        "model": "gpt-5.2",
+        "temperature": 0.4,
+        "base_url": "https://example.test/v1",
+        "max_tokens": 2048,
+    }
+
+
+def test_architecture_selector_uses_request_scoped_model_config(monkeypatch):
+    """ArchitectureSelector should pass request-scoped model settings to ChatOpenAI."""
+
+    captured_kwargs = {}
+
+    monkeypatch.setattr(
+        architecture_selector,
+        "ChatOpenAI",
+        make_capturing_llm(captured_kwargs),
+    )
+
+    architecture_selector.ArchitectureSelector(
+        model_config=ModelConfig(model="gpt-5-mini", temperature=0.2, max_tokens=1024)
+    )
+
+    assert captured_kwargs == {
+        "model": "gpt-5-mini",
+        "temperature": 0.2,
+        "max_tokens": 1024,
+    }

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -23,6 +23,7 @@ from langgraph_system_generator.generator.nodes import (
     tooling_plan_node,
 )
 from langgraph_system_generator.generator.state import CellSpec, Constraint, QAReport
+from langgraph_system_generator.utils.config import GenerationConfig
 
 
 class DummyResponse:
@@ -114,6 +115,21 @@ async def test_architecture_selection_node_defaults_when_missing(monkeypatch):
     assert result["selected_patterns"] == {}
     assert result["architecture_type"] == "router"
     assert result["architecture_justification"] == "Because"
+
+
+@pytest.mark.asyncio
+async def test_architecture_selection_node_honors_agent_type_override():
+    result = await architecture_selection_node(
+        {
+            "constraints": [],
+            "docs_context": [],
+            "generation_config": GenerationConfig(agent_type="subagents"),
+        }
+    )
+
+    assert result["selected_patterns"] == {"primary": "subagents", "secondary": []}
+    assert result["architecture_type"] == "subagents"
+    assert "agent_type override" in result["architecture_justification"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a request-scoped generation config and pass it through live generation
- wire supported live options into agent construction and architecture override handling
- reject unsupported advanced options instead of silently accepting them
- update the web UI to match the supported OpenAI-compatible surface
- add generator, API, and UI regression coverage for the new behavior

## Issues
- Closes #259

## Validation
- C:\\Users\\darf3\\Documents\\langgraph_system_generator\\.venv\\Scripts\\python.exe -m pytest tests/unit/test_advanced_options_ui.py tests/unit/test_generator_agents.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py -q