### PR TITLE
Harden runtime contracts and request-scoped config

### DIFF
--- a/src/langgraph_system_generator/api/progress_streaming.py
+++ b/src/langgraph_system_generator/api/progress_streaming.py
@@ -37,8 +37,26 @@ _JOB_TTL_SECONDS = 3600  # 1 hour
 # Completed job retention - keep completed jobs for clients that connect late
 _COMPLETED_JOB_TTL_SECONDS = 300  # 5 minutes
 
+
+def _get_max_events_per_job() -> int:
+    """Read the per-job event cap from the environment with safe fallback."""
+    raw_value = os.getenv("LNF_MAX_EVENTS_PER_JOB", "10000")
+
+    try:
+        parsed_value = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid LNF_MAX_EVENTS_PER_JOB value %r; falling back to default %d",
+            raw_value,
+            10000,
+        )
+        return 10000
+
+    return max(parsed_value, 1)
+
+
 # Bound replay history while still allowing one truncation marker and a terminal event.
-_MAX_EVENTS_PER_JOB = int(os.getenv("LNF_MAX_EVENTS_PER_JOB", "10000"))
+_MAX_EVENTS_PER_JOB = _get_max_events_per_job()
 
 
 def create_job() -> str:

--- a/src/langgraph_system_generator/api/progress_streaming.py
+++ b/src/langgraph_system_generator/api/progress_streaming.py
@@ -6,6 +6,7 @@ import asyncio
 from dataclasses import dataclass, field
 import json
 import logging
+import os
 import time
 from typing import Any, AsyncGenerator, Dict
 from uuid import uuid4
@@ -25,6 +26,7 @@ class JobRecord:
     next_event_id: int = 0
     completed: bool = False
     completed_at: float | None = None
+    events_truncated: bool = False
 
 
 _active_jobs: Dict[str, JobRecord] = {}
@@ -34,6 +36,9 @@ _JOB_TTL_SECONDS = 3600  # 1 hour
 
 # Completed job retention - keep completed jobs for clients that connect late
 _COMPLETED_JOB_TTL_SECONDS = 300  # 5 minutes
+
+# Bound replay history while still allowing one truncation marker and a terminal event.
+_MAX_EVENTS_PER_JOB = int(os.getenv("LNF_MAX_EVENTS_PER_JOB", "10000"))
 
 
 def create_job() -> str:
@@ -150,6 +155,37 @@ def emit_progress(
     record = _active_jobs.get(job_id)
     if record is None:
         logger.warning("Cannot emit to job %s: not found", job_id)
+        return
+
+    is_terminal = event_type in ("complete", "error")
+    if not is_terminal and len(record.events) >= _MAX_EVENTS_PER_JOB:
+        if not record.events_truncated:
+            record.events_truncated = True
+            truncation_event_id = record.next_event_id
+            record.next_event_id += 1
+            record.events.append(
+                {
+                    "id": truncation_event_id,
+                    "event": "events_truncated",
+                    "data": {
+                        "message": (
+                            "Event history truncated after "
+                            f"{_MAX_EVENTS_PER_JOB} replayable events. "
+                            "Further non-terminal events will not be stored."
+                        ),
+                        "max_events": _MAX_EVENTS_PER_JOB,
+                    },
+                }
+            )
+            logger.warning(
+                "Job %s reached the replay history limit (%d); dropping further non-terminal events",
+                job_id,
+                _MAX_EVENTS_PER_JOB,
+            )
+            try:
+                asyncio.create_task(_notify_listeners(record))
+            except RuntimeError:
+                logger.debug("Cannot notify listeners for %s - no event loop", job_id)
         return
 
     event_id = record.next_event_id

--- a/src/langgraph_system_generator/api/server.py
+++ b/src/langgraph_system_generator/api/server.py
@@ -187,7 +187,10 @@ class GenerationRequest(BaseModel):
     )
     formats: Optional[list[str]] = Field(
         default=None,
-        description="List of output formats to generate (ipynb, html, pdf, docx, zip). Generates all if not specified.",
+        description=(
+            "List of output formats to generate (ipynb, html, markdown, pdf, docx, zip). "
+            "If not specified, generates the default export set: ipynb, html, markdown, docx, zip."
+        ),
     )
     # Advanced options
     model: Optional[str] = Field(

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -740,7 +740,11 @@ def build_parser() -> argparse.ArgumentParser:
         nargs="+",
         choices=["ipynb", "html", "markdown", "pdf", "docx", "zip"],
         default=None,
-        help="Output formats to generate (default: all formats). Specify one or more.",
+        help=(
+            "Output formats to generate "
+            "(default: ipynb html markdown docx zip; PDF only when requested). "
+            "Specify one or more."
+        ),
     )
     gen.add_argument(
         "--agent-type",

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -209,7 +209,7 @@ This notebook implements a LangGraph workflow using the **{plan.architecture_typ
             "from getpass import getpass",
             "",
             "# Configuration",
-            f'MODEL = "{self.model_config.model}"',
+            f"MODEL = {json.dumps(self.model_config.model)}",
             f"TEMPERATURE = {self.model_config.temperature}",
             "MAX_ITERATIONS = 10",
             (
@@ -218,7 +218,7 @@ This notebook implements a LangGraph workflow using the **{plan.architecture_typ
                 else "MAX_TOKENS = None"
             ),
             (
-                f'API_BASE = "{self.model_config.api_base}"'
+                f"API_BASE = {json.dumps(self.model_config.api_base)}"
                 if self.model_config.api_base
                 else "API_BASE = None"
             ),

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -36,9 +36,13 @@ class NotebookComposer:
         model: str | None = None,
         model_config: ModelConfig | None = None,
     ):
+        self.model_config = model_config or ModelConfig(
+            model=model or settings.default_model,
+            temperature=0.0,
+        )
         self.llm = build_chat_llm(
             model=model,
-            model_config=model_config,
+            model_config=self.model_config,
             chat_openai_class=ChatOpenAI,
         )
 
@@ -200,19 +204,33 @@ This notebook implements a LangGraph workflow using the **{plan.architecture_typ
 
     def _create_config_cells(self) -> List[CellSpec]:
         """Create configuration cells."""
-        config_content = """import os
-from getpass import getpass
-
-# Configuration
-MODEL = "gpt-5-mini"
-MAX_ITERATIONS = 10
-
-# API Keys
-if not os.environ.get("OPENAI_API_KEY"):
-    os.environ["OPENAI_API_KEY"] = getpass("Enter OpenAI API Key: ")
-
-if not os.environ.get("ANTHROPIC_API_KEY"):
-    os.environ["ANTHROPIC_API_KEY"] = getpass("Enter Anthropic API Key (optional): ")"""
+        config_lines = [
+            "import os",
+            "from getpass import getpass",
+            "",
+            "# Configuration",
+            f'MODEL = "{self.model_config.model}"',
+            f"TEMPERATURE = {self.model_config.temperature}",
+            "MAX_ITERATIONS = 10",
+            (
+                f"MAX_TOKENS = {self.model_config.max_tokens}"
+                if self.model_config.max_tokens is not None
+                else "MAX_TOKENS = None"
+            ),
+            (
+                f'API_BASE = "{self.model_config.api_base}"'
+                if self.model_config.api_base
+                else "API_BASE = None"
+            ),
+            "",
+            "# API Keys",
+            'if not os.environ.get("OPENAI_API_KEY"):',
+            '    os.environ["OPENAI_API_KEY"] = getpass("Enter OpenAI API Key: ")',
+            "",
+            'if not os.environ.get("ANTHROPIC_API_KEY"):',
+            '    os.environ["ANTHROPIC_API_KEY"] = getpass("Enter Anthropic API Key (optional): ")',
+        ]
+        config_content = "\n".join(config_lines)
 
         return [
             CellSpec(
@@ -684,8 +702,7 @@ Generate the complete Python function implementation.""")
         """
         cells = []
 
-        # Create model config from settings
-        model_config = ModelConfig(model=settings.default_model)
+        model_config = self.model_config
 
         if architecture_type == "router":
             # Extract routes from nodes

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -174,6 +174,15 @@ async def test_api_rejects_unsupported_advanced_options(
     assert "Unsupported advanced options" in response.json()["detail"]
 
 
+def test_generation_request_formats_description_mentions_markdown():
+    description = app.openapi()["components"]["schemas"]["GenerationRequest"]["properties"][
+        "formats"
+    ]["description"]
+
+    assert "markdown" in description.lower()
+    assert "ipynb, html, markdown, docx, zip" in description
+
+
 @pytest.mark.asyncio
 async def test_api_accepts_arbitrary_openai_compatible_model_id(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -8,6 +8,7 @@ import pytest
 
 from langgraph_system_generator.generator.agents import notebook_composer as composer_module
 from langgraph_system_generator.generator.state import NotebookPlan
+from langgraph_system_generator.utils.config import ModelConfig
 
 
 class DummyLLM:
@@ -286,3 +287,81 @@ def test_graph_fallback_uses_sanitized_function_references(
     assert 'workflow.add_node("start node", start_node_node)' in graph_code
     assert 'workflow.add_node("9 result-node", _9_result_node_node)' in graph_code
     compile(graph_code, "<graph_fallback>", "exec")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "architecture_type",
+    ["router", "subagents", "critique_loop", "autoagent"],
+)
+async def test_pattern_nodes_use_request_scoped_model_config(
+    monkeypatch: pytest.MonkeyPatch,
+    architecture_type: str,
+):
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer(
+        model_config=ModelConfig(
+            model="gpt-5.2",
+            temperature=0.3,
+            api_base="https://example.test/v1",
+            max_tokens=2048,
+        )
+    )
+
+    plan = NotebookPlan(
+        title="Configured Workflow Notebook",
+        sections=["Installation", "Workflow", "Execution"],
+        patterns_used=[architecture_type],
+        architecture_type=architecture_type,
+    )
+
+    if architecture_type == "router":
+        nodes = [
+            {"name": "router", "purpose": "Route requests"},
+            {"name": "search", "purpose": "Search documents"},
+        ]
+    elif architecture_type == "subagents":
+        nodes = [
+            {"name": "supervisor", "purpose": "Coordinate agents"},
+            {"name": "researcher", "purpose": "Research documents"},
+        ]
+    elif architecture_type == "autoagent":
+        nodes = [{"name": "planner", "purpose": "Plan the work"}]
+    else:
+        nodes = [
+            {"name": "generate", "purpose": "Generate an initial draft"},
+            {"name": "critique", "purpose": "Critique the current draft"},
+            {"name": "revise", "purpose": "Revise the draft using feedback"},
+        ]
+
+    cells = await composer.compose_notebook(
+        notebook_plan=plan,
+        workflow_design={
+            "architecture_type": architecture_type,
+            "state_schema": {"user_input": "User question"},
+            "nodes": nodes,
+        },
+        tools=[],
+        architecture={
+            "architecture_type": architecture_type,
+            "justification": "Matches the workflow requirements.",
+        },
+    )
+
+    node_cells = [cell for cell in cells if cell.section == "nodes"]
+    assert node_cells
+    assert any(
+        "ChatOpenAI(model='gpt-5.2', temperature=0.3, base_url='https://example.test/v1', max_tokens=2048)"
+        in cell.content
+        for cell in node_cells
+    )
+
+    setup_code_cells = [
+        cell
+        for cell in cells
+        if cell.section == "setup" and cell.cell_type == "code"
+    ]
+    assert any('MODEL = "gpt-5.2"' in cell.content for cell in setup_code_cells)
+    assert any("TEMPERATURE = 0.3" in cell.content for cell in setup_code_cells)
+    assert any('API_BASE = "https://example.test/v1"' in cell.content for cell in setup_code_cells)
+    assert any("MAX_TOKENS = 2048" in cell.content for cell in setup_code_cells)

--- a/tests/unit/test_progress_streaming.py
+++ b/tests/unit/test_progress_streaming.py
@@ -61,8 +61,10 @@ async def test_progress_streaming_resumes_after_last_event_id():
 
 
 @pytest.mark.asyncio
-async def test_completed_job_cleanup_waits_for_retention_window(monkeypatch: pytest.MonkeyPatch):
-    """Completed jobs should not be removed before the retention sleep occurs."""
+async def test_completed_job_cleanup_waits_for_retention_window(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Completed jobs should not be removed before the retention window expires."""
     sleep_calls: list[float] = []
 
     async def fake_sleep(delay: float) -> None:
@@ -79,3 +81,29 @@ async def test_completed_job_cleanup_waits_for_retention_window(monkeypatch: pyt
 
     assert sleep_calls == [progress_streaming._COMPLETED_JOB_TTL_SECONDS]
     assert job_id not in progress_streaming._active_jobs
+@pytest.mark.asyncio
+async def test_progress_streaming_truncates_history_after_configured_limit(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Replay history should stay bounded and emit a truncation marker."""
+    monkeypatch.setattr(progress_streaming, "_MAX_EVENTS_PER_JOB", 2, raising=False)
+
+    job_id = progress_streaming.create_job()
+    progress_streaming.emit_node_progress(job_id, "start", 0, "Starting generation...")
+    progress_streaming.emit_node_progress(job_id, "compose", 50, "Composing notebook...")
+    progress_streaming.emit_log(job_id, "info", "This event should be dropped")
+    progress_streaming.emit_complete(job_id, {"success": True})
+
+    events = await _collect_events(job_id)
+
+    assert [event["event"] for event in events] == [
+        "progress",
+        "progress",
+        "events_truncated",
+        "complete",
+    ]
+    assert events[2]["data"]["max_events"] == 2
+    assert "truncated" in events[2]["data"]["message"].lower()
+    assert events[3]["data"]["success"] is True
+
+    progress_streaming.cleanup_job(job_id)


### PR DESCRIPTION
## Summary
- bound SSE replay history with a truncation signal and correct completed-job retention behavior
- thread request-scoped model configuration through pattern-generated notebook code and generated config cells
- align API and CLI format descriptions with the actual default export set, including Markdown

## Testing
- pytest tests/unit -q

## Notes
- this is the first implementation slice of the broader runtime-contract hardening roadmap, scoped to concrete contract fixes and regression coverage