### PR TITLE
Finish shared platform hardening for exports and errors

### DIFF
--- a/docs/NOTEBOOK_OUTPUT_GUIDE.md
+++ b/docs/NOTEBOOK_OUTPUT_GUIDE.md
@@ -185,20 +185,43 @@ The `NotebookComposer` automatically adds these sections if not present, ensurin
 
 ## Error Handling
 
-Export errors are handled gracefully:
+Export outcomes are tracked in the manifest with structured status:
 
 ```json
 {
   "notebook_path": "./output/notebook.ipynb",
   "html_path": "./output/notebook.html",
-  "pdf_error": "webpdf export failed: jupyter command not found..."
+  "warnings": [
+    {
+      "phase": "export_pdf",
+      "format": "pdf",
+      "message": "PDF export requires nbconvert."
+    }
+  ],
+  "export_results": {
+    "html": {
+      "requested": true,
+      "status": "completed",
+      "path": "./output/notebook.html"
+    },
+    "pdf": {
+      "requested": false,
+      "status": "failed",
+      "path": null,
+      "error": {
+        "code": "dependency_unavailable",
+        "phase": "export_pdf",
+        "message": "PDF export requires nbconvert."
+      }
+    }
+  }
 }
 ```
 
 If an export fails:
-- The error is captured in the manifest (e.g., `pdf_error`)
-- Other exports continue normally
-- The main notebook generation always succeeds
+- Explicitly requested formats fail the overall request with a structured error
+- Default convenience exports are downgraded to manifest warnings when possible
+- Legacy `*_error` keys may still appear for compatibility, but `export_results` is the source of truth
 
 ## Dependencies
 

--- a/docs/NOTEBOOK_OUTPUT_GUIDE.md
+++ b/docs/NOTEBOOK_OUTPUT_GUIDE.md
@@ -220,6 +220,7 @@ Export outcomes are tracked in the manifest with structured status:
 
 If an export fails:
 - Explicitly requested formats fail the overall request with a structured error
+- PDF export remains best-effort even when selected, because `webpdf` host dependencies are environment-sensitive
 - Default convenience exports are downgraded to manifest warnings when possible
 - Legacy `*_error` keys may still appear for compatibility, but `export_results` is the source of truth
 

--- a/docs/wiki/CLI-and-API-Reference.md
+++ b/docs/wiki/CLI-and-API-Reference.md
@@ -521,6 +521,10 @@ phase timing, per-format export status, and non-fatal warnings:
 }
 ```
 
+Requested formats are strict by default, but PDF remains best-effort because
+the `webpdf` toolchain depends on host Playwright/browser support that may not
+be installed in every environment.
+
 ## Advanced Usage
 
 ### Custom Pipeline Stages

--- a/docs/wiki/CLI-and-API-Reference.md
+++ b/docs/wiki/CLI-and-API-Reference.md
@@ -472,59 +472,50 @@ Every successful generation produces:
 
 ### Manifest Structure
 
-The `manifest.json` contains complete generation metadata:
+The `manifest.json` contains complete generation metadata, including structured
+phase timing, per-format export status, and non-fatal warnings:
 
 ```json
 {
   "prompt": "User's original prompt",
   "mode": "stub | live",
-  "architecture": "router | subagents | hybrid",
-  "patterns": ["router"],
-  "timestamp": "YYYY-MM-DDTHH:MM:SSZ",
-  "version": "<current_version>",
-  
-  "artifacts": {
-    "notebook": "./notebook.ipynb",
-    "html": "./notebook.html",
-    "docx": "./notebook.docx",
-    "pdf": "./notebook.pdf",
-    "zip": "./notebook_bundle.zip",
-    "plan": "./notebook_plan.json",
-    "cells": "./generated_cells.json"
-  },
-  
-  "qa_status": {
-    "passed": true,
-    "checks_performed": 5,
-    "checks_passed": 5,
-    "checks_failed": 0,
-    "repair_attempts": 0
-  },
-  
-  "metadata": {
-    "cells_generated": 12,
-    "sections": [
-      "Setup & Configuration",
-      "State Definition",
-      "Node Implementation",
-      "Graph Construction",
-      "Execution & Testing"
-    ],
-    "generation_time_ms": 850,
-    "model_used": "gpt-4-turbo-preview",
-    "tokens_used": 15432
-  },
-  
-  "qa_reports": [
+  "architecture_type": "router | subagents | hybrid | autoagent",
+  "plan_title": "LangGraph Workflow: Example",
+  "notebook_path": "./output/api/notebook.ipynb",
+  "html_path": "./output/api/notebook.html",
+  "zip_path": "./output/api/notebook_bundle.zip",
+  "warnings": [
     {
-      "check_name": "json_structure",
-      "passed": true,
-      "message": "Notebook structure is valid"
+      "code": "dependency_unavailable",
+      "phase": "export_pdf",
+      "format": "pdf",
+      "message": "PDF export requires nbconvert.",
+      "hint": "Install the full extra with: pip install -e \".[full]\""
+    }
+  ],
+  "export_results": {
+    "ipynb": {
+      "requested": true,
+      "status": "completed",
+      "path": "./output/api/notebook.ipynb"
     },
+    "pdf": {
+      "requested": false,
+      "status": "failed",
+      "path": null,
+      "error": {
+        "code": "dependency_unavailable",
+        "phase": "export_pdf",
+        "message": "PDF export requires nbconvert."
+      }
+    }
+  },
+  "phase_summary": [
     {
-      "check_name": "required_sections",
-      "passed": true,
-      "message": "All required sections present"
+      "phase": "compose",
+      "status": "completed",
+      "message": "Notebook composed successfully.",
+      "duration_ms": 42
     }
   ]
 }

--- a/src/langgraph_system_generator/api/progress_streaming.py
+++ b/src/langgraph_system_generator/api/progress_streaming.py
@@ -252,15 +252,23 @@ def emit_node_progress(
     )
 
 
-def emit_log(job_id: str, level: str, message: str) -> None:
+def emit_log(
+    job_id: str,
+    level: str,
+    message: str,
+    details: Dict[str, Any] | None = None,
+) -> None:
     """Emit a log message to the job's SSE stream."""
+    payload = {
+        "level": level,
+        "message": message,
+    }
+    if details:
+        payload["details"] = details
     emit_progress(
         job_id,
         "log",
-        {
-            "level": level,
-            "message": message,
-        },
+        payload,
         log=False,
     )
 

--- a/src/langgraph_system_generator/api/server.py
+++ b/src/langgraph_system_generator/api/server.py
@@ -25,9 +25,11 @@ from langgraph_system_generator.api.progress_streaming import (
     create_job,
     emit_complete,
     emit_error,
+    emit_log,
     emit_node_progress,
     get_stream_response,
 )
+from langgraph_system_generator.utils.error_handling import GenerationError
 from langgraph_system_generator.utils.generation_options import (
     SUPPORTED_AGENT_TYPES,
     normalize_agent_type,
@@ -48,6 +50,46 @@ _DEFAULT_API_OUTPUT = (_BASE_OUTPUT / "api").resolve()
 _MAX_CONCURRENT_GENERATIONS = int(os.getenv("LNF_MAX_CONCURRENT_GENERATIONS", "5"))
 _generation_lock = asyncio.Lock()
 _active_generation_count = 0
+
+
+def _generation_error_payload(exc: Exception) -> dict[str, Any]:
+    """Normalize exceptions into a structured API error payload."""
+
+    if isinstance(exc, GenerationError):
+        return exc.to_payload()
+
+    if isinstance(exc, OptionalDependencyError):
+        payload: dict[str, Any] = {
+            "code": "dependency_unavailable",
+            "message": str(exc),
+            "status_code": 503,
+        }
+        if exc.hint:
+            payload["hint"] = exc.hint
+        details = {}
+        if exc.dependency:
+            details["dependency"] = exc.dependency
+        if exc.extra:
+            details["extra"] = exc.extra
+        if details:
+            payload["details"] = details
+        return payload
+
+    return {
+        "code": "generation_error",
+        "message": str(exc),
+        "status_code": 500,
+        "details": {"error_type": type(exc).__name__},
+    }
+
+
+def _raise_generation_http_error(exc: Exception) -> None:
+    """Raise an HTTPException from a normalized generation error."""
+
+    payload = _generation_error_payload(exc)
+    raise HTTPException(status_code=payload["status_code"], detail=payload)
+
+
 async def _try_acquire_generation_slot() -> bool:
     """Reserve a generation slot if capacity is available."""
     global _active_generation_count
@@ -309,8 +351,6 @@ async def generate_notebook(request: GenerationRequest) -> GenerationResponse:
     """Generate notebook artifacts via the generator pipeline."""
     normalized_request = _normalize_request(request)
 
-    _validate_advanced_options(request)
-
     # Use the secure path resolution function
     output_path = _resolve_output_dir(request.output_dir)
 
@@ -335,13 +375,15 @@ async def generate_notebook(request: GenerationRequest) -> GenerationResponse:
                 manifest_path=artifacts["manifest_path"],
                 output_dir=artifacts["output_dir"],
             )
-        except (
-            OptionalDependencyError,
-            RuntimeError,
-            ValueError,
-        ) as exc:  # pragma: no cover - surfaced via HTTPException
+        except (GenerationError, OptionalDependencyError) as exc:
+            logging.exception("Generation request failed")
+            _raise_generation_http_error(exc)
+        except ValueError as exc:  # pragma: no cover - surfaced via HTTPException
             logging.exception("Generation request failed")
             raise HTTPException(status_code=400, detail=str(exc))
+        except Exception as exc:  # pragma: no cover - defensive
+            logging.exception("Generation request failed")
+            _raise_generation_http_error(exc)
 
 
 @app.post("/generate-async", response_model=GenerationStartResponse)
@@ -364,8 +406,6 @@ async def start_async_generation(
         HTTPException 503: When concurrent generation limit is reached
     """
     normalized_request = _normalize_request(request)
-
-    # Validate output directory
     output_path = _resolve_output_dir(request.output_dir)
 
     # Acquire capacity before the job is accepted so overload requests fail fast.
@@ -436,9 +476,33 @@ async def _run_generation_with_progress(
         # Run generation
         emit_node_progress(job_id, "generation", 10, "Initializing generator...")
 
-        def progress_callback(node: str, percentage: int, message: str) -> None:
+        def progress_callback(event: Any, percentage: int | None = None, message: str | None = None) -> None:
             """Forward progress to SSE stream."""
-            emit_node_progress(job_id, node, percentage, message)
+            if isinstance(event, dict):
+                event_type = event.get("event", "progress")
+                phase = event.get("phase") or event.get("node") or "generation"
+                event_message = event.get("message", "")
+                if event_type == "log":
+                    emit_log(
+                        job_id,
+                        event.get("status", "info"),
+                        event_message,
+                        details={
+                            "phase": phase,
+                            "details": event.get("details", {}),
+                        },
+                    )
+                else:
+                    emit_node_progress(
+                        job_id,
+                        phase,
+                        int(event.get("percentage", 0)),
+                        event_message,
+                        status=event.get("status", "running"),
+                    )
+                return
+
+            emit_node_progress(job_id, str(event), int(percentage or 0), message or "")
 
         artifacts: GenerationArtifacts = await generate_artifacts(
             request.prompt,
@@ -467,10 +531,29 @@ async def _run_generation_with_progress(
 
     except Exception as exc:
         logging.exception(f"Generation failed for job {job_id}")
+        payload = _generation_error_payload(exc)
+        emit_log(
+            job_id,
+            "error",
+            payload["message"],
+            details={
+                "phase": payload.get("phase"),
+                "code": payload.get("code"),
+                "hint": payload.get("hint"),
+                "details": payload.get("details", {}),
+            },
+        )
         emit_error(
             job_id,
-            str(exc),
-            {"type": type(exc).__name__},
+            payload["message"],
+            {
+                "type": type(exc).__name__,
+                "code": payload.get("code"),
+                "phase": payload.get("phase"),
+                "hint": payload.get("hint"),
+                "status_code": payload.get("status_code"),
+                "details": payload.get("details", {}),
+            },
         )
     finally:
         await _release_generation_slot()

--- a/src/langgraph_system_generator/api/static/app.js
+++ b/src/langgraph_system_generator/api/static/app.js
@@ -17,6 +17,7 @@ const progressFill = document.getElementById('progressFill');
 const progressText = document.getElementById('progressText');
 const progressPercentage = document.getElementById('progressPercentage');
 const progressSteps = document.getElementById('progressSteps');
+let currentEventSource = null;
 
 // Validation constants
 const CHAR_COUNT_MIN = 10;
@@ -360,205 +361,107 @@ function showProgress(step, percentage, message) {
 // Show success result
 function showResult(data) {
     hideResults();
-    
+
     const manifest = data.manifest || {};
     const mode = data.mode || 'unknown';
-    
-    // Clear any previous content
+    const warnings = Array.isArray(manifest.warnings) ? manifest.warnings : [];
+
     resultContent.replaceChildren();
-    
-    // Create result content wrapper
+
     const resultWrapper = document.createElement('div');
     resultWrapper.className = 'result-content';
-    
-    // Success message
+
     const successItem = document.createElement('div');
     successItem.className = 'result-item';
-    
+
     const successHeading = document.createElement('h3');
     successHeading.style.color = 'var(--success-color)';
     successHeading.style.marginBottom = '0.5rem';
-    successHeading.textContent = 'Generation Successful!';
-    
+    successHeading.textContent = warnings.length > 0
+        ? 'Generation Completed With Warnings'
+        : 'Generation Successful!';
+
     const successParagraph = document.createElement('p');
-    successParagraph.textContent = 'Your system was generated in ';
-    
-    const modeStrong = document.createElement('strong');
-    modeStrong.textContent = mode;
-    
-    successParagraph.appendChild(modeStrong);
-    successParagraph.appendChild(document.createTextNode(' mode.'));
-    
+    successParagraph.textContent = `Your system was generated in ${mode} mode.`;
+
     successItem.appendChild(successHeading);
     successItem.appendChild(successParagraph);
     resultWrapper.appendChild(successItem);
-    
-    // Architecture type
+
     if (manifest.architecture_type) {
         const archItem = document.createElement('div');
         archItem.className = 'result-item';
-        
-        const archLabel = document.createElement('strong');
-        archLabel.textContent = 'Architecture: ';
-        
-        const archValue = document.createElement('span');
-        archValue.style.color = 'var(--primary-color)';
-        archValue.textContent = manifest.architecture_type;
-        
-        archItem.appendChild(archLabel);
-        archItem.appendChild(archValue);
+        archItem.innerHTML = `<strong>Architecture:</strong> <span style="color: var(--primary-color);">${manifest.architecture_type}</span>`;
         resultWrapper.appendChild(archItem);
     }
-    
-    // Plan title
+
     if (manifest.plan_title) {
         const planItem = document.createElement('div');
         planItem.className = 'result-item';
-        
-        const planLabel = document.createElement('strong');
-        planLabel.textContent = 'Plan Title: ';
-        
-        const planValue = document.createTextNode(manifest.plan_title);
-        
-        planItem.appendChild(planLabel);
-        planItem.appendChild(planValue);
+        planItem.innerHTML = `<strong>Plan Title:</strong> ${manifest.plan_title}`;
         resultWrapper.appendChild(planItem);
     }
-    
-    // Cell count
+
     if (manifest.cell_count) {
         const cellItem = document.createElement('div');
         cellItem.className = 'result-item';
-        
-        const cellLabel = document.createElement('strong');
-        cellLabel.textContent = 'Generated Cells: ';
-        
-        const cellValue = document.createTextNode(String(manifest.cell_count));
-        
-        cellItem.appendChild(cellLabel);
-        cellItem.appendChild(cellValue);
+        cellItem.innerHTML = `<strong>Generated Cells:</strong> ${String(manifest.cell_count)}`;
         resultWrapper.appendChild(cellItem);
     }
-    
-    // Output directory
-    if (data.manifest_path) {
+
+    if (data.output_dir) {
         const outputItem = document.createElement('div');
         outputItem.className = 'result-item';
-        
-        const outputLabel = document.createElement('strong');
-        outputLabel.textContent = 'Output Directory: ';
-        
-        const outputCode = document.createElement('code');
-        outputCode.style.background = 'var(--bg-tertiary)';
-        outputCode.style.padding = '0.25rem 0.5rem';
-        outputCode.style.borderRadius = '0.25rem';
-        outputCode.textContent = data.output_dir || 'output/';
-        
-        outputItem.appendChild(outputLabel);
-        outputItem.appendChild(outputCode);
+        outputItem.innerHTML = `<strong>Output Directory:</strong> <code>${data.output_dir}</code>`;
         resultWrapper.appendChild(outputItem);
     }
-    
-    // Notebook plan path
-    if (manifest.plan_path) {
-        const planPathItem = document.createElement('div');
-        planPathItem.className = 'result-item';
-        
-        const planPathLabel = document.createElement('strong');
-        planPathLabel.textContent = 'Notebook Plan: ';
-        
-        const planPathCode = document.createElement('code');
-        planPathCode.style.background = 'var(--bg-tertiary)';
-        planPathCode.style.padding = '0.25rem 0.5rem';
-        planPathCode.style.borderRadius = '0.25rem';
-        planPathCode.style.fontSize = '0.875rem';
-        planPathCode.textContent = manifest.plan_path;
-        
-        planPathItem.appendChild(planPathLabel);
-        planPathItem.appendChild(planPathCode);
-        resultWrapper.appendChild(planPathItem);
+
+    if (warnings.length > 0) {
+        const warningItem = document.createElement('div');
+        warningItem.className = 'result-item';
+        warningItem.style.background = 'var(--bg-primary)';
+        warningItem.style.padding = '1rem';
+        warningItem.style.borderRadius = '0.5rem';
+        warningItem.style.marginTop = '1rem';
+
+        const warningHeading = document.createElement('h4');
+        warningHeading.textContent = 'Warnings';
+        warningHeading.style.marginBottom = '0.5rem';
+        warningItem.appendChild(warningHeading);
+
+        const warningList = document.createElement('ul');
+        warnings.forEach((warning) => {
+            const item = document.createElement('li');
+            item.textContent = warning.message || 'A non-fatal export warning occurred.';
+            warningList.appendChild(item);
+        });
+        warningItem.appendChild(warningList);
+        resultWrapper.appendChild(warningItem);
     }
-    
-    // Generated cells path
-    if (manifest.cells_path) {
-        const cellsPathItem = document.createElement('div');
-        cellsPathItem.className = 'result-item';
-        
-        const cellsPathLabel = document.createElement('strong');
-        cellsPathLabel.textContent = 'Generated Cells: ';
-        
-        const cellsPathCode = document.createElement('code');
-        cellsPathCode.style.background = 'var(--bg-tertiary)';
-        cellsPathCode.style.padding = '0.25rem 0.5rem';
-        cellsPathCode.style.borderRadius = '0.25rem';
-        cellsPathCode.style.fontSize = '0.875rem';
-        cellsPathCode.textContent = manifest.cells_path;
-        
-        cellsPathItem.appendChild(cellsPathLabel);
-        cellsPathItem.appendChild(cellsPathCode);
-        resultWrapper.appendChild(cellsPathItem);
-    }
-    
-    // Next steps section
-    const stepsItem = document.createElement('div');
-    stepsItem.className = 'result-item';
-    stepsItem.style.marginTop = '1.5rem';
-    stepsItem.style.padding = '1rem';
-    stepsItem.style.background = 'var(--bg-primary)';
-    stepsItem.style.borderRadius = '0.5rem';
-    
-    const stepsHeading = document.createElement('h4');
-    stepsHeading.style.marginBottom = '0.5rem';
-    stepsHeading.style.color = 'var(--text-primary)';
-    stepsHeading.textContent = 'Next Steps:';
-    
-    const stepsList = document.createElement('ol');
-    stepsList.style.marginLeft = '1.5rem';
-    stepsList.style.color = 'var(--text-secondary)';
-    
-    const steps = [
-        'Check the output directory for generated artifacts',
-        'Review the notebook plan and generated cells',
-        'Import the cells into a Jupyter notebook',
-        'Customize and run your multi-agent system'
-    ];
-    
-    steps.forEach(stepText => {
-        const li = document.createElement('li');
-        li.textContent = stepText;
-        stepsList.appendChild(li);
-    });
-    
-    stepsItem.appendChild(stepsHeading);
-    stepsItem.appendChild(stepsList);
-    resultWrapper.appendChild(stepsItem);
-    
-    // Add export buttons section
+
     const exportSection = document.createElement('div');
     exportSection.className = 'result-item';
     exportSection.style.marginTop = '1.5rem';
-    
+
     const exportHeading = document.createElement('h4');
     exportHeading.style.marginBottom = '1rem';
     exportHeading.style.color = 'var(--text-primary)';
     exportHeading.textContent = 'Available Downloads:';
-    
+    exportSection.appendChild(exportHeading);
+
     const exportButtons = document.createElement('div');
     exportButtons.style.display = 'flex';
     exportButtons.style.gap = '0.75rem';
     exportButtons.style.flexWrap = 'wrap';
-    
-    // Add download buttons for available formats
-    const formats = [
+
+    [
         { key: 'notebook_path', label: 'Notebook (.ipynb)' },
         { key: 'html_path', label: 'HTML' },
         { key: 'docx_path', label: 'Word Doc' },
         { key: 'pdf_path', label: 'PDF' },
         { key: 'zip_path', label: 'ZIP Bundle' },
         { key: 'markdown_path', label: 'Markdown (.md)' }
-    ];
-    
-    formats.forEach(format => {
+    ].forEach((format) => {
         if (manifest[format.key]) {
             const btn = document.createElement('a');
             btn.className = 'btn btn-secondary';
@@ -570,29 +473,58 @@ function showResult(data) {
             exportButtons.appendChild(btn);
         }
     });
-    
-    // Add copy result button
+
     const copyBtn = document.createElement('button');
     copyBtn.className = 'btn btn-secondary';
     copyBtn.textContent = 'Copy Result Info';
-    copyBtn.onclick = () => {
-        const resultText = JSON.stringify(manifest, null, 2);
-        // Use the shared clipboard helper so toasts and errors are handled consistently
-        copyTextToClipboard(resultText, 'Result info copied to clipboard');
-    // Add to DOM
+    copyBtn.addEventListener('click', () => {
+        copyTextToClipboard(JSON.stringify(manifest, null, 2), 'Result info copied to clipboard');
+    });
+    exportButtons.appendChild(copyBtn);
+
+    exportSection.appendChild(exportButtons);
+    resultWrapper.appendChild(exportSection);
+
     resultContent.appendChild(resultWrapper);
     resultCard.style.display = 'block';
     resultCard.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 }
 
+function extractErrorMessage(payload, fallback = null) {
+    if (payload && typeof payload === 'object') {
+        if (typeof payload.message === 'string' && payload.message.trim()) {
+            return payload.message.trim();
+        }
+        if (typeof payload.error === 'string' && payload.error.trim()) {
+            return payload.error.trim();
+        }
+        if (payload.detail) {
+            if (typeof payload.detail === 'string' && payload.detail.trim()) {
+                return payload.detail.trim();
+            }
+            if (typeof payload.detail === 'object') {
+                return extractErrorMessage(payload.detail, fallback);
+            }
+        }
+    }
+    if (fallback && typeof fallback === 'object') {
+        return extractErrorMessage(fallback, null);
+    }
+    return 'Generation failed. Please review the server details and try again.';
+}
+
+function closeProgressStream() {
+    if (currentEventSource) {
+        currentEventSource.close();
+        currentEventSource = null;
+    }
+}
+
 // Show error
 function showError(message) {
     hideResults();
-    
-    // Clear any previous error content
     errorContent.replaceChildren();
 
-    // Build error block safely using DOM APIs
     const wrapper = document.createElement('div');
     wrapper.style.background = 'var(--bg-tertiary)';
     wrapper.style.padding = '1rem';
@@ -604,43 +536,100 @@ function showError(message) {
     messageParagraph.style.marginBottom = '0.5rem';
     messageParagraph.textContent = message;
 
-    const helperText = document.createElement('small');
-    helperText.style.color = 'var(--text-muted)';
-    helperText.textContent = 'Please check your inputs and try again.';
-
     wrapper.appendChild(messageParagraph);
-    wrapper.appendChild(helperText);
     errorContent.appendChild(wrapper);
-    
+
     errorCard.style.display = 'block';
     errorCard.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+}
+
+function streamGeneration(streamUrl) {
+    return new Promise((resolve, reject) => {
+        closeProgressStream();
+        const eventSource = new EventSource(streamUrl);
+        currentEventSource = eventSource;
+        let latestErrorDetails = null;
+
+        eventSource.addEventListener('progress', (event) => {
+            const payload = JSON.parse(event.data);
+            showProgress(
+                payload.node || payload.phase || 'generation',
+                payload.percentage || 0,
+                payload.message || 'Working...'
+            );
+        });
+
+        eventSource.addEventListener('log', (event) => {
+            const payload = JSON.parse(event.data);
+            if (payload.level === 'error') {
+                latestErrorDetails = payload.details || {};
+            }
+        });
+
+        eventSource.addEventListener('complete', (event) => {
+            const payload = JSON.parse(event.data);
+            closeProgressStream();
+            resolve(payload);
+        });
+
+        eventSource.addEventListener('error', (event) => {
+            let payload = {};
+            try {
+                payload = event.data ? JSON.parse(event.data) : {};
+            } catch (err) {
+                payload = {};
+            }
+            closeProgressStream();
+            reject(new Error(extractErrorMessage(payload, latestErrorDetails)));
+        });
+
+        eventSource.onerror = () => {
+            if (eventSource.readyState === EventSource.CLOSED) {
+                closeProgressStream();
+            }
+        };
+    });
+}
+
+async function startAsyncGeneration(data) {
+    const response = await fetch('/generate-async', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data)
+    });
+
+    const payload = await response.json();
+    if (!response.ok) {
+        throw new Error(extractErrorMessage(payload));
+    }
+
+    showProgress('queued', 12, 'Generation accepted. Connecting to progress stream...');
+    return streamGeneration(payload.stream_url);
 }
 
 // Handle form submission
 form.addEventListener('submit', async (e) => {
     e.preventDefault();
-    
+
     const formData = new FormData(form);
-    
-    // Collect selected formats
     const formats = [];
     const formatCheckboxes = document.querySelectorAll('input[name="formats"]:checked');
     formatCheckboxes.forEach(cb => formats.push(cb.value));
-    
-    // Validate at least one format is selected
+
     if (formats.length === 0) {
         showError('Please select at least one output format.');
         return;
     }
-    
+
     const data = {
         prompt: formData.get('prompt'),
         mode: formData.get('mode'),
         output_dir: formData.get('outputDir'),
         formats: formats
     };
-    
-    // Add advanced options if specified
+
     const model = formData.get('model');
     const customEndpoint = formData.get('customEndpoint');
     const customModel = formData.get('customModel');
@@ -650,96 +639,47 @@ form.addEventListener('submit', async (e) => {
     } else if (model) {
         data.model = model;
     }
-    
+
     const temperature = parseFloat(formData.get('temperature'));
-    // Only send temperature if it differs from default (0.7)
     if (!isNaN(temperature) && temperature !== 0.7) data.temperature = temperature;
-    
+
     const maxTokens = formData.get('maxTokens');
     if (maxTokens) data.max_tokens = parseInt(maxTokens);
-    
+
     const agentType = formData.get('agentType');
     if (agentType) data.agent_type = agentType;
-    
-    // Validate prompt length (using Unicode code points)
+
     if (getCharacterCount(data.prompt) > CHAR_COUNT_MAX) {
         showError(`Prompt exceeds maximum length of ${CHAR_COUNT_MAX} characters.`);
         return;
     }
-    
+
     if (getCharacterCount(data.prompt.trim()) < CHAR_COUNT_MIN) {
         showError(`Please enter a prompt of at least ${CHAR_COUNT_MIN} characters.`);
         return;
     }
-    
-    // Prevent submission if the output directory path is currently invalid
+
     if (outputDirInput && outputDirInput.classList.contains('invalid')) {
         const errorMsg = outputDirInput.getAttribute('title') || 'Invalid output directory path';
         showError(`Please fix the output directory: ${errorMsg}`);
         outputDirInput.focus();
         return;
     }
-    
-    // Save to history
+
     saveToHistory(data);
-    
+
     setLoading(true);
     hideResults();
-    
-    // Show initial progress
-    showProgress(1, 10, 'Validating input...');
-    
-    // Track progress timeout IDs to clear them if API completes early
-    const progressTimeouts = [];
-    
+    showProgress('validation', 10, 'Validating input...');
+
     try {
-        // Simulate progress updates only if they haven't been overtaken by actual progress
-        progressTimeouts.push(setTimeout(() => {
-            if (progressPercentage.textContent === '10%') {
-                showProgress(2, 25, 'Preparing generation context...');
-            }
-        }, 500));
-        progressTimeouts.push(setTimeout(() => {
-            if (parseInt(progressPercentage.textContent) < 50) {
-                showProgress(3, 50, 'Invoking LLM...');
-            }
-        }, 1000));
-        
-        const response = await fetch('/generate', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(data)
-        });
-        
-        // Clear any pending simulated progress updates
-        progressTimeouts.forEach(id => clearTimeout(id));
-        
-        showProgress(4, 75, 'Generating artifacts...');
-        
-        const result = await response.json();
-        
-        showProgress(5, 90, 'Finalizing outputs...');
-        
-        if (response.ok && result.success) {
-            setTimeout(() => {
-                showProgress(6, 100, 'Complete!');
-                setTimeout(() => showResult(result), 500);
-            }, 300);
-        } else {
-            // Log detailed error for debugging but show generic message to user
-            const serverErrorDetail = (result && (result.error || result.detail)) || '';
-            if (serverErrorDetail) {
-                console.error('Server error during generation:', serverErrorDetail);
-            }
-            const errorMsg = 'Generation failed. Please try again or contact support if the problem persists.';
-            showError(errorMsg);
-        }
+        const result = await startAsyncGeneration(data);
+        showResult(result);
     } catch (error) {
         console.error('Generation error:', error);
-        showError('Network error: Unable to reach the server. Please ensure the server is running and try again.');
+        showError(error.message || 'Unable to complete generation.');
     } finally {
+        closeProgressStream();
         setLoading(false);
     }
 });

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from datetime import datetime, timezone
 import json
 import logging
 import os
 from pathlib import Path
+from time import perf_counter
 from typing import Any, Dict, List, Literal, TypedDict
 
 from langgraph_system_generator.generator.state import (
@@ -19,6 +21,7 @@ from langgraph_system_generator.generator.state import (
     Constraint,
     NotebookPlan,
 )
+from langgraph_system_generator.utils.error_handling import GenerationError
 from langgraph_system_generator.utils.config import GenerationConfig, settings
 from langgraph_system_generator.utils.generation_options import (
     SUPPORTED_AGENT_TYPES,
@@ -31,6 +34,7 @@ from langgraph_system_generator.utils.optional_deps import (
 
 BASE_DIR = Path(__file__).resolve().parents[2]
 DEFAULT_CACHE_PATH = (BASE_DIR / "data" / "cached_docs").resolve()
+logger = logging.getLogger(__name__)
 
 GenerationMode = Literal["stub", "live"]
 
@@ -90,6 +94,178 @@ def _serialize(obj: Any) -> Any:
 
 def _write_json(path: Path, payload: Any) -> None:
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _utc_now_iso() -> str:
+    """Return a UTC timestamp string for telemetry payloads."""
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_generation_error(
+    exc: Exception,
+    *,
+    phase: str,
+    default_code: str = "generation_error",
+    default_status_code: int = 500,
+) -> GenerationError:
+    """Normalize arbitrary exceptions into a structured generation error."""
+
+    if isinstance(exc, GenerationError):
+        return exc
+
+    if isinstance(exc, OptionalDependencyError):
+        details = {}
+        if exc.dependency:
+            details["dependency"] = exc.dependency
+        if exc.extra:
+            details["extra"] = exc.extra
+        if exc.feature:
+            details["feature"] = exc.feature
+        return GenerationError(
+            str(exc),
+            code="dependency_unavailable",
+            phase=phase,
+            hint=exc.hint,
+            details=details,
+            status_code=503,
+        )
+
+    return GenerationError(
+        str(exc),
+        code=default_code,
+        phase=phase,
+        details={"error_type": type(exc).__name__},
+        status_code=default_status_code,
+    )
+
+
+class _PhaseTracker:
+    """Track structured phase telemetry across generation and export steps."""
+
+    def __init__(self, progress_callback: Any | None = None) -> None:
+        self.progress_callback = progress_callback
+        self._active: Dict[str, tuple[float, str]] = {}
+        self.summary: List[Dict[str, Any]] = []
+
+    def _emit_progress(
+        self,
+        phase: str,
+        percentage: int,
+        message: str,
+        *,
+        status: str = "running",
+        event: str = "progress",
+        details: Dict[str, Any] | None = None,
+    ) -> None:
+        if not self.progress_callback:
+            return
+
+        payload = {
+            "event": event,
+            "phase": phase,
+            "node": phase,
+            "percentage": min(100, max(0, percentage)),
+            "message": message,
+            "status": status,
+        }
+        if details:
+            payload["details"] = details
+
+        try:
+            self.progress_callback(payload)
+        except TypeError:
+            self.progress_callback(phase, payload["percentage"], message)
+        except Exception:
+            logger.warning(
+                "Progress callback failed for phase=%s percentage=%s",
+                phase,
+                percentage,
+                exc_info=True,
+            )
+
+    def _log_phase(
+        self,
+        phase: str,
+        status: str,
+        message: str,
+        *,
+        duration_ms: int = 0,
+        details: Dict[str, Any] | None = None,
+    ) -> None:
+        logger.info(
+            "Generation phase %s: %s",
+            status,
+            phase,
+            extra={
+                "phase": phase,
+                "status": status,
+                "duration_ms": duration_ms,
+                "phase_message": message,
+                "phase_details": details or {},
+            },
+        )
+
+    def start(
+        self,
+        phase: str,
+        message: str,
+        *,
+        percentage: int | None = None,
+        details: Dict[str, Any] | None = None,
+    ) -> None:
+        started_at = _utc_now_iso()
+        self._active[phase] = (perf_counter(), started_at)
+        self._log_phase(phase, "started", message, details=details)
+        if percentage is not None:
+            self._emit_progress(
+                phase,
+                percentage,
+                message,
+                status="running",
+                details=details,
+            )
+
+    def finish(
+        self,
+        phase: str,
+        message: str,
+        *,
+        percentage: int | None = None,
+        status: str = "completed",
+        details: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        timer_start, started_at = self._active.pop(phase, (perf_counter(), _utc_now_iso()))
+        duration_ms = int((perf_counter() - timer_start) * 1000)
+        finished_at = _utc_now_iso()
+        entry = {
+            "phase": phase,
+            "status": status,
+            "message": message,
+            "started_at": started_at,
+            "finished_at": finished_at,
+            "duration_ms": duration_ms,
+            "details": details or {},
+        }
+        self.summary.append(entry)
+        self._log_phase(
+            phase,
+            status,
+            message,
+            duration_ms=duration_ms,
+            details=details,
+        )
+        if percentage is not None:
+            event_type = "log" if status == "warning" else "progress"
+            self._emit_progress(
+                phase,
+                percentage,
+                message,
+                status=status,
+                event=event_type,
+                details=details,
+            )
+        return entry
 
 
 def _infer_stub_architecture(prompt: str) -> tuple[str, str]:
@@ -441,43 +617,44 @@ async def generate_artifacts(
         agent_type=agent_type,
     )
 
-    def _report_progress(node: str, percentage: int, message: str) -> None:
-        """Helper to report progress if callback is provided."""
-        if progress_callback:
-            try:
-                progress_callback(node, percentage, message)
-            except Exception as e:
-                # Log progress callback failures instead of silently swallowing
-                logging.warning(
-                    f"Progress callback failed for node={node}, percentage={percentage}: {e}",
-                    exc_info=True,
-                )
-
+    tracker = _PhaseTracker(progress_callback)
     target = Path(output_dir)
     target.mkdir(parents=True, exist_ok=True)
 
-    _report_progress("init", 5, "Initializing generation...")
+    tracker.start("init", "Initializing generation...", percentage=5)
+    tracker.finish(
+        "init",
+        "Generation initialized.",
+        percentage=10,
+        details={"mode": mode},
+    )
 
     if mode == "live":
         create_generator_graph = _load_generator_graph()
         if not custom_endpoint and not os.environ.get("OPENAI_API_KEY"):
-            raise RuntimeError(
-                "LLM API credentials are required for live generation mode."
+            raise GenerationError(
+                "LLM API credentials are required for live generation mode.",
+                code="credentials_required",
+                phase="graph_init",
+                hint="Set OPENAI_API_KEY or provide a custom_endpoint with an explicit model.",
+                status_code=503,
             )
-        _report_progress("graph_init", 10, "Creating generator graph...")
+        tracker.start("graph_init", "Creating generator graph...", percentage=12)
         graph = create_generator_graph()
-        _report_progress("graph_invoke", 15, "Invoking generator graph...")
+        tracker.finish("graph_init", "Generator graph created.", percentage=15)
+        tracker.start("graph_invoke", "Invoking generator graph...", percentage=18)
         result = await graph.ainvoke(
             _default_state(prompt, generation_config, generation_mode="live")
         )
-        _report_progress("graph_complete", 60, "Generator graph completed")
+        tracker.finish("graph_invoke", "Generator graph completed.", percentage=60)
     else:
-        _report_progress("stub", 30, "Building stub result...")
+        tracker.start("stub_build", "Building stub result...", percentage=30)
         result = _build_stub_result(prompt, agent_type=agent_type)
-        _report_progress("stub_complete", 60, "Stub generation complete")
+        tracker.finish("stub_build", "Stub generation complete.", percentage=60)
 
-    _report_progress("serialize", 62, "Serializing results...")
+    tracker.start("serialize", "Serializing generation results...", percentage=62)
     serialized = _serialize(result)
+    tracker.finish("serialize", "Serialized generation results.", percentage=64)
     if "architecture_type" in serialized and serialized.get("architecture_type"):
         architecture_type = serialized.get("architecture_type")
     else:
@@ -494,6 +671,8 @@ async def generate_artifacts(
         "architecture_type": architecture_type,
         "cell_count": len(serialized.get("generated_cells", []) or []),
         "plan_title": plan_title,
+        "warnings": [],
+        "export_results": {},
     }
 
     # Persist request metadata for reproducibility and downstream consumers.
@@ -521,91 +700,213 @@ async def generate_artifacts(
         _write_json(cells_path, cells)
         manifest["cells_path"] = str(cells_path)
 
-    # Build and export notebook in requested formats
-    if cells:
-        _report_progress("compose", 65, "Composing notebook...")
-        # Convert serialized cells back to CellSpec objects
-        cell_specs = [CellSpec(**cell) for cell in cells]
+    default_formats = ["ipynb", "html", "markdown", "docx", "zip"]
+    requested_formats = list(formats or default_formats)
+    explicit_request = bool(formats)
 
-        # Build the notebook
+    if cells:
+        tracker.start("compose", "Composing notebook...", percentage=65)
+        cell_specs = [CellSpec(**cell) for cell in cells]
         composer = NotebookComposer(colab_friendly=True)
         notebook = composer.build_notebook(cell_specs, ensure_minimum_sections=True)
+        tracker.finish(
+            "compose",
+            "Notebook composed successfully.",
+            percentage=70,
+            details={"cell_count": len(cell_specs)},
+        )
 
-        # Determine which formats to generate
-        if formats is None or not formats:
-            formats = ["ipynb", "html", "markdown", "docx", "zip"]
-
-        _report_progress("export_init", 70, f"Exporting to {len(formats)} format(s)...")
         exporter = NotebookExporter()
+        ipynb_path: Path | None = None
 
-        # Export to requested formats
-        if "ipynb" in formats:
-            _report_progress("export_ipynb", 72, "Exporting to Jupyter notebook...")
-            ipynb_path = target / "notebook.ipynb"
-            exporter.export_ipynb(notebook, ipynb_path)
-            manifest["notebook_path"] = str(ipynb_path)
+        def _record_export_success(
+            format_name: str,
+            phase: str,
+            *,
+            path: Path,
+            manifest_key: str,
+            percentage: int,
+        ) -> None:
+            manifest[manifest_key] = str(path)
+            manifest["export_results"][format_name] = {
+                "requested": explicit_request and format_name in requested_formats,
+                "status": "completed",
+                "path": str(path),
+            }
+            tracker.finish(
+                phase,
+                f"{format_name.upper()} export completed.",
+                percentage=percentage,
+                details={"format": format_name, "path": str(path)},
+            )
 
-        if "html" in formats:
+        def _handle_export_failure(
+            format_name: str,
+            phase: str,
+            exc: Exception,
+            *,
+            percentage: int,
+        ) -> None:
+            error = _normalize_generation_error(
+                exc,
+                phase=phase,
+                default_code="requested_export_failed",
+                default_status_code=500,
+            )
+            requested = explicit_request and format_name in requested_formats
+            manifest["export_results"][format_name] = {
+                "requested": requested,
+                "status": "failed",
+                "path": None,
+                "error": error.to_payload(),
+            }
+            manifest[f"{format_name}_error"] = str(error)
+
+            if requested:
+                tracker.finish(
+                    phase,
+                    str(error),
+                    percentage=percentage,
+                    status="failed",
+                    details=error.to_payload(),
+                )
+                raise error
+
+            manifest["warnings"].append(
+                {
+                    "code": error.code,
+                    "phase": phase,
+                    "format": format_name,
+                    "message": str(error),
+                    "hint": error.hint,
+                }
+            )
+            tracker.finish(
+                phase,
+                f"{format_name.upper()} export unavailable; continuing with remaining exports.",
+                percentage=percentage,
+                status="warning",
+                details=error.to_payload(),
+            )
+
+        if "ipynb" in requested_formats:
+            phase = "export_ipynb"
+            tracker.start(phase, "Exporting to Jupyter notebook...", percentage=72)
             try:
-                _report_progress("export_html", 78, "Exporting to HTML...")
+                ipynb_path = target / "notebook.ipynb"
+                exporter.export_ipynb(notebook, ipynb_path)
+                _record_export_success(
+                    "ipynb",
+                    phase,
+                    path=ipynb_path,
+                    manifest_key="notebook_path",
+                    percentage=74,
+                )
+            except Exception as exc:
+                _handle_export_failure("ipynb", phase, exc, percentage=74)
+
+        if "html" in requested_formats:
+            phase = "export_html"
+            tracker.start(phase, "Exporting to HTML...", percentage=78)
+            try:
                 html_path = target / "notebook.html"
                 exporter.export_to_html(notebook, html_path)
-                manifest["html_path"] = str(html_path)
-            except Exception as e:
-                manifest["html_error"] = str(e)
+                _record_export_success(
+                    "html",
+                    phase,
+                    path=html_path,
+                    manifest_key="html_path",
+                    percentage=80,
+                )
+            except Exception as exc:
+                _handle_export_failure("html", phase, exc, percentage=80)
 
-        if "markdown" in formats:
+        if "markdown" in requested_formats:
+            phase = "export_markdown"
+            tracker.start(phase, "Exporting to Markdown...", percentage=81)
             try:
-                _report_progress("export_markdown", 81, "Exporting to Markdown...")
                 markdown_path = target / "notebook.md"
                 exporter.export_to_markdown(notebook, markdown_path)
-                manifest["markdown_path"] = str(markdown_path)
-            except Exception as e:
-                manifest["markdown_error"] = str(e)
+                _record_export_success(
+                    "markdown",
+                    phase,
+                    path=markdown_path,
+                    manifest_key="markdown_path",
+                    percentage=83,
+                )
+            except Exception as exc:
+                _handle_export_failure("markdown", phase, exc, percentage=83)
 
-        if "docx" in formats:
+        if "docx" in requested_formats:
+            phase = "export_docx"
+            tracker.start(phase, "Exporting to Word document...", percentage=84)
             try:
-                _report_progress("export_docx", 84, "Exporting to Word document...")
                 docx_path = target / "notebook.docx"
                 exporter.export_notebook_to_docx(notebook, docx_path, title=plan_title)
-                manifest["docx_path"] = str(docx_path)
-            except Exception as e:
-                manifest["docx_error"] = str(e)
+                _record_export_success(
+                    "docx",
+                    phase,
+                    path=docx_path,
+                    manifest_key="docx_path",
+                    percentage=87,
+                )
+            except Exception as exc:
+                _handle_export_failure("docx", phase, exc, percentage=87)
 
-        if "pdf" in formats:
+        if "pdf" in requested_formats:
+            phase = "export_pdf"
+            tracker.start(phase, "Exporting to PDF...", percentage=90)
             try:
-                _report_progress("export_pdf", 90, "Exporting to PDF...")
-                # PDF export requires the notebook to be saved first
-                if "ipynb" not in formats:
+                if ipynb_path is None:
                     ipynb_path = target / "notebook.ipynb"
                     exporter.export_ipynb(notebook, ipynb_path)
+                    manifest["notebook_path"] = str(ipynb_path)
                 pdf_path = target / "notebook.pdf"
                 exporter.export_to_pdf(ipynb_path, pdf_path, method="webpdf")
-                manifest["pdf_path"] = str(pdf_path)
-            except Exception as e:
-                manifest["pdf_error"] = str(e)
+                _record_export_success(
+                    "pdf",
+                    phase,
+                    path=pdf_path,
+                    manifest_key="pdf_path",
+                    percentage=92,
+                )
+            except Exception as exc:
+                _handle_export_failure("pdf", phase, exc, percentage=92)
 
-        if "zip" in formats:
+        if "zip" in requested_formats:
+            phase = "export_zip"
+            tracker.start(phase, "Creating ZIP archive...", percentage=95)
             try:
-                _report_progress("export_zip", 95, "Creating ZIP archive...")
-                # Include JSON artifacts in the ZIP
                 extra_files = []
                 if manifest.get("plan_path"):
                     extra_files.append(manifest["plan_path"])
                 if manifest.get("cells_path"):
                     extra_files.append(manifest["cells_path"])
+                for format_name, export_result in manifest["export_results"].items():
+                    if export_result.get("status") == "completed" and export_result.get(
+                        "path"
+                    ):
+                        if format_name not in {"ipynb", "zip"}:
+                            extra_files.append(export_result["path"])
 
                 zip_path = target / "notebook_bundle.zip"
                 exporter.export_zip(notebook, zip_path, extra_files=extra_files)
-                manifest["zip_path"] = str(zip_path)
-            except Exception as e:
-                manifest["zip_error"] = str(e)
+                _record_export_success(
+                    "zip",
+                    phase,
+                    path=zip_path,
+                    manifest_key="zip_path",
+                    percentage=97,
+                )
+            except Exception as exc:
+                _handle_export_failure("zip", phase, exc, percentage=97)
 
-    _report_progress("finalize", 98, "Finalizing artifacts...")
+    tracker.start("finalize", "Finalizing artifacts...", percentage=98)
+    tracker.finish("finalize", "Artifacts finalized.", percentage=100)
+    manifest["phase_summary"] = list(tracker.summary)
     manifest_path = target / "manifest.json"
     _write_json(manifest_path, manifest)
 
-    _report_progress("complete", 100, "Generation complete!")
     return GenerationArtifacts(
         mode=mode,
         prompt=prompt,
@@ -659,8 +960,15 @@ def _run_generate(args: argparse.Namespace) -> int:
                 agent_type=args.agent_type,
             )
         )
+    except GenerationError as exc:
+        print(f"✗ Failed to generate artifacts: {exc}")
+        if exc.hint:
+            print(f"  Hint: {exc.hint}")
+        return 1
     except OptionalDependencyError as exc:
         print(f"✗ Failed to generate artifacts: {exc}")
+        if exc.hint:
+            print(f"  Hint: {exc.hint}")
         return 1
 
     print(f"✓ Generated artifacts in {artifacts['output_dir']}")
@@ -681,6 +989,8 @@ def _run_generate(args: argparse.Namespace) -> int:
         print(f"  PDF: {artifacts['manifest']['pdf_path']}")
     if artifacts["manifest"].get("zip_path"):
         print(f"  ZIP Bundle: {artifacts['manifest']['zip_path']}")
+    for warning in artifacts["manifest"].get("warnings", []):
+        print(f"  Warning: {warning['message']}")
     return 0
 
 

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -762,7 +762,11 @@ async def generate_artifacts(
             }
             manifest[f"{format_name}_error"] = str(error)
 
-            if requested:
+            # PDF export remains best-effort because the webpdf toolchain depends on
+            # host Playwright/browser support that is not guaranteed across environments.
+            requested_is_fatal = requested and format_name != "pdf"
+
+            if requested_is_fatal:
                 tracker.finish(
                     phase,
                     str(error),

--- a/src/langgraph_system_generator/notebook/__init__.py
+++ b/src/langgraph_system_generator/notebook/__init__.py
@@ -1,9 +1,8 @@
 """Notebook composition, export, and manuscript generation."""
 
-from langgraph_system_generator.notebook.composer import NotebookComposer
-from langgraph_system_generator.notebook.exporters import NotebookExporter
-from langgraph_system_generator.notebook.manuscript_docx import ManuscriptDOCXGenerator
-from langgraph_system_generator.notebook.manuscript_pdf import ManuscriptPDFGenerator
+from __future__ import annotations
+
+from importlib import import_module
 
 __all__ = [
     "NotebookComposer",
@@ -11,3 +10,21 @@ __all__ = [
     "ManuscriptDOCXGenerator",
     "ManuscriptPDFGenerator",
 ]
+
+
+def __getattr__(name: str):
+    """Lazily expose notebook helpers to avoid circular imports during cold loads."""
+
+    if name == "NotebookComposer":
+        return import_module("langgraph_system_generator.notebook.composer").NotebookComposer
+    if name == "NotebookExporter":
+        return import_module("langgraph_system_generator.notebook.exporters").NotebookExporter
+    if name == "ManuscriptDOCXGenerator":
+        return import_module(
+            "langgraph_system_generator.notebook.manuscript_docx"
+        ).ManuscriptDOCXGenerator
+    if name == "ManuscriptPDFGenerator":
+        return import_module(
+            "langgraph_system_generator.notebook.manuscript_pdf"
+        ).ManuscriptPDFGenerator
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/langgraph_system_generator/notebook/exporters.py
+++ b/src/langgraph_system_generator/notebook/exporters.py
@@ -11,6 +11,10 @@ from typing import Sequence
 
 import nbformat
 from langgraph_system_generator.constants import is_relative_to_base
+from langgraph_system_generator.utils.optional_deps import (
+    OptionalDependencyError,
+    missing_external_tool,
+)
 
 
 def _get_base_output() -> Path:
@@ -137,8 +141,12 @@ class NotebookExporter:
         try:
             from nbconvert import HTMLExporter
         except ImportError as exc:
-            raise ImportError(
-                "nbconvert is required for HTML export. Install it with: pip install nbconvert"
+            raise OptionalDependencyError(
+                "HTML export requires nbconvert.",
+                hint='Install the full extra with: pip install -e ".[full]"',
+                dependency="nbconvert",
+                extra="full",
+                feature="HTML export",
             ) from exc
 
         nbformat.validate(notebook)
@@ -160,8 +168,12 @@ class NotebookExporter:
         try:
             from nbconvert import MarkdownExporter
         except ImportError as exc:
-            raise ImportError(
-                "nbconvert is required for Markdown export. Install it with: pip install nbconvert"
+            raise OptionalDependencyError(
+                "Markdown export requires nbconvert.",
+                hint='Install the full extra with: pip install -e ".[full]"',
+                dependency="nbconvert",
+                extra="full",
+                feature="Markdown export",
             ) from exc
 
         nbformat.validate(notebook)
@@ -196,8 +208,12 @@ class NotebookExporter:
         try:
             from nbconvert import PDFExporter
         except ImportError as exc:
-            raise ImportError(
-                "nbconvert is required for PDF export. Install it with: pip install nbconvert"
+            raise OptionalDependencyError(
+                "PDF export requires nbconvert.",
+                hint='Install the full extra with: pip install -e ".[full]"',
+                dependency="nbconvert",
+                extra="full",
+                feature="PDF export",
             ) from exc
 
         source = Path(notebook_path)
@@ -280,8 +296,10 @@ class NotebookExporter:
                     "Ensure Jupyter and Chromium/Chrome are installed."
                 ) from exc
             except FileNotFoundError as exc:
-                raise RuntimeError(
-                    "jupyter command not found. Ensure Jupyter is installed and in PATH."
+                raise missing_external_tool(
+                    "jupyter",
+                    feature="PDF export",
+                    hint='Install the full extra with: pip install -e ".[full]" and ensure Jupyter is on PATH.',
                 ) from exc
 
     def export_notebook_to_docx(
@@ -310,8 +328,12 @@ class NotebookExporter:
         try:
             from docx import Document
         except ImportError as exc:
-            raise ImportError(
-                "python-docx is required for DOCX export. Install it with: pip install python-docx"
+            raise OptionalDependencyError(
+                "DOCX export requires python-docx.",
+                hint='Install the full extra with: pip install -e ".[full]"',
+                dependency="python-docx",
+                extra="full",
+                feature="DOCX export",
             ) from exc
 
         nbformat.validate(notebook)

--- a/src/langgraph_system_generator/notebook/exporters.py
+++ b/src/langgraph_system_generator/notebook/exporters.py
@@ -291,8 +291,21 @@ class NotebookExporter:
                     )
 
             except subprocess.CalledProcessError as exc:
+                stderr = exc.stderr or ""
+                stderr_lower = stderr.lower()
+                if (
+                    "playwright is not installed" in stderr_lower
+                    or "nbconvert[webpdf]" in stderr_lower
+                ):
+                    raise OptionalDependencyError(
+                        "PDF export requires Playwright webpdf dependencies.",
+                        hint='Install the full extra with: pip install -e ".[full]" and ensure nbconvert[webpdf] / Playwright are available.',
+                        dependency="playwright",
+                        extra="full",
+                        feature="PDF export",
+                    ) from exc
                 raise RuntimeError(
-                    f"webpdf export failed: {exc.stderr}. "
+                    f"webpdf export failed: {stderr}. "
                     "Ensure Jupyter and Chromium/Chrome are installed."
                 ) from exc
             except FileNotFoundError as exc:

--- a/src/langgraph_system_generator/utils/error_handling.py
+++ b/src/langgraph_system_generator/utils/error_handling.py
@@ -1,0 +1,42 @@
+"""Structured error types for generation surfaces."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class GenerationError(RuntimeError):
+    """A normalized error that can be surfaced consistently across CLI/API/UI."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "generation_error",
+        phase: str | None = None,
+        hint: str | None = None,
+        details: Dict[str, Any] | None = None,
+        status_code: int = 500,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.phase = phase
+        self.hint = hint
+        self.details = details or {}
+        self.status_code = status_code
+
+    def to_payload(self) -> Dict[str, Any]:
+        """Serialize this error into an API-safe payload."""
+
+        payload: Dict[str, Any] = {
+            "code": self.code,
+            "message": str(self),
+            "status_code": self.status_code,
+        }
+        if self.phase:
+            payload["phase"] = self.phase
+        if self.hint:
+            payload["hint"] = self.hint
+        if self.details:
+            payload["details"] = self.details
+        return payload

--- a/src/langgraph_system_generator/utils/optional_deps.py
+++ b/src/langgraph_system_generator/utils/optional_deps.py
@@ -9,6 +9,21 @@ from typing import Any
 class OptionalDependencyError(RuntimeError):
     """Raised when an optional dependency group is required but unavailable."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        hint: str | None = None,
+        dependency: str | None = None,
+        extra: str | None = None,
+        feature: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.hint = hint
+        self.dependency = dependency
+        self.extra = extra
+        self.feature = feature
+
 
 _EXTRA_HINTS = {
     "api": 'pip install -e ".[api]"',
@@ -24,7 +39,27 @@ def require_optional_module(module_name: str, *, feature: str, extra: str) -> An
         hint = _EXTRA_HINTS.get(extra, f'pip install -e ".[{extra}]"')
         raise OptionalDependencyError(
             f"{feature} requires optional dependencies that are not installed. "
-            f"Install the '{extra}' extra with: {hint}"
+            f"Install the '{extra}' extra with: {hint}",
+            hint=hint,
+            dependency=module_name,
+            extra=extra,
+            feature=feature,
         ) from exc
     except ImportError:
         raise
+
+
+def missing_external_tool(
+    tool_name: str,
+    *,
+    feature: str,
+    hint: str,
+) -> OptionalDependencyError:
+    """Create a consistent error for missing external tools."""
+
+    return OptionalDependencyError(
+        f"{feature} requires the external tool '{tool_name}', but it is not available.",
+        hint=hint,
+        dependency=tool_name,
+        feature=feature,
+    )

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -260,8 +260,11 @@ async def test_api_generate_surfaces_optional_dependency_errors(
             },
         )
 
-    assert response.status_code == 400
-    assert response.json()["detail"] == error_message
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert detail["code"] == "dependency_unavailable"
+    assert detail["message"] == error_message
+    assert detail["status_code"] == 503
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_shared_platform_hardening.py
+++ b/tests/unit/test_shared_platform_hardening.py
@@ -1,0 +1,192 @@
+"""Regression tests for shared platform hardening behaviors."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+
+import httpx
+import pytest
+
+from langgraph_system_generator.utils import optional_deps
+
+
+@pytest.mark.asyncio
+async def test_generate_artifacts_records_phase_summary_and_export_results(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Generation should persist structured phase and export metadata."""
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_phase_summary_manifest")
+
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.cli as cli_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(cli_module)
+
+    caplog.set_level(logging.INFO, logger="langgraph_system_generator.cli")
+
+    artifacts = await cli_module.generate_artifacts(
+        "Track structured generation phases",
+        output_dir=str(constants_module._BASE_OUTPUT / "phase_summary"),
+        mode="stub",
+        formats=["ipynb"],
+    )
+
+    manifest = artifacts["manifest"]
+
+    assert manifest["warnings"] == []
+    assert "phase_summary" in manifest
+    assert any(
+        entry["phase"] == "export_ipynb" and entry["status"] == "completed"
+        for entry in manifest["phase_summary"]
+    )
+    assert manifest["export_results"]["ipynb"]["requested"] is True
+    assert manifest["export_results"]["ipynb"]["status"] == "completed"
+    assert manifest["export_results"]["ipynb"]["path"] == manifest["notebook_path"]
+
+    phase_records = [record for record in caplog.records if hasattr(record, "phase")]
+    assert any(
+        getattr(record, "phase", None) == "export_ipynb"
+        and getattr(record, "status", None) == "completed"
+        for record in phase_records
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_export_failures_become_manifest_warnings(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Default convenience exports should degrade to warnings instead of failing."""
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_default_export_warning")
+
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.cli as cli_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(cli_module)
+
+    def fail_html(self, notebook, output_path):
+        raise optional_deps.OptionalDependencyError(
+            "HTML export dependencies are unavailable.",
+        )
+
+    monkeypatch.setattr(exporters_module.NotebookExporter, "export_to_html", fail_html)
+
+    artifacts = await cli_module.generate_artifacts(
+        "Allow default export warnings",
+        output_dir=str(constants_module._BASE_OUTPUT / "default_warning"),
+        mode="stub",
+        formats=None,
+    )
+
+    manifest = artifacts["manifest"]
+
+    assert manifest["export_results"]["html"]["requested"] is False
+    assert manifest["export_results"]["html"]["status"] == "failed"
+    assert manifest["warnings"]
+    assert any(warning["phase"] == "export_html" for warning in manifest["warnings"])
+    assert "html_error" in manifest
+    assert "notebook_path" in manifest
+
+
+@pytest.mark.asyncio
+async def test_requested_export_failures_raise_generation_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Explicitly requested exports should fail the overall request."""
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_requested_export_failure")
+
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.cli as cli_module
+    from langgraph_system_generator.utils.error_handling import GenerationError
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(cli_module)
+
+    def fail_html(self, notebook, output_path):
+        raise optional_deps.OptionalDependencyError(
+            'Install the "full" extra with: pip install -e ".[full]"',
+        )
+
+    monkeypatch.setattr(exporters_module.NotebookExporter, "export_to_html", fail_html)
+
+    with pytest.raises(GenerationError) as exc_info:
+        await cli_module.generate_artifacts(
+            "Fail requested export",
+            output_dir=str(constants_module._BASE_OUTPUT / "requested_failure"),
+            mode="stub",
+            formats=["ipynb", "html"],
+        )
+
+    assert exc_info.value.phase == "export_html"
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.code in {
+        "dependency_unavailable",
+        "requested_export_failed",
+    }
+
+
+@pytest.mark.asyncio
+async def test_api_returns_structured_generation_errors(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The API should surface phase-aware structured error payloads."""
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_structured_api_errors")
+
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.api.server as server_module
+    from langgraph_system_generator.utils.error_handling import GenerationError
+
+    importlib.reload(constants_module)
+    importlib.reload(server_module)
+
+    async def fail_generation(*_args, **_kwargs):
+        raise GenerationError(
+            "HTML export could not run because notebook export dependencies are missing.",
+            code="dependency_unavailable",
+            phase="export_html",
+            hint='Install the full extra with: pip install -e ".[full]"',
+            status_code=503,
+        )
+
+    monkeypatch.setattr(server_module, "generate_artifacts", fail_generation)
+
+    transport = httpx.ASGITransport(app=server_module.app)
+    output_dir = constants_module._BASE_OUTPUT / "structured_api_errors"
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/generate",
+            json={
+                "prompt": "Trigger structured error",
+                "mode": "stub",
+                "output_dir": str(output_dir),
+                "formats": ["ipynb", "html"],
+            },
+        )
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert detail["code"] == "dependency_unavailable"
+    assert detail["phase"] == "export_html"
+    assert "Install the full extra" in detail["hint"]
+
+
+def test_web_ui_uses_async_generation_and_eventsource():
+    """The web UI should use SSE-backed async generation instead of fake sync progress."""
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    app_js = (repo_root / "src/langgraph_system_generator/api/static/app.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert "/generate-async" in app_js
+    assert "new EventSource(" in app_js
+    assert "fetch('/generate'" not in app_js


### PR DESCRIPTION
## Summary
- finish the rescued shared-platform-hardening tranche on top of current `main`
- add structured manifest phase/export metadata plus normalized generation errors
- switch the web UI to `/generate-async` with SSE-backed progress and actionable failures

## Testing
- pytest tests/unit/test_shared_platform_hardening.py tests/unit/test_cli_api.py -q
- pytest tests/unit -q
- python -m compileall src\langgraph_system_generator\cli.py src\langgraph_system_generator\api\server.py src\langgraph_system_generator\api\progress_streaming.py src\langgraph_system_generator\notebook\exporters.py

Advances #256