### PR TITLE
Harden RequirementsAnalyst single-turn intake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ These node functions are the clearest map of the runtime lifecycle:
 
 | Pipeline stage | Node | Main collaborator | Typical state written |
 | --- | --- | --- | --- |
-| Intake | `intake_node` | `RequirementsAnalyst` | `constraints` |
+| Intake | `intake_node` | `RequirementsAnalyst` | `constraints`, `requirements_feedback` |
 | Retrieval | `rag_retrieval_node` | `DocsRetriever` | `docs_context` |
 | Architecture selection | `architecture_selection_node` | `ArchitectureSelector` | `selected_patterns`, `architecture_type`, `architecture_justification` |
 | Workflow design | `graph_design_node` | `GraphDesigner` | `workflow_design`, `notebook_plan` |
@@ -106,6 +106,7 @@ That state is the integration contract between stages.
 Important patterns:
 
 - `constraints` and `docs_context` are accumulated lists.
+- `requirements_feedback` is advisory metadata from intake. It should surface fallback/gap/conflict guidance without replacing `constraints` as the downstream source of truth.
 - `generated_cells` is authoritative for the current repair iteration and is
   replaced rather than concatenated.
 - `qa_reports` is the current QA snapshot for the active pass, while

--- a/docs/wiki/Architecture-Deep-Dive.md
+++ b/docs/wiki/Architecture-Deep-Dive.md
@@ -40,7 +40,7 @@ graph TB
 
 #### 1. Requirements Analysis (Intake)
 **Input**: User prompt  
-**Output**: Structured constraints
+**Output**: Structured constraints plus advisory requirements feedback
 
 The Requirements Analyst extracts structured constraints from the natural language prompt:
 
@@ -51,7 +51,13 @@ The Requirements Analyst extracts structured constraints from the natural langua
     {"type": "architecture", "value": "routing", "priority": 1},
     {"type": "domain", "value": "customer support", "priority": 1},
     {"type": "capability", "value": "classification", "priority": 2}
-  ]
+  ],
+  "requirements_feedback": {
+    "fallback_used": false,
+    "missing_inputs": [],
+    "conflicts": [],
+    "suggestions": []
+  }
 }
 ```
 
@@ -343,6 +349,7 @@ class GeneratorState(TypedDict):
     
     # Extracted requirements
     constraints: Annotated[List[Constraint], operator.add]
+    requirements_feedback: RequirementsFeedback
     selected_patterns: Dict[str, Any]
     
     # RAG Retrieval
@@ -374,6 +381,7 @@ class GeneratorState(TypedDict):
 
 **Key Features**:
 - **Annotated Lists**: Fields like `constraints` and `docs_context` use `operator.add` to append values across nodes
+- **Advisory Intake Feedback**: `requirements_feedback` captures fallback, conflict, and missing-input guidance without replacing `constraints` as the downstream planning contract
 - **Last-write-wins cells**: `generated_cells` intentionally has no reducer, so each repair pass replaces prior cells
 - **Immutability**: State updates create new state versions (LangGraph managed)
 - **Type Safety**: TypedDict provides IDE autocomplete and validation

--- a/docs/wiki/Architecture-Deep-Dive.md
+++ b/docs/wiki/Architecture-Deep-Dive.md
@@ -48,9 +48,9 @@ The Requirements Analyst extracts structured constraints from the natural langua
 {
   "user_prompt": "Create a customer support chatbot with routing",
   "constraints": [
-    {"type": "architecture", "value": "routing", "priority": 1},
-    {"type": "domain", "value": "customer support", "priority": 1},
-    {"type": "capability", "value": "classification", "priority": 2}
+    {"type": "goal", "value": "Build a customer support chatbot", "priority": 5},
+    {"type": "structure", "value": "Use routing between support flows", "priority": 3},
+    {"type": "environment", "value": "Run in a notebook-friendly environment", "priority": 2}
   ],
   "requirements_feedback": {
     "fallback_used": false,

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -20,6 +20,7 @@ from langgraph_system_generator.generator.state import (
     CellSpec,
     Constraint,
     NotebookPlan,
+    RequirementsFeedback,
 )
 from langgraph_system_generator.utils.error_handling import GenerationError
 from langgraph_system_generator.utils.config import GenerationConfig, settings
@@ -61,6 +62,18 @@ def _default_state(
         "user_prompt": prompt,
         "uploaded_files": None,
         "constraints": [],
+        "requirements_feedback": RequirementsFeedback(
+            fallback_used=False,
+            available_constraint_types=[
+                "goal",
+                "tone",
+                "length",
+                "structure",
+                "runtime",
+                "environment",
+                *settings.requirements_constraint_types,
+            ],
+        ),
         "selected_patterns": {},
         "docs_context": [],
         "notebook_plan": None,
@@ -138,6 +151,55 @@ def _normalize_generation_error(
         details={"error_type": type(exc).__name__},
         status_code=default_status_code,
     )
+
+
+def _requirements_warning_entries(
+    feedback: Dict[str, Any] | None,
+) -> List[Dict[str, Any]]:
+    """Convert structured requirements feedback into manifest warnings."""
+
+    if not isinstance(feedback, dict):
+        return []
+
+    warnings: List[Dict[str, Any]] = []
+    suggestions = list(feedback.get("suggestions") or [])
+    if feedback.get("fallback_used"):
+        warnings.append(
+            {
+                "code": "requirements_fallback",
+                "phase": "intake",
+                "message": feedback.get("fallback_reason")
+                or "Requirements extraction used a fallback goal constraint.",
+                "suggestions": suggestions,
+            }
+        )
+
+    missing_inputs = list(feedback.get("missing_inputs") or [])
+    if missing_inputs:
+        warnings.append(
+            {
+                "code": "requirements_missing_inputs",
+                "phase": "intake",
+                "message": "Missing core requirement categories: "
+                + ", ".join(missing_inputs),
+                "missing_inputs": missing_inputs,
+                "suggestions": suggestions,
+            }
+        )
+
+    conflicts = list(feedback.get("conflicts") or [])
+    if conflicts:
+        warnings.append(
+            {
+                "code": "requirements_conflicts",
+                "phase": "intake",
+                "message": "Conflicting requirements were detected during intake.",
+                "conflicts": conflicts,
+                "suggestions": suggestions,
+            }
+        )
+
+    return warnings
 
 
 class _PhaseTracker:
@@ -528,6 +590,18 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
 
     return {
         "constraints": constraints,
+        "requirements_feedback": RequirementsFeedback(
+            fallback_used=False,
+            available_constraint_types=[
+                "goal",
+                "tone",
+                "length",
+                "structure",
+                "runtime",
+                "environment",
+                *settings.requirements_constraint_types,
+            ],
+        ),
         "selected_patterns": {"primary": architecture_type},
         "docs_context": [],
         "notebook_plan": plan,
@@ -664,6 +738,7 @@ async def generate_artifacts(
     plan_title = (
         serialized.get("notebook_plan", {}).get("title") or "Generated Notebook"
     )
+    requirements_feedback = serialized.get("requirements_feedback") or {}
 
     manifest: Dict[str, Any] = {
         "prompt": prompt,
@@ -671,7 +746,8 @@ async def generate_artifacts(
         "architecture_type": architecture_type,
         "cell_count": len(serialized.get("generated_cells", []) or []),
         "plan_title": plan_title,
-        "warnings": [],
+        "requirements_feedback": requirements_feedback,
+        "warnings": _requirements_warning_entries(requirements_feedback),
         "export_results": {},
     }
 

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -17,6 +17,7 @@ from time import perf_counter
 from typing import Any, Dict, List, Literal, TypedDict
 
 from langgraph_system_generator.generator.state import (
+    build_constraint_type_registry,
     CellSpec,
     Constraint,
     NotebookPlan,
@@ -51,6 +52,12 @@ class GenerationArtifacts(TypedDict):
     result: Dict[str, Any]
 
 
+def _available_constraint_types() -> List[str]:
+    """Return the normalized intake constraint registry for manifests and defaults."""
+
+    return build_constraint_type_registry(settings.requirements_constraint_types)
+
+
 def _default_state(
     prompt: str,
     generation_config: GenerationConfig | None = None,
@@ -64,15 +71,7 @@ def _default_state(
         "constraints": [],
         "requirements_feedback": RequirementsFeedback(
             fallback_used=False,
-            available_constraint_types=[
-                "goal",
-                "tone",
-                "length",
-                "structure",
-                "runtime",
-                "environment",
-                *settings.requirements_constraint_types,
-            ],
+            available_constraint_types=_available_constraint_types(),
         ),
         "selected_patterns": {},
         "docs_context": [],
@@ -592,15 +591,7 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
         "constraints": constraints,
         "requirements_feedback": RequirementsFeedback(
             fallback_used=False,
-            available_constraint_types=[
-                "goal",
-                "tone",
-                "length",
-                "structure",
-                "runtime",
-                "environment",
-                *settings.requirements_constraint_types,
-            ],
+            available_constraint_types=_available_constraint_types(),
         ),
         "selected_patterns": {"primary": architecture_type},
         "docs_context": [],

--- a/src/langgraph_system_generator/generator/agents/requirements_analyst.py
+++ b/src/langgraph_system_generator/generator/agents/requirements_analyst.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, List
+from typing import Any, Dict, List, Set
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from langgraph_system_generator.generator.agents._llm import build_chat_llm
 from langgraph_system_generator.generator.state import (
+    build_constraint_type_registry,
     Constraint,
+    normalize_constraint_type,
     RequirementsAnalysis,
     RequirementsFeedback,
 )
@@ -19,14 +21,6 @@ from langgraph_system_generator.utils.config import ModelConfig, settings
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_CONSTRAINT_TYPES = (
-    "goal",
-    "tone",
-    "length",
-    "structure",
-    "runtime",
-    "environment",
-)
 CORE_CONSTRAINT_TYPES = ("goal", "runtime", "environment")
 CONSTRAINT_TYPE_DESCRIPTIONS = {
     "goal": "The main objective, deliverable, or workflow outcome.",
@@ -41,13 +35,6 @@ MISSING_INPUT_SUGGESTIONS = {
     "runtime": "Add runtime constraints such as model choice, latency, budget, or retry limits.",
     "environment": "Describe the target environment, such as Colab, local Jupyter, deployment target, or required libraries.",
 }
-
-
-def _normalize_constraint_type(value: str) -> str:
-    """Return a normalized constraint type name."""
-
-    return value.strip().lower().replace(" ", "_")
-
 
 class RequirementsAnalyst:
     """Extracts structured constraints from user prompt."""
@@ -66,13 +53,7 @@ class RequirementsAnalyst:
 
     def _constraint_type_registry(self) -> List[str]:
         """Return the current ordered registry of supported constraint types."""
-
-        registry: List[str] = []
-        for raw_type in [*DEFAULT_CONSTRAINT_TYPES, *settings.requirements_constraint_types]:
-            normalized = _normalize_constraint_type(raw_type)
-            if normalized and normalized not in registry:
-                registry.append(normalized)
-        return registry
+        return build_constraint_type_registry(settings.requirements_constraint_types)
 
     def _build_analysis_prompt(self) -> SystemMessage:
         """Return the system prompt used for requirements extraction."""
@@ -130,7 +111,15 @@ class RequirementsAnalyst:
         for item in payload:
             if not isinstance(item, dict):
                 raise ValueError("Each extracted constraint must be an object.")
-            normalized_type = _normalize_constraint_type(str(item.get("type", "")))
+            raw_type = item.get("type")
+            normalized_type = normalize_constraint_type(raw_type)
+            if not normalized_type:
+                raise ValueError("Each extracted constraint must include a non-empty type.")
+            if normalized_type not in self.constraint_types:
+                raise ValueError(
+                    f"Unsupported constraint type '{raw_type}'. "
+                    "Use one of the configured intake registry types."
+                )
             constraint = Constraint(
                 **{
                     **item,
@@ -158,7 +147,7 @@ class RequirementsAnalyst:
     def _detect_conflicts(self, constraints: List[Constraint]) -> List[str]:
         """Return conflicts where the same constraint type has divergent values."""
 
-        values_by_type: dict[str, set[str]] = {}
+        values_by_type: Dict[str, Set[str]] = {}
         for constraint in constraints:
             values_by_type.setdefault(constraint.type, set()).add(
                 constraint.value.strip().lower()
@@ -175,7 +164,7 @@ class RequirementsAnalyst:
     def _missing_core_inputs(self, constraints: List[Constraint]) -> List[str]:
         """Return missing core requirement categories."""
 
-        present = {_normalize_constraint_type(constraint.type) for constraint in constraints}
+        present = {normalize_constraint_type(constraint.type) for constraint in constraints}
         return [constraint_type for constraint_type in CORE_CONSTRAINT_TYPES if constraint_type not in present]
 
     def _build_feedback(

--- a/src/langgraph_system_generator/generator/agents/requirements_analyst.py
+++ b/src/langgraph_system_generator/generator/agents/requirements_analyst.py
@@ -2,15 +2,51 @@
 
 from __future__ import annotations
 
-from typing import List
+import logging
+from typing import Any, List
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from langgraph_system_generator.generator.agents._llm import build_chat_llm
-from langgraph_system_generator.generator.state import Constraint
+from langgraph_system_generator.generator.state import (
+    Constraint,
+    RequirementsAnalysis,
+    RequirementsFeedback,
+)
 from langgraph_system_generator.generator.utils import extract_json_from_llm_response
-from langgraph_system_generator.utils.config import ModelConfig
+from langgraph_system_generator.utils.config import ModelConfig, settings
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONSTRAINT_TYPES = (
+    "goal",
+    "tone",
+    "length",
+    "structure",
+    "runtime",
+    "environment",
+)
+CORE_CONSTRAINT_TYPES = ("goal", "runtime", "environment")
+CONSTRAINT_TYPE_DESCRIPTIONS = {
+    "goal": "The main objective, deliverable, or workflow outcome.",
+    "tone": "Style, voice, or presentation constraints.",
+    "length": "Length, scope, or detail expectations.",
+    "structure": "Structural or organizational requirements.",
+    "runtime": "Runtime behavior such as models, latency, budget, or iteration limits.",
+    "environment": "Execution environment, dependencies, or platform targets.",
+}
+MISSING_INPUT_SUGGESTIONS = {
+    "goal": "State the primary deliverable or workflow objective explicitly.",
+    "runtime": "Add runtime constraints such as model choice, latency, budget, or retry limits.",
+    "environment": "Describe the target environment, such as Colab, local Jupyter, deployment target, or required libraries.",
+}
+
+
+def _normalize_constraint_type(value: str) -> str:
+    """Return a normalized constraint type name."""
+
+    return value.strip().lower().replace(" ", "_")
 
 
 class RequirementsAnalyst:
@@ -26,54 +62,181 @@ class RequirementsAnalyst:
             model_config=model_config,
             chat_openai_class=ChatOpenAI,
         )
+        self.constraint_types = self._constraint_type_registry()
 
-    async def analyze(self, prompt: str) -> List[Constraint]:
-        """Extract constraints from prompt.
+    def _constraint_type_registry(self) -> List[str]:
+        """Return the current ordered registry of supported constraint types."""
 
-        Args:
-            prompt: User's project description
+        registry: List[str] = []
+        for raw_type in [*DEFAULT_CONSTRAINT_TYPES, *settings.requirements_constraint_types]:
+            normalized = _normalize_constraint_type(raw_type)
+            if normalized and normalized not in registry:
+                registry.append(normalized)
+        return registry
 
-        Returns:
-            List of structured constraints
-        """
-        analysis_prompt = SystemMessage(
-            content="""You are a requirements analyst. Extract structured constraints from the user's project description.
+    def _build_analysis_prompt(self) -> SystemMessage:
+        """Return the system prompt used for requirements extraction."""
 
-Identify and categorize:
-- **goal**: The main objective and deliverables
-- **tone**: Style, tone, or voice constraints (e.g., professional, casual, technical)
-- **length**: Length or size requirements (e.g., short, detailed, comprehensive)
-- **structure**: Structural requirements (e.g., modular, linear, hierarchical)
-- **runtime**: Runtime constraints (budget, iterations, model preferences, timeouts)
-- **environment**: Environment constraints (Colab, libraries, Python version, deployment target)
+        type_lines = []
+        for constraint_type in self.constraint_types:
+            description = CONSTRAINT_TYPE_DESCRIPTIONS.get(
+                constraint_type,
+                "Project-specific requirement category configured for this repository.",
+            )
+            type_lines.append(f'- "{constraint_type}": {description}')
 
-Return a JSON array of constraints with this structure:
-[
-  {"type": "goal", "value": "description", "priority": 5},
-  {"type": "tone", "value": "description", "priority": 3},
-  ...
-]
-
-Priority: 1 (low) to 5 (high). Goals are typically priority 5."""
+        return SystemMessage(
+            content=(
+                "You are a requirements analyst. Extract structured constraints from the user's project description.\n\n"
+                "Available constraint types:\n"
+                f"{chr(10).join(type_lines)}\n\n"
+                "Return a JSON object with this shape:\n"
+                "{\n"
+                '  "constraints": [\n'
+                "    {\n"
+                '      "type": "goal",\n'
+                '      "value": "description",\n'
+                '      "priority": 5,\n'
+                '      "confidence": 0.0,\n'
+                '      "explanation": "why this constraint was extracted"\n'
+                "    }\n"
+                "  ]\n"
+                "}\n\n"
+                "Rules:\n"
+                "- Use only the available constraint types listed above.\n"
+                "- Omit any constraint type that is not justified by the prompt.\n"
+                "- Priority is 1 (low) to 5 (high). Goals are usually priority 5.\n"
+                "- Confidence is optional and should be between 0.0 and 1.0.\n"
+                "- Explanations should be short and actionable.\n"
+                "- Return valid JSON only."
+            )
         )
 
-        user_message = HumanMessage(content=prompt)
+    def _parse_constraints_payload(self, payload: Any) -> List[Constraint]:
+        """Convert model JSON into a list of constraints."""
 
+        if isinstance(payload, dict):
+            if "constraints" in payload:
+                payload = payload["constraints"]
+            elif {"type", "value"}.issubset(payload):
+                payload = [payload]
+            else:
+                raise ValueError("Requirements payload did not contain a constraints array.")
+
+        if not isinstance(payload, list):
+            raise ValueError("Requirements payload must be a list of constraints.")
+
+        constraints: List[Constraint] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                raise ValueError("Each extracted constraint must be an object.")
+            normalized_type = _normalize_constraint_type(str(item.get("type", "")))
+            constraint = Constraint(
+                **{
+                    **item,
+                    "type": normalized_type,
+                }
+            )
+            constraints.append(constraint)
+
+        return constraints
+
+    def _fallback_constraint(self, prompt: str) -> Constraint:
+        """Create a conservative fallback constraint from the raw prompt."""
+
+        return Constraint(
+            type="goal",
+            value=prompt[:200] if len(prompt) > 200 else prompt,
+            priority=5,
+            confidence=0.15,
+            explanation=(
+                "Fallback goal created from the raw prompt because structured "
+                "requirements extraction was unavailable."
+            ),
+        )
+
+    def _detect_conflicts(self, constraints: List[Constraint]) -> List[str]:
+        """Return conflicts where the same constraint type has divergent values."""
+
+        values_by_type: dict[str, set[str]] = {}
+        for constraint in constraints:
+            values_by_type.setdefault(constraint.type, set()).add(
+                constraint.value.strip().lower()
+            )
+
+        conflicts = []
+        for constraint_type, distinct_values in values_by_type.items():
+            if len(distinct_values) > 1:
+                conflicts.append(
+                    f"Conflicting {constraint_type} constraints were extracted from the prompt."
+                )
+        return conflicts
+
+    def _missing_core_inputs(self, constraints: List[Constraint]) -> List[str]:
+        """Return missing core requirement categories."""
+
+        present = {_normalize_constraint_type(constraint.type) for constraint in constraints}
+        return [constraint_type for constraint_type in CORE_CONSTRAINT_TYPES if constraint_type not in present]
+
+    def _build_feedback(
+        self,
+        constraints: List[Constraint],
+        *,
+        fallback_used: bool,
+        fallback_reason: str | None,
+    ) -> RequirementsFeedback:
+        """Build structured advisory feedback from parsed constraints."""
+
+        missing_inputs = self._missing_core_inputs(constraints)
+        conflicts = self._detect_conflicts(constraints)
+
+        suggestions: List[str] = []
+        if fallback_used:
+            suggestions.append(
+                "Clarify the main goal, runtime expectations, and target environment to improve requirements extraction."
+            )
+        for missing_input in missing_inputs:
+            suggestion = MISSING_INPUT_SUGGESTIONS.get(missing_input)
+            if suggestion and suggestion not in suggestions:
+                suggestions.append(suggestion)
+        if conflicts:
+            suggestions.append(
+                "Resolve conflicting prompt instructions so the generator can pick a single interpretation."
+            )
+
+        return RequirementsFeedback(
+            fallback_used=fallback_used,
+            fallback_reason=fallback_reason,
+            missing_inputs=missing_inputs,
+            conflicts=conflicts,
+            suggestions=suggestions,
+            available_constraint_types=list(self.constraint_types),
+        )
+
+    async def analyze(self, prompt: str) -> RequirementsAnalysis:
+        """Extract structured constraints and feedback from a user prompt."""
+
+        analysis_prompt = self._build_analysis_prompt()
+        user_message = HumanMessage(content=prompt)
         response = await self.llm.ainvoke([analysis_prompt, user_message])
+
+        fallback_used = False
+        fallback_reason: str | None = None
 
         try:
             constraints_data = extract_json_from_llm_response(response.content)
-            constraints = [Constraint(**c) for c in constraints_data]
-            return constraints
-        except (ValueError, KeyError, TypeError) as e:
-            import logging
+            constraints = self._parse_constraints_payload(constraints_data)
+            if not constraints:
+                raise ValueError("No constraints were extracted from the model response.")
+        except (ValueError, KeyError, TypeError) as exc:
+            fallback_used = True
+            fallback_reason = f"Requirements extraction fallback used: {exc}"
+            logger.warning(fallback_reason)
+            constraints = [self._fallback_constraint(prompt)]
 
-            logging.warning(f"Failed to parse LLM response for constraints: {e}")
-            # Fallback: create a basic goal constraint from the prompt
-            return [
-                Constraint(
-                    type="goal",
-                    value=prompt[:200] if len(prompt) > 200 else prompt,
-                    priority=5,
-                )
-            ]
+        feedback = self._build_feedback(
+            constraints,
+            fallback_used=fallback_used,
+            fallback_reason=fallback_reason,
+        )
+        return RequirementsAnalysis(constraints=constraints, feedback=feedback)

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -154,9 +154,12 @@ async def intake_node(state: GeneratorState) -> Dict[str, Any]:
         Updated state with extracted constraints
     """
     analyst = RequirementsAnalyst(model_config=_resolve_model_config(state))
-    constraints = await analyst.analyze(state["user_prompt"])
+    analysis = await analyst.analyze(state["user_prompt"])
 
-    return {"constraints": constraints}
+    return {
+        "constraints": analysis.constraints,
+        "requirements_feedback": analysis.feedback,
+    }
 
 
 async def rag_retrieval_node(state: GeneratorState) -> Dict[str, Any]:
@@ -599,12 +602,18 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
         Updated state with artifacts manifest and completion flag
     """
     # Create artifacts manifest
+    requirements_feedback = state.get("requirements_feedback")
     manifest = {
         "notebook_plan": str(state.get("notebook_plan")),
         "cell_count": str(len(state.get("generated_cells", []))),
         "architecture_type": state.get("architecture_type")
         or state.get("selected_patterns", {}).get("primary", "router"),
         "constraints_count": str(len(state.get("constraints", []))),
+        "requirements_feedback": (
+            requirements_feedback.model_dump()
+            if hasattr(requirements_feedback, "model_dump")
+            else (requirements_feedback or {})
+        ),
     }
 
     return {

--- a/src/langgraph_system_generator/generator/state.py
+++ b/src/langgraph_system_generator/generator/state.py
@@ -19,6 +19,58 @@ class Constraint(BaseModel):
     )
     value: str = Field(description="Constraint value or description")
     priority: int = Field(default=1, description="Priority level (1=low, 5=high)")
+    confidence: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Optional confidence score for the extracted constraint.",
+    )
+    explanation: Optional[str] = Field(
+        default=None,
+        description="Optional human-readable explanation for why the constraint was extracted.",
+    )
+
+
+class RequirementsFeedback(BaseModel):
+    """Advisory feedback captured during requirements extraction."""
+
+    fallback_used: bool = Field(
+        default=False,
+        description="Whether the analyst had to fall back to a synthetic goal constraint.",
+    )
+    fallback_reason: Optional[str] = Field(
+        default=None,
+        description="Reason fallback mode was used, when applicable.",
+    )
+    missing_inputs: List[str] = Field(
+        default_factory=list,
+        description="Core requirement categories that were missing from the prompt.",
+    )
+    conflicts: List[str] = Field(
+        default_factory=list,
+        description="Conflicting requirement interpretations detected during extraction.",
+    )
+    suggestions: List[str] = Field(
+        default_factory=list,
+        description="Actionable follow-up suggestions for improving requirement quality.",
+    )
+    available_constraint_types: List[str] = Field(
+        default_factory=list,
+        description="Constraint types available to the analyst for the current request.",
+    )
+
+
+class RequirementsAnalysis(BaseModel):
+    """Structured single-turn requirements analysis output."""
+
+    constraints: List[Constraint] = Field(
+        default_factory=list,
+        description="Constraints extracted from the user's prompt.",
+    )
+    feedback: RequirementsFeedback = Field(
+        default_factory=RequirementsFeedback,
+        description="Advisory feedback captured during requirements extraction.",
+    )
 
 
 class DocSnippet(BaseModel):
@@ -90,6 +142,7 @@ class GeneratorState(TypedDict):
 
     # Extracted requirements
     constraints: Annotated[List[Constraint], operator.add]
+    requirements_feedback: RequirementsFeedback
     selected_patterns: Dict[str, Any]
 
     # RAG context
@@ -120,6 +173,6 @@ class GeneratorState(TypedDict):
     repair_attempts: int
 
     # Output
-    artifacts_manifest: Dict[str, str]
+    artifacts_manifest: Dict[str, Any]
     generation_complete: bool
     error_message: Optional[str]

--- a/src/langgraph_system_generator/generator/state.py
+++ b/src/langgraph_system_generator/generator/state.py
@@ -10,12 +10,47 @@ from typing_extensions import TypedDict
 
 from langgraph_system_generator.utils.config import GenerationConfig
 
+DEFAULT_REQUIREMENTS_CONSTRAINT_TYPES = (
+    "goal",
+    "tone",
+    "length",
+    "structure",
+    "runtime",
+    "environment",
+)
+
+
+def normalize_constraint_type(value: str) -> str:
+    """Return a normalized constraint type token."""
+
+    if not isinstance(value, str):
+        return ""
+    return value.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def build_constraint_type_registry(extra_types: Optional[List[str]] = None) -> List[str]:
+    """Build the ordered, de-duplicated registry of supported constraint types."""
+
+    registry: List[str] = []
+    for raw_type in [
+        *DEFAULT_REQUIREMENTS_CONSTRAINT_TYPES,
+        *(extra_types or []),
+    ]:
+        normalized = normalize_constraint_type(raw_type)
+        if normalized and normalized not in registry:
+            registry.append(normalized)
+    return registry
+
 
 class Constraint(BaseModel):
     """User constraint specification."""
 
     type: str = Field(
-        description="Constraint type: 'goal', 'tone', 'length', 'structure', 'runtime', 'environment'"
+        description=(
+            "Constraint type from the current intake registry, such as "
+            "'goal', 'tone', 'length', 'structure', 'runtime', "
+            "'environment', or configured extras."
+        )
     )
     value: str = Field(description="Constraint value or description")
     priority: int = Field(default=1, description="Priority level (1=low, 5=high)")

--- a/src/langgraph_system_generator/utils/config.py
+++ b/src/langgraph_system_generator/utils/config.py
@@ -8,10 +8,10 @@ import json
 import os
 from pathlib import Path
 import sys
-from typing import Optional, Union
+from typing import Annotated, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
 class ModelConfig(BaseModel):
@@ -132,7 +132,7 @@ class Settings(BaseSettings):
         default=100000,
         description="Default token budget allocated for a generation run.",
     )
-    requirements_constraint_types: list[str] = Field(
+    requirements_constraint_types: Annotated[list[str], NoDecode] = Field(
         default_factory=list,
         description="Optional extra requirement constraint types made available during intake.",
     )
@@ -150,7 +150,12 @@ class Settings(BaseSettings):
             if not stripped:
                 return []
             if stripped.startswith("["):
-                parsed = json.loads(stripped)
+                try:
+                    parsed = json.loads(stripped)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"Invalid JSON in requirements_constraint_types: {exc}"
+                    ) from exc
                 if not isinstance(parsed, list):
                     raise ValueError("requirements_constraint_types must decode to a list")
                 return parsed

--- a/src/langgraph_system_generator/utils/config.py
+++ b/src/langgraph_system_generator/utils/config.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from functools import lru_cache
+import json
 import os
 from pathlib import Path
 import sys
 from typing import Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -131,6 +132,30 @@ class Settings(BaseSettings):
         default=100000,
         description="Default token budget allocated for a generation run.",
     )
+    requirements_constraint_types: list[str] = Field(
+        default_factory=list,
+        description="Optional extra requirement constraint types made available during intake.",
+    )
+
+    @field_validator("requirements_constraint_types", mode="before")
+    @classmethod
+    def _parse_requirements_constraint_types(cls, value):
+        """Accept JSON arrays or comma-separated strings from the environment."""
+        if value in (None, ""):
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return []
+            if stripped.startswith("["):
+                parsed = json.loads(stripped)
+                if not isinstance(parsed, list):
+                    raise ValueError("requirements_constraint_types must decode to a list")
+                return parsed
+            return [item.strip() for item in stripped.split(",") if item.strip()]
+        return value
 
 
 _DEFAULT_ENV_FILE = object()
@@ -144,6 +169,7 @@ _TEST_SETTINGS_ENV_KEYS = (
     "DEFAULT_MODEL",
     "MAX_REPAIR_ATTEMPTS",
     "DEFAULT_BUDGET_TOKENS",
+    "REQUIREMENTS_CONSTRAINT_TYPES",
 )
 
 

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -50,6 +50,8 @@ async def test_generate_artifacts_stub(tmp_path: Path, monkeypatch: pytest.Monke
 
     assert artifacts["manifest"]["prompt"] == "Test prompt"
     assert artifacts["manifest"]["cell_count"] > 0
+    assert artifacts["manifest"]["requirements_feedback"]["fallback_used"] is False
+    assert artifacts["result"]["requirements_feedback"]["fallback_used"] is False
     assert Path(artifacts["manifest_path"]).exists()
     assert artifacts["result"]["generation_complete"] is True
 
@@ -65,6 +67,8 @@ def test_default_state_includes_generation_mode_and_qa_history():
 
     assert state["generation_mode"] == "live"
     assert state["qa_history"] == []
+    assert state["requirements_feedback"].fallback_used is False
+    assert "goal" in state["requirements_feedback"].available_constraint_types
 
 
 @pytest.mark.asyncio
@@ -157,6 +161,51 @@ async def test_api_generate_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert payload["prompt"] == "API prompt"
     assert "output_dir" in payload
     assert payload["output_dir"] == str(output_dir)
+    assert payload["manifest"]["requirements_feedback"]["fallback_used"] is False
+
+
+@pytest.mark.asyncio
+async def test_generate_artifacts_surfaces_requirements_feedback_as_warnings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_requirements_feedback_warning")
+
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.cli as cli_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(cli_module)
+
+    original_build_stub_result = cli_module._build_stub_result
+
+    def build_stub_result_with_feedback(prompt: str, agent_type: str | None = None):
+        result = original_build_stub_result(prompt, agent_type=agent_type)
+        result["requirements_feedback"] = {
+            "fallback_used": True,
+            "fallback_reason": "Failed to parse requirements payload.",
+            "missing_inputs": ["runtime", "environment"],
+            "conflicts": ["Conflicting runtime instructions were detected."],
+            "suggestions": ["Clarify the target runtime and environment constraints."],
+            "available_constraint_types": ["goal", "runtime", "environment"],
+        }
+        return result
+
+    monkeypatch.setattr(cli_module, "_build_stub_result", build_stub_result_with_feedback)
+
+    output_dir = constants_module._BASE_OUTPUT / tmp_path.name
+    artifacts = await cli_module.generate_artifacts(
+        "Ambiguous prompt",
+        output_dir=str(output_dir),
+        mode="stub",
+    )
+
+    warning_codes = {warning["code"] for warning in artifacts["manifest"]["warnings"]}
+    assert "requirements_fallback" in warning_codes
+    assert "requirements_missing_inputs" in warning_codes
+    assert "requirements_conflicts" in warning_codes
+    assert artifacts["manifest"]["requirements_feedback"]["fallback_used"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -71,6 +71,40 @@ def test_default_state_includes_generation_mode_and_qa_history():
     assert "goal" in state["requirements_feedback"].available_constraint_types
 
 
+def test_default_and_stub_results_normalize_constraint_type_registry(monkeypatch):
+    import langgraph_system_generator.cli as cli_module
+
+    monkeypatch.setattr(
+        cli_module,
+        "settings",
+        cli_module.settings.model_copy(
+            update={
+                "requirements_constraint_types": [
+                    "Custom Type",
+                    " runtime ",
+                    "custom-type",
+                ]
+            }
+        ),
+    )
+
+    expected_registry = [
+        "goal",
+        "tone",
+        "length",
+        "structure",
+        "runtime",
+        "environment",
+        "custom_type",
+    ]
+
+    state = cli_module._default_state("Test prompt")
+    stub_result = cli_module._build_stub_result("Test prompt")
+
+    assert state["requirements_feedback"].available_constraint_types == expected_registry
+    assert stub_result["requirements_feedback"].available_constraint_types == expected_registry
+
+
 @pytest.mark.asyncio
 async def test_generate_artifacts_stub_autoagent_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from pydantic_settings import SettingsConfigDict
 
 from langgraph_system_generator.utils.config import (
@@ -139,6 +140,27 @@ def test_settings_default_load_ignores_lnf_env_file_under_pytest(tmp_path, monke
 
     assert explicit.openai_api_key == "from-env-file"
     assert explicit.default_model == "from-env-file"
+
+
+def test_settings_reject_invalid_requirements_constraint_types_json(tmp_path):
+    from pydantic import ValidationError
+
+    env_path = Path(tmp_path) / ".env"
+    env_path.write_text(
+        'REQUIREMENTS_CONSTRAINT_TYPES=["goal",}\n',
+        encoding="utf-8",
+    )
+
+    class FileSettings(Settings):
+        model_config = SettingsConfigDict(
+            env_file=env_path, env_file_encoding="utf-8", extra="ignore"
+        )
+
+    with pytest.raises(
+        ValidationError,
+        match="Invalid JSON in requirements_constraint_types",
+    ):
+        FileSettings()
 
 
 def test_model_config_defaults():

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from langgraph_system_generator.generator.agents import (
@@ -49,24 +51,162 @@ def make_capturing_llm(captured_kwargs: dict):
     return CapturingLLM
 
 
+def make_recording_llm(content: str, captured_messages: list):
+    """Create a ChatOpenAI stub that records prompt messages."""
+
+    class RecordingLLM:
+        def __init__(self, *_args, **_kwargs):
+            self._content = content
+
+        async def ainvoke(self, messages):
+            captured_messages.append(messages)
+            return DummyResponse(self._content)
+
+    return RecordingLLM
+
+
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("payload", "expected_value"),
-    [
-        ('[{"type":"goal","value":"from-json","priority":5}]', "from-json"),
-        ("not json", "x"),
-    ],
-)
-async def test_requirements_analyst_parsing(payload, expected_value, monkeypatch):
-    """RequirementsAnalyst returns parsed constraints or fallback on errors."""
+async def test_requirements_analyst_parsing(monkeypatch):
+    """RequirementsAnalyst returns structured constraints and feedback."""
+    payload = """
+    {
+      "constraints": [
+        {
+          "type": "goal",
+          "value": "from-json",
+          "priority": 5,
+          "confidence": 0.92,
+          "explanation": "Prompt clearly asks for this deliverable."
+        },
+        {
+          "type": "environment",
+          "value": "Run in Colab",
+          "priority": 3,
+          "confidence": 0.61,
+          "explanation": "The prompt references notebook execution."
+        }
+      ],
+      "feedback": {
+        "fallback_used": false,
+        "fallback_reason": null,
+        "missing_inputs": [],
+        "conflicts": [],
+        "suggestions": [],
+        "available_constraint_types": ["goal", "environment"]
+      }
+    }
+    """
     monkeypatch.setattr(
         requirements_analyst,
         "ChatOpenAI",
         make_stub_llm(payload),
     )
     analyst = requirements_analyst.RequirementsAnalyst()
-    results = await analyst.analyze("x")
-    assert results[0].value == expected_value
+    analysis = await analyst.analyze("x")
+    assert analysis.constraints[0].value == "from-json"
+    assert analysis.constraints[0].confidence == pytest.approx(0.92)
+    assert analysis.constraints[0].explanation == "Prompt clearly asks for this deliverable."
+    assert analysis.feedback.fallback_used is False
+    assert "goal" in analysis.feedback.available_constraint_types
+    assert "environment" in analysis.feedback.available_constraint_types
+
+
+@pytest.mark.asyncio
+async def test_requirements_analyst_fallback_truncates_prompt_on_bad_json(monkeypatch):
+    """Malformed model output should produce fallback constraints plus structured feedback."""
+    long_prompt = "Build a workflow " + ("with a long prompt " * 15)
+    assert len(long_prompt) > 200
+
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock()
+    mock_llm.ainvoke.return_value.content = "not-json"
+
+    with patch(
+        "langgraph_system_generator.generator.agents.requirements_analyst.ChatOpenAI",
+        return_value=mock_llm,
+    ):
+        analyst = requirements_analyst.RequirementsAnalyst(model="test-model")
+        analysis = await analyst.analyze(long_prompt)
+
+    assert len(analysis.constraints) == 1
+    constraint = analysis.constraints[0]
+    assert constraint.type == "goal"
+    assert constraint.priority == 5
+    assert constraint.value == long_prompt[:200]
+    assert len(constraint.value) == 200
+    assert analysis.feedback.fallback_used is True
+    assert analysis.feedback.fallback_reason
+    assert {"runtime", "environment"}.issubset(set(analysis.feedback.missing_inputs))
+    assert analysis.feedback.suggestions
+
+
+@pytest.mark.asyncio
+async def test_requirements_analyst_detects_conflicts_and_missing_inputs(monkeypatch):
+    """Conflicting duplicates and missing core inputs should be surfaced in feedback."""
+    payload = """
+    {
+      "constraints": [
+        {"type": "goal", "value": "Build an agent notebook", "priority": 5},
+        {"type": "runtime", "value": "Use gpt-5-mini", "priority": 4},
+        {"type": "runtime", "value": "Use claude-3", "priority": 4}
+      ]
+    }
+    """
+
+    monkeypatch.setattr(
+        requirements_analyst,
+        "ChatOpenAI",
+        make_stub_llm(payload),
+    )
+
+    analyst = requirements_analyst.RequirementsAnalyst()
+    analysis = await analyst.analyze("Build an agent notebook with conflicting model instructions")
+
+    assert analysis.feedback.fallback_used is False
+    assert "environment" in analysis.feedback.missing_inputs
+    assert analysis.feedback.conflicts
+    assert any("runtime" in conflict.lower() for conflict in analysis.feedback.conflicts)
+    assert analysis.feedback.suggestions
+
+
+@pytest.mark.asyncio
+async def test_requirements_analyst_uses_configured_constraint_type_registry(monkeypatch):
+    """Configured extra requirement types should appear in the prompt registry and feedback."""
+    captured_messages = []
+    monkeypatch.setattr(
+        requirements_analyst,
+        "settings",
+        requirements_analyst.settings.model_copy(
+            update={"requirements_constraint_types": ["regulatory"]}
+        ),
+    )
+    monkeypatch.setattr(
+        requirements_analyst,
+        "ChatOpenAI",
+        make_recording_llm(
+            """
+            {
+              "constraints": [
+                {
+                  "type": "regulatory",
+                  "value": "Must follow SOC 2 controls",
+                  "priority": 4,
+                  "confidence": 0.8,
+                  "explanation": "The prompt explicitly names compliance."
+                }
+              ]
+            }
+            """,
+            captured_messages,
+        ),
+    )
+
+    analyst = requirements_analyst.RequirementsAnalyst()
+    analysis = await analyst.analyze("Build a SOC 2 compliant workflow")
+
+    assert analysis.constraints[0].type == "regulatory"
+    assert "regulatory" in analysis.feedback.available_constraint_types
+    assert "regulatory" in captured_messages[0][0].content
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -141,6 +141,52 @@ async def test_requirements_analyst_fallback_truncates_prompt_on_bad_json(monkey
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "reason_fragment"),
+    [
+        (
+            """
+            {
+              "constraints": [
+                {"value": "Build an agent notebook", "priority": 5}
+              ]
+            }
+            """,
+            "must include a non-empty type",
+        ),
+        (
+            """
+            {
+              "constraints": [
+                {"type": "architecture", "value": "router", "priority": 4}
+              ]
+            }
+            """,
+            "Unsupported constraint type",
+        ),
+    ],
+)
+async def test_requirements_analyst_falls_back_for_invalid_constraint_types(
+    monkeypatch, payload, reason_fragment
+):
+    """Invalid or unsupported constraint types should trigger the fallback path."""
+
+    monkeypatch.setattr(
+        requirements_analyst,
+        "ChatOpenAI",
+        make_stub_llm(payload),
+    )
+
+    analyst = requirements_analyst.RequirementsAnalyst()
+    analysis = await analyst.analyze("Build an agent notebook")
+
+    assert analysis.feedback.fallback_used is True
+    assert reason_fragment in (analysis.feedback.fallback_reason or "")
+    assert len(analysis.constraints) == 1
+    assert analysis.constraints[0].type == "goal"
+
+
+@pytest.mark.asyncio
 async def test_requirements_analyst_detects_conflicts_and_missing_inputs(monkeypatch):
     """Conflicting duplicates and missing core inputs should be surfaced in feedback."""
     payload = """
@@ -177,7 +223,13 @@ async def test_requirements_analyst_uses_configured_constraint_type_registry(mon
         requirements_analyst,
         "settings",
         requirements_analyst.settings.model_copy(
-            update={"requirements_constraint_types": ["regulatory"]}
+            update={
+                "requirements_constraint_types": [
+                    "Regulatory",
+                    " regulatory ",
+                    "custom type",
+                ]
+            }
         ),
     )
     monkeypatch.setattr(
@@ -206,7 +258,10 @@ async def test_requirements_analyst_uses_configured_constraint_type_registry(mon
 
     assert analysis.constraints[0].type == "regulatory"
     assert "regulatory" in analysis.feedback.available_constraint_types
+    assert "custom_type" in analysis.feedback.available_constraint_types
+    assert analysis.feedback.available_constraint_types.count("regulatory") == 1
     assert "regulatory" in captured_messages[0][0].content
+    assert "custom_type" in captured_messages[0][0].content
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_nodes.py
+++ b/tests/unit/test_generator_nodes.py
@@ -12,7 +12,13 @@ from langgraph_system_generator.generator.nodes import (
     notebook_assembly_node,
     tooling_plan_node,
 )
-from langgraph_system_generator.generator.state import CellSpec, Constraint, NotebookPlan
+from langgraph_system_generator.generator.state import (
+    CellSpec,
+    Constraint,
+    NotebookPlan,
+    RequirementsAnalysis,
+    RequirementsFeedback,
+)
 from langgraph_system_generator.generator.nodes import intake_node, rag_retrieval_node
 from langgraph_system_generator.generator.state import Constraint, DocSnippet
 
@@ -31,36 +37,22 @@ async def test_intake_node_returns_constraints():
         with patch.object(
             RequirementsAnalyst,
             "analyze",
-            new=AsyncMock(return_value=constraints),
+            new=AsyncMock(
+                return_value=RequirementsAnalysis(
+                    constraints=constraints,
+                    feedback=RequirementsFeedback(
+                        fallback_used=False,
+                        available_constraint_types=["goal", "tone"],
+                    ),
+                )
+            ),
         ) as mock_analyze:
             result = await intake_node({"user_prompt": "Build a router workflow"})
 
-    assert result == {"constraints": constraints}
+    assert result["constraints"] == constraints
+    assert result["requirements_feedback"].fallback_used is False
+    assert result["requirements_feedback"].available_constraint_types == ["goal", "tone"]
     mock_analyze.assert_awaited_once_with("Build a router workflow")
-
-
-@pytest.mark.asyncio
-async def test_requirements_analyst_fallback_truncates_prompt_on_bad_json():
-    long_prompt = "Build a workflow " + ("with a long prompt " * 15)
-    assert len(long_prompt) > 200
-
-    mock_llm = MagicMock()
-    mock_llm.ainvoke = AsyncMock()
-    mock_llm.ainvoke.return_value.content = "not-json"
-
-    with patch(
-        "langgraph_system_generator.generator.agents.requirements_analyst.ChatOpenAI",
-        return_value=mock_llm,
-    ):
-        analyst = RequirementsAnalyst(model="test-model")
-        constraints = await analyst.analyze(long_prompt)
-
-    assert len(constraints) == 1
-    constraint = constraints[0]
-    assert constraint.type == "goal"
-    assert constraint.priority == 5
-    assert constraint.value == long_prompt[:200]
-    assert len(constraint.value) == 200
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_nodes.py
+++ b/tests/unit/test_generator_nodes.py
@@ -10,17 +10,17 @@ from langgraph_system_generator.generator.agents.requirements_analyst import (
 from langgraph_system_generator.generator.nodes import (
     intake_node,
     notebook_assembly_node,
+    rag_retrieval_node,
     tooling_plan_node,
 )
 from langgraph_system_generator.generator.state import (
     CellSpec,
     Constraint,
+    DocSnippet,
     NotebookPlan,
     RequirementsAnalysis,
     RequirementsFeedback,
 )
-from langgraph_system_generator.generator.nodes import intake_node, rag_retrieval_node
-from langgraph_system_generator.generator.state import Constraint, DocSnippet
 
 
 @pytest.mark.asyncio
@@ -59,7 +59,6 @@ async def test_intake_node_returns_constraints():
 async def test_tooling_plan_node_returns_tools_plan():
     constraints = [Constraint(type="goal", value="Build agents", priority=5)]
     workflow_design = {"nodes": [{"name": "agent", "purpose": "coordinate"}]}
-    expected_tools = [{"name": "search", "category": "search"}]
     expected_tools = [{"name": "search", "category": "search"}]
 
     # Patch ChatOpenAI used inside ToolchainEngineer.__init__ to avoid requiring OPENAI_API_KEY

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -22,7 +22,6 @@ from langgraph_system_generator.generator.nodes import (
     tooling_plan_node,
 )
 from langgraph_system_generator.generator.state import CellSpec, Constraint, QAReport
-from langgraph_system_generator.generator.state import RequirementsFeedback
 from langgraph_system_generator.utils.config import GenerationConfig
 
 

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -22,6 +22,7 @@ from langgraph_system_generator.generator.nodes import (
     tooling_plan_node,
 )
 from langgraph_system_generator.generator.state import CellSpec, Constraint, QAReport
+from langgraph_system_generator.generator.state import RequirementsFeedback
 from langgraph_system_generator.utils.config import GenerationConfig
 
 
@@ -48,7 +49,19 @@ def make_stub_llm(content: str):
 @pytest.mark.asyncio
 async def test_intake_node_sets_constraints(monkeypatch):
     constraints = [Constraint(type="goal", value="Test", priority=5)]
-    payload = '[{"type":"goal","value":"Test","priority":5}]'
+    payload = """
+    {
+      "constraints": [{"type":"goal","value":"Test","priority":5}],
+      "feedback": {
+        "fallback_used": false,
+        "fallback_reason": null,
+        "missing_inputs": [],
+        "conflicts": [],
+        "suggestions": [],
+        "available_constraint_types": ["goal", "tone"]
+      }
+    }
+    """
 
     monkeypatch.setattr(
         requirements_analyst,
@@ -59,6 +72,9 @@ async def test_intake_node_sets_constraints(monkeypatch):
     result = await intake_node({"user_prompt": "Build a test workflow"})
 
     assert result["constraints"] == constraints
+    assert result["requirements_feedback"].fallback_used is False
+    assert "goal" in result["requirements_feedback"].available_constraint_types
+    assert "tone" in result["requirements_feedback"].available_constraint_types
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- harden `RequirementsAnalyst` into a structured single-turn intake step with confidence, explanations, fallback feedback, and configurable constraint types
- persist `requirements_feedback` through intake, manifests, and result payloads while keeping `constraints` as the downstream contract
- refresh the baseline docs and issue #256 so the roadmap reflects the merged hardening work and the next runtime-agent tranche

## Testing
- pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py -q
- pytest tests/unit -q
- pytest --asyncio-mode=auto -q

Advances #197
Refs #256
