### PR TITLE
Harden ArchitectureSelector feedback, validation, and fallback handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ These node functions are the clearest map of the runtime lifecycle:
 | --- | --- | --- | --- |
 | Intake | `intake_node` | `RequirementsAnalyst` | `constraints`, `requirements_feedback` |
 | Retrieval | `rag_retrieval_node` | `DocsRetriever` | `docs_context` |
-| Architecture selection | `architecture_selection_node` | `ArchitectureSelector` | `selected_patterns`, `architecture_type`, `architecture_justification` |
+| Architecture selection | `architecture_selection_node` | `ArchitectureSelector` | `selected_patterns`, `architecture_type`, `architecture_justification`, `architecture_feedback` |
 | Workflow design | `graph_design_node` | `GraphDesigner` | `workflow_design`, `notebook_plan` |
 | Tool planning | `tooling_plan_node` | `ToolchainEngineer` | `tools_plan` |
 | Notebook assembly | `notebook_assembly_node` | `NotebookComposer` | `generated_cells` |
@@ -107,6 +107,7 @@ Important patterns:
 
 - `constraints` and `docs_context` are accumulated lists.
 - `requirements_feedback` is advisory metadata from intake. It should surface fallback/gap/conflict guidance without replacing `constraints` as the downstream source of truth.
+- `architecture_feedback` is advisory metadata from architecture selection. It should surface fallback, tradeoff, and validation guidance without replacing `architecture_type` or `selected_patterns` as the downstream contract.
 - `generated_cells` is authoritative for the current repair iteration and is
   replaced rather than concatenated.
 - `qa_reports` is the current QA snapshot for the active pass, while

--- a/docs/wiki/Architecture-Deep-Dive.md
+++ b/docs/wiki/Architecture-Deep-Dive.md
@@ -94,7 +94,7 @@ Retrieves relevant LangGraph/LangChain documentation based on the requirements:
 
 #### 3. Architecture Selection
 **Input**: Constraints + Documentation context  
-**Output**: Selected architecture and justification
+**Output**: Selected architecture, justification, and advisory architecture feedback
 
 Selects the most appropriate multi-agent pattern:
 
@@ -104,8 +104,15 @@ Selects the most appropriate multi-agent pattern:
   "architecture_justification": "Router pattern selected for customer support routing based on classification requirements",
   "selected_patterns": {
     "primary": "router",
-    "secondary": null,
-    "hybrid": false
+    "secondary": []
+  },
+  "architecture_feedback": {
+    "confidence": 0.78,
+    "fallback_used": false,
+    "validation_errors": [],
+    "tradeoffs": [
+      "Router keeps coordination simple but offers less worker specialization than subagents."
+    ]
   }
 }
 ```
@@ -113,8 +120,8 @@ Selects the most appropriate multi-agent pattern:
 **Available Architectures**:
 - `router`: Dynamic routing pattern
 - `subagents`: Supervisor-subagent coordination
-- `critique_revise`: Iterative refinement loop
 - `hybrid`: Combination of multiple patterns
+- `autoagent`: Planner/executor/critic loop for autonomous multi-step execution
 
 **Agent**: `ArchitectureSelector`  
 **LLM-Powered**: Yes (live mode) / Heuristics (stub mode)

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -17,6 +17,7 @@ from time import perf_counter
 from typing import Any, Dict, List, Literal, TypedDict
 
 from langgraph_system_generator.generator.state import (
+    ArchitectureFeedback,
     build_constraint_type_registry,
     CellSpec,
     Constraint,
@@ -73,6 +74,7 @@ def _default_state(
             fallback_used=False,
             available_constraint_types=_available_constraint_types(),
         ),
+        "architecture_feedback": ArchitectureFeedback(fallback_used=False),
         "selected_patterns": {},
         "docs_context": [],
         "notebook_plan": None,
@@ -195,6 +197,46 @@ def _requirements_warning_entries(
                 "message": "Conflicting requirements were detected during intake.",
                 "conflicts": conflicts,
                 "suggestions": suggestions,
+            }
+        )
+
+    return warnings
+
+
+def _architecture_warning_entries(
+    feedback: Dict[str, Any] | None,
+) -> List[Dict[str, Any]]:
+    """Convert structured architecture feedback into manifest warnings."""
+
+    if not isinstance(feedback, dict):
+        return []
+
+    warnings: List[Dict[str, Any]] = []
+    tradeoffs = list(feedback.get("tradeoffs") or [])
+    docs_considered = list(feedback.get("docs_considered") or [])
+
+    if feedback.get("fallback_used"):
+        warnings.append(
+            {
+                "code": "architecture_fallback",
+                "phase": "architecture_selection",
+                "message": feedback.get("fallback_reason")
+                or "Architecture selection used a router fallback.",
+                "tradeoffs": tradeoffs,
+                "docs_considered": docs_considered,
+            }
+        )
+
+    validation_errors = list(feedback.get("validation_errors") or [])
+    if validation_errors:
+        warnings.append(
+            {
+                "code": "architecture_validation",
+                "phase": "architecture_selection",
+                "message": "Architecture selection reported validation issues.",
+                "validation_errors": validation_errors,
+                "tradeoffs": tradeoffs,
+                "docs_considered": docs_considered,
             }
         )
 
@@ -399,8 +441,20 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
             f"{normalized_agent_type.title()} pattern selected from the requested "
             "agent_type override."
         )
+        architecture_feedback = ArchitectureFeedback(
+            confidence=1.0,
+            tradeoffs=[
+                "Selection was forced by request-scoped agent_type override; heuristic ranking was skipped."
+            ],
+        )
     else:
         architecture_type, justification = _infer_stub_architecture(prompt)
+        architecture_feedback = ArchitectureFeedback(
+            confidence=0.45,
+            tradeoffs=[
+                "Stub mode uses heuristic architecture inference instead of live architecture ranking."
+            ],
+        )
 
     constraints = [
         Constraint(type="goal", value=f"Deliver a notebook for: {prompt}", priority=5),
@@ -593,7 +647,8 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
             fallback_used=False,
             available_constraint_types=_available_constraint_types(),
         ),
-        "selected_patterns": {"primary": architecture_type},
+        "architecture_feedback": architecture_feedback,
+        "selected_patterns": {"primary": architecture_type, "secondary": []},
         "docs_context": [],
         "notebook_plan": plan,
         "architecture_type": plan.architecture_type,
@@ -730,6 +785,7 @@ async def generate_artifacts(
         serialized.get("notebook_plan", {}).get("title") or "Generated Notebook"
     )
     requirements_feedback = serialized.get("requirements_feedback") or {}
+    architecture_feedback = serialized.get("architecture_feedback") or {}
 
     manifest: Dict[str, Any] = {
         "prompt": prompt,
@@ -738,7 +794,11 @@ async def generate_artifacts(
         "cell_count": len(serialized.get("generated_cells", []) or []),
         "plan_title": plan_title,
         "requirements_feedback": requirements_feedback,
-        "warnings": _requirements_warning_entries(requirements_feedback),
+        "architecture_feedback": architecture_feedback,
+        "warnings": [
+            *_requirements_warning_entries(requirements_feedback),
+            *_architecture_warning_entries(architecture_feedback),
+        ],
         "export_results": {},
     }
 

--- a/src/langgraph_system_generator/generator/agents/architecture_selector.py
+++ b/src/langgraph_system_generator/generator/agents/architecture_selector.py
@@ -7,12 +7,26 @@ from typing import Any, Dict, List
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
+from pydantic import ValidationError
 
 from langgraph_system_generator.generator.agents._llm import build_chat_llm
-from langgraph_system_generator.generator.state import Constraint, DocSnippet
+from langgraph_system_generator.generator.state import (
+    ArchitectureAlternative,
+    ArchitectureFeedback,
+    ArchitecturePatternSelection,
+    ArchitectureSelectionResult,
+    Constraint,
+    DocSnippet,
+)
 from langgraph_system_generator.generator.utils import extract_json_from_llm_response
 from langgraph_system_generator.rag.retriever import DocsRetriever
 from langgraph_system_generator.utils.config import ModelConfig
+from langgraph_system_generator.utils.generation_options import (
+    SUPPORTED_AGENT_TYPES,
+    normalize_agent_type,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class ArchitectureSelector:
@@ -33,22 +47,12 @@ class ArchitectureSelector:
 
     async def select_architecture(
         self, constraints: List[Constraint], docs_context: List[DocSnippet]
-    ) -> Dict[str, Any]:
-        """Select router vs subagents vs hybrid vs autoagent pattern.
+    ) -> ArchitectureSelectionResult:
+        """Select router vs subagents vs hybrid vs autoagent pattern."""
 
-        Args:
-            constraints: Extracted project constraints
-            docs_context: Retrieved documentation snippets
-
-        Returns:
-            Dictionary with patterns, architecture_type, and justification
-        """
-        # Retrieve pattern-specific documentation if retriever is available
         pattern_docs = []
         if self.docs_retriever:
-            pattern_docs.extend(
-                self.docs_retriever.retrieve_for_pattern("router") or []
-            )
+            pattern_docs.extend(self.docs_retriever.retrieve_for_pattern("router") or [])
             pattern_docs.extend(
                 self.docs_retriever.retrieve_for_pattern("subagents") or []
             )
@@ -59,35 +63,18 @@ class ArchitectureSelector:
                 self.docs_retriever.retrieve_for_pattern("supervisor") or []
             )
 
-        def _normalize_doc(doc: Any) -> Dict[str, Any]:
-            if isinstance(doc, DocSnippet):
-                return doc.model_dump()
-            if hasattr(doc, "model_dump"):
-                try:
-                    return doc.model_dump()
-                except Exception as exc:  # noqa: BLE001
-                    logging.debug("Failed model_dump on doc snippet: %s", exc)
-            if isinstance(doc, dict):
-                return doc
-            return {
-                "content": str(doc),
-                "source": "",
-                "heading": None,
-                "relevance_score": 0.0,
-            }
+        docs_list = pattern_docs or docs_context
+        normalized_docs = [self._normalize_doc(doc) for doc in docs_list]
+        prompt_docs = normalized_docs[:5]
+        docs_considered = [self._doc_label(doc) for doc in prompt_docs]
 
-        # Format constraints for LLM
         constraints_text = "\n".join(
             [f"- [{c.type}] {c.value} (priority: {c.priority})" for c in constraints]
         )
-
-        # Format documentation snippets
-        docs_list = pattern_docs or docs_context
-        normalized_docs = [_normalize_doc(doc) for doc in docs_list]
         docs_text = "\n\n".join(
             [
                 f"[{doc.get('heading') or 'Section'}]\n{str(doc.get('content', ''))[:500]}"
-                for doc in normalized_docs[:5]
+                for doc in prompt_docs
             ]
         )
 
@@ -113,27 +100,287 @@ Return a JSON object with this structure:
     "primary": "pattern_name",
     "secondary": ["additional_patterns"]
   },
-  "justification": "detailed explanation of why this architecture was chosen"
+  "justification": "detailed explanation of why this architecture was chosen",
+  "feedback": {
+    "confidence": 0.0,
+    "alternatives": [
+      {
+        "architecture_type": "router",
+        "score": 0.0,
+        "rationale": "why this alternative ranked lower"
+      }
+    ],
+    "tradeoffs": ["short tradeoff statement"]
+  }
 }"""
         )
 
-        user_message = HumanMessage(content=f"""Requirements:
+        user_message = HumanMessage(
+            content=f"""Requirements:
 {constraints_text}
 
 Documentation Context:
 {docs_text}
 
-Recommend the best architecture.""")
+Recommend the best architecture."""
+        )
 
         response = await self.llm.ainvoke([selection_prompt, user_message])
 
         try:
             result = extract_json_from_llm_response(response.content)
-            return result
-        except (ValueError, KeyError, TypeError):
-            # Fallback to router pattern
-            return {
-                "architecture_type": "router",
-                "patterns": {"primary": "router", "secondary": []},
-                "justification": "Default router pattern selected as fallback due to parsing error.",
-            }
+            return self._normalize_selection_result(result, docs_considered=docs_considered)
+        except (ValueError, KeyError, TypeError, ValidationError) as exc:
+            reason = f"Architecture selection fallback used: {exc}"
+            logger.warning(reason)
+            return self._fallback_result(
+                reason,
+                docs_considered=docs_considered,
+                validation_errors=[str(exc)],
+            )
+
+    def _normalize_doc(self, doc: Any) -> Dict[str, Any]:
+        if isinstance(doc, DocSnippet):
+            return doc.model_dump()
+        if hasattr(doc, "model_dump"):
+            try:
+                return doc.model_dump()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Failed model_dump on doc snippet: %s", exc)
+        if isinstance(doc, dict):
+            return doc
+        return {
+            "content": str(doc),
+            "source": "",
+            "heading": None,
+            "relevance_score": 0.0,
+        }
+
+    def _doc_label(self, doc: Dict[str, Any]) -> str:
+        heading = str(doc.get("heading") or "").strip()
+        source = str(doc.get("source") or "").strip()
+        if heading and source:
+            return f"{source}#{heading}"
+        if heading:
+            return heading
+        if source:
+            return source
+        content = str(doc.get("content", "")).strip()
+        return content[:80] if content else "doc"
+
+    def _normalize_architecture_type(self, value: Any) -> str:
+        normalized = normalize_agent_type(value if isinstance(value, str) else None)
+        if normalized not in SUPPORTED_AGENT_TYPES:
+            raise ValueError(
+                f"Unsupported architecture_type '{value}'. "
+                f"Expected one of: {', '.join(sorted(SUPPORTED_AGENT_TYPES))}."
+            )
+        return normalized
+
+    def _normalize_patterns(
+        self,
+        architecture_type: str,
+        raw_patterns: Any,
+    ) -> tuple[ArchitecturePatternSelection, List[str]]:
+        validation_errors: List[str] = []
+        if raw_patterns in (None, ""):
+            return (
+                ArchitecturePatternSelection(primary=architecture_type, secondary=[]),
+                validation_errors,
+            )
+        if not isinstance(raw_patterns, dict):
+            raise ValueError("Architecture selection returned malformed patterns payload.")
+
+        primary = raw_patterns.get("primary")
+        normalized_primary = normalize_agent_type(
+            primary if isinstance(primary, str) else None
+        )
+        if normalized_primary is None:
+            normalized_primary = architecture_type
+        elif normalized_primary not in SUPPORTED_AGENT_TYPES:
+            raise ValueError(
+                "Architecture selection returned malformed patterns payload: "
+                f"unsupported primary '{primary}'."
+            )
+        elif normalized_primary != architecture_type:
+            validation_errors.append(
+                "Returned primary pattern did not match architecture_type; normalized to the selected architecture."
+            )
+            normalized_primary = architecture_type
+
+        secondary = raw_patterns.get("secondary", [])
+        if secondary is None:
+            secondary = []
+        if not isinstance(secondary, list):
+            raise ValueError("Architecture selection returned malformed patterns payload.")
+
+        normalized_secondary: List[str] = []
+        for item in secondary:
+            normalized_item = normalize_agent_type(item if isinstance(item, str) else None)
+            if normalized_item is None:
+                continue
+            if normalized_item not in SUPPORTED_AGENT_TYPES:
+                raise ValueError(
+                    "Architecture selection returned malformed patterns payload: "
+                    f"unsupported secondary '{item}'."
+                )
+            if (
+                normalized_item == normalized_primary
+                or normalized_item in normalized_secondary
+            ):
+                continue
+            normalized_secondary.append(normalized_item)
+
+        return (
+            ArchitecturePatternSelection(
+                primary=normalized_primary,
+                secondary=normalized_secondary,
+            ),
+            validation_errors,
+        )
+
+    def _normalize_feedback(
+        self,
+        raw_feedback: Any,
+        *,
+        docs_considered: List[str],
+        validation_errors: List[str],
+    ) -> ArchitectureFeedback:
+        if raw_feedback in (None, ""):
+            return ArchitectureFeedback(
+                validation_errors=list(validation_errors),
+                docs_considered=docs_considered,
+            )
+        if not isinstance(raw_feedback, dict):
+            return ArchitectureFeedback(
+                validation_errors=[
+                    *validation_errors,
+                    "Architecture feedback payload was not an object and was ignored.",
+                ],
+                docs_considered=docs_considered,
+            )
+
+        feedback_validation_errors = list(validation_errors)
+        alternatives_payload = raw_feedback.get("alternatives", [])
+        if alternatives_payload in (None, ""):
+            alternatives_payload = []
+        if not isinstance(alternatives_payload, list):
+            feedback_validation_errors.append(
+                "Architecture feedback alternatives payload was not a list and was ignored."
+            )
+            alternatives_payload = []
+
+        alternatives: List[ArchitectureAlternative] = []
+        for alternative in alternatives_payload:
+            if not isinstance(alternative, dict):
+                feedback_validation_errors.append(
+                    "Ignored non-object architecture alternative entry."
+                )
+                continue
+            alt_type = normalize_agent_type(
+                alternative.get("architecture_type")
+                if isinstance(alternative.get("architecture_type"), str)
+                else None
+            )
+            if alt_type not in SUPPORTED_AGENT_TYPES:
+                feedback_validation_errors.append(
+                    "Ignored architecture alternative with unsupported architecture_type."
+                )
+                continue
+            try:
+                alternatives.append(
+                    ArchitectureAlternative(
+                        architecture_type=alt_type,
+                        score=alternative.get("score"),
+                        rationale=alternative.get("rationale"),
+                    )
+                )
+            except ValidationError as exc:
+                feedback_validation_errors.append(
+                    f"Ignored malformed architecture alternative: {exc.errors()[0]['msg']}."
+                )
+
+        tradeoffs_payload = raw_feedback.get("tradeoffs", [])
+        if tradeoffs_payload in (None, ""):
+            tradeoffs_payload = []
+        if not isinstance(tradeoffs_payload, list):
+            feedback_validation_errors.append(
+                "Architecture feedback tradeoffs payload was not a list and was ignored."
+            )
+            tradeoffs_payload = []
+
+        tradeoffs = [str(item).strip() for item in tradeoffs_payload if str(item).strip()]
+        try:
+            return ArchitectureFeedback(
+                confidence=raw_feedback.get("confidence"),
+                alternatives=alternatives,
+                tradeoffs=tradeoffs,
+                validation_errors=feedback_validation_errors,
+                docs_considered=docs_considered,
+            )
+        except ValidationError as exc:
+            feedback_validation_errors.append(
+                f"Architecture feedback validation failed: {exc.errors()[0]['msg']}."
+            )
+            return ArchitectureFeedback(
+                alternatives=alternatives,
+                tradeoffs=tradeoffs,
+                validation_errors=feedback_validation_errors,
+                docs_considered=docs_considered,
+            )
+
+    def _normalize_selection_result(
+        self,
+        payload: Any,
+        *,
+        docs_considered: List[str],
+    ) -> ArchitectureSelectionResult:
+        if not isinstance(payload, dict):
+            raise ValueError("Architecture selection payload must be an object.")
+
+        architecture_type = self._normalize_architecture_type(payload.get("architecture_type"))
+        justification = str(payload.get("justification") or "").strip()
+        if not justification:
+            raise ValueError("Architecture selection must include a non-empty justification.")
+
+        patterns, validation_errors = self._normalize_patterns(
+            architecture_type,
+            payload.get("patterns"),
+        )
+        feedback = self._normalize_feedback(
+            payload.get("feedback"),
+            docs_considered=docs_considered,
+            validation_errors=validation_errors,
+        )
+
+        return ArchitectureSelectionResult(
+            architecture_type=architecture_type,
+            patterns=patterns,
+            justification=justification,
+            feedback=feedback,
+        )
+
+    def _fallback_result(
+        self,
+        reason: str,
+        *,
+        docs_considered: List[str],
+        validation_errors: List[str] | None = None,
+    ) -> ArchitectureSelectionResult:
+        return ArchitectureSelectionResult(
+            architecture_type="router",
+            patterns=ArchitecturePatternSelection(primary="router", secondary=[]),
+            justification=(
+                "Default router pattern selected as a safe fallback because "
+                "architecture selection could not be validated."
+            ),
+            feedback=ArchitectureFeedback(
+                fallback_used=True,
+                fallback_reason=reason,
+                validation_errors=list(validation_errors or []),
+                tradeoffs=[
+                    "Router fallback favors reliability over architecture-specific optimization."
+                ],
+                docs_considered=docs_considered,
+            ),
+        )

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -18,6 +18,7 @@ from langgraph_system_generator.generator.agents import (
     ToolchainEngineer,
 )
 from langgraph_system_generator.generator.state import (
+    ArchitectureFeedback,
     CellSpec,
     DocSnippet,
     GeneratorState,
@@ -216,6 +217,12 @@ async def architecture_selection_node(state: GeneratorState) -> Dict[str, Any]:
             "architecture_justification": (
                 f"Architecture forced by request-scoped agent_type override: {requested_architecture}."
             ),
+            "architecture_feedback": ArchitectureFeedback(
+                confidence=1.0,
+                tradeoffs=[
+                    "Selection was forced by request-scoped agent_type override; automatic ranking was skipped."
+                ],
+            ),
         }
 
     try:
@@ -236,13 +243,14 @@ async def architecture_selection_node(state: GeneratorState) -> Dict[str, Any]:
         state["constraints"], state["docs_context"]
     )
 
-    selected_patterns = architecture.get("patterns", {}) or {}
-    architecture_type = architecture.get("architecture_type") or "router"
+    selected_patterns = architecture.patterns.model_dump()
+    architecture_type = architecture.architecture_type
 
     return {
         "selected_patterns": selected_patterns,
         "architecture_type": architecture_type,
-        "architecture_justification": architecture.get("justification", ""),
+        "architecture_justification": architecture.justification,
+        "architecture_feedback": architecture.feedback,
     }
 
 
@@ -603,6 +611,7 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
     """
     # Create artifacts manifest
     requirements_feedback = state.get("requirements_feedback")
+    architecture_feedback = state.get("architecture_feedback")
     manifest = {
         "notebook_plan": str(state.get("notebook_plan")),
         "cell_count": str(len(state.get("generated_cells", []))),
@@ -613,6 +622,11 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
             requirements_feedback.model_dump()
             if hasattr(requirements_feedback, "model_dump")
             else (requirements_feedback or {})
+        ),
+        "architecture_feedback": (
+            architecture_feedback.model_dump()
+            if hasattr(architecture_feedback, "model_dump")
+            else (architecture_feedback or {})
         ),
     }
 

--- a/src/langgraph_system_generator/generator/state.py
+++ b/src/langgraph_system_generator/generator/state.py
@@ -108,6 +108,92 @@ class RequirementsAnalysis(BaseModel):
     )
 
 
+ArchitectureType = Literal["router", "subagents", "hybrid", "autoagent"]
+
+
+class ArchitectureAlternative(BaseModel):
+    """Advisory alternative architecture considered during selection."""
+
+    architecture_type: ArchitectureType = Field(
+        description="Alternative architecture option considered during selection."
+    )
+    score: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Optional relative score for this alternative.",
+    )
+    rationale: Optional[str] = Field(
+        default=None,
+        description="Short rationale for why this alternative ranked below the winner.",
+    )
+
+
+class ArchitecturePatternSelection(BaseModel):
+    """Normalized selected-pattern payload for architecture selection."""
+
+    primary: ArchitectureType = Field(
+        description="Primary architecture pattern selected for the workflow."
+    )
+    secondary: List[ArchitectureType] = Field(
+        default_factory=list,
+        description="Secondary patterns that complement the primary architecture.",
+    )
+
+
+class ArchitectureFeedback(BaseModel):
+    """Advisory feedback captured during architecture selection."""
+
+    confidence: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Optional confidence score for the selected architecture.",
+    )
+    alternatives: List[ArchitectureAlternative] = Field(
+        default_factory=list,
+        description="Alternative architectures considered during selection.",
+    )
+    tradeoffs: List[str] = Field(
+        default_factory=list,
+        description="Short tradeoffs associated with the selected architecture.",
+    )
+    fallback_used: bool = Field(
+        default=False,
+        description="Whether the selector fell back to a default architecture.",
+    )
+    fallback_reason: Optional[str] = Field(
+        default=None,
+        description="Reason fallback mode was used, when applicable.",
+    )
+    validation_errors: List[str] = Field(
+        default_factory=list,
+        description="Validation or normalization issues detected in selector output.",
+    )
+    docs_considered: List[str] = Field(
+        default_factory=list,
+        description="Documentation snippets or pattern docs considered during selection.",
+    )
+
+
+class ArchitectureSelectionResult(BaseModel):
+    """Structured architecture-selection output."""
+
+    architecture_type: ArchitectureType = Field(
+        description="Final selected architecture type."
+    )
+    patterns: ArchitecturePatternSelection = Field(
+        description="Normalized selected pattern payload."
+    )
+    justification: str = Field(
+        description="Human-readable explanation for why this architecture was chosen."
+    )
+    feedback: ArchitectureFeedback = Field(
+        default_factory=ArchitectureFeedback,
+        description="Advisory architecture-selection metadata.",
+    )
+
+
 class DocSnippet(BaseModel):
     """Retrieved documentation snippet."""
 
@@ -178,6 +264,7 @@ class GeneratorState(TypedDict):
     # Extracted requirements
     constraints: Annotated[List[Constraint], operator.add]
     requirements_feedback: RequirementsFeedback
+    architecture_feedback: ArchitectureFeedback
     selected_patterns: Dict[str, Any]
 
     # RAG context

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -51,7 +51,9 @@ async def test_generate_artifacts_stub(tmp_path: Path, monkeypatch: pytest.Monke
     assert artifacts["manifest"]["prompt"] == "Test prompt"
     assert artifacts["manifest"]["cell_count"] > 0
     assert artifacts["manifest"]["requirements_feedback"]["fallback_used"] is False
+    assert artifacts["manifest"]["architecture_feedback"]["fallback_used"] is False
     assert artifacts["result"]["requirements_feedback"]["fallback_used"] is False
+    assert artifacts["result"]["architecture_feedback"]["fallback_used"] is False
     assert Path(artifacts["manifest_path"]).exists()
     assert artifacts["result"]["generation_complete"] is True
 
@@ -68,6 +70,7 @@ def test_default_state_includes_generation_mode_and_qa_history():
     assert state["generation_mode"] == "live"
     assert state["qa_history"] == []
     assert state["requirements_feedback"].fallback_used is False
+    assert state["architecture_feedback"].fallback_used is False
     assert "goal" in state["requirements_feedback"].available_constraint_types
 
 
@@ -196,6 +199,7 @@ async def test_api_generate_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert "output_dir" in payload
     assert payload["output_dir"] == str(output_dir)
     assert payload["manifest"]["requirements_feedback"]["fallback_used"] is False
+    assert payload["manifest"]["architecture_feedback"]["fallback_used"] is False
 
 
 @pytest.mark.asyncio
@@ -240,6 +244,50 @@ async def test_generate_artifacts_surfaces_requirements_feedback_as_warnings(
     assert "requirements_missing_inputs" in warning_codes
     assert "requirements_conflicts" in warning_codes
     assert artifacts["manifest"]["requirements_feedback"]["fallback_used"] is True
+
+
+@pytest.mark.asyncio
+async def test_generate_artifacts_surfaces_architecture_feedback_as_warnings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_architecture_feedback_warning")
+
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.cli as cli_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(cli_module)
+
+    original_build_stub_result = cli_module._build_stub_result
+
+    def build_stub_result_with_feedback(prompt: str, agent_type: str | None = None):
+        result = original_build_stub_result(prompt, agent_type=agent_type)
+        result["architecture_feedback"] = {
+            "confidence": 0.21,
+            "fallback_used": True,
+            "fallback_reason": "Architecture selection fallback used after validation failed.",
+            "validation_errors": ["Unsupported architecture_type 'swarm'."],
+            "tradeoffs": ["Router fallback may underfit specialized workflows."],
+            "alternatives": [],
+            "docs_considered": ["router", "subagents"],
+        }
+        return result
+
+    monkeypatch.setattr(cli_module, "_build_stub_result", build_stub_result_with_feedback)
+
+    output_dir = constants_module._BASE_OUTPUT / tmp_path.name
+    artifacts = await cli_module.generate_artifacts(
+        "Ambiguous architecture prompt",
+        output_dir=str(output_dir),
+        mode="stub",
+    )
+
+    warning_codes = {warning["code"] for warning in artifacts["manifest"]["warnings"]}
+    assert "architecture_fallback" in warning_codes
+    assert "architecture_validation" in warning_codes
+    assert artifacts["manifest"]["architecture_feedback"]["fallback_used"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -14,7 +14,10 @@ from langgraph_system_generator.generator.agents import (
     requirements_analyst,
     toolchain_engineer,
 )
-from langgraph_system_generator.generator.state import Constraint
+from langgraph_system_generator.generator.state import (
+    ArchitectureSelectionResult,
+    Constraint,
+)
 from langgraph_system_generator.utils.config import ModelConfig
 
 
@@ -265,18 +268,28 @@ async def test_requirements_analyst_uses_configured_constraint_type_registry(mon
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("payload", "expected_arch"),
-    [
-        (
-            '{"architecture_type":"subagents","patterns":{"primary":"subagents","secondary":[]},"justification":"x"}',
-            "subagents",
-        ),
-        ("nope", "router"),
-    ],
-)
-async def test_architecture_selector_parsing(payload, expected_arch, monkeypatch):
-    """ArchitectureSelector falls back to router on parse errors."""
+async def test_architecture_selector_parsing(monkeypatch):
+    """ArchitectureSelector returns typed results with structured feedback."""
+    payload = """
+    {
+      "architecture_type": "subagents",
+      "patterns": {"primary": "subagents", "secondary": ["router"]},
+      "justification": "Subagents fit specialized worker contexts better than a single router.",
+      "feedback": {
+        "confidence": 0.82,
+        "alternatives": [
+          {
+            "architecture_type": "router",
+            "score": 0.47,
+            "rationale": "Simpler, but weaker for isolated specialist contexts."
+          }
+        ],
+        "tradeoffs": [
+          "Higher coordination overhead than a single router."
+        ]
+      }
+    }
+    """
     monkeypatch.setattr(
         architecture_selector,
         "ChatOpenAI",
@@ -285,7 +298,80 @@ async def test_architecture_selector_parsing(payload, expected_arch, monkeypatch
     selector = architecture_selector.ArchitectureSelector()
     constraints = [Constraint(type="goal", value="x", priority=5)]
     result = await selector.select_architecture(constraints, [])
-    assert result["architecture_type"] == expected_arch
+    assert isinstance(result, ArchitectureSelectionResult)
+    assert result.architecture_type == "subagents"
+    assert result.patterns.primary == "subagents"
+    assert result.patterns.secondary == ["router"]
+    assert result.feedback.confidence == pytest.approx(0.82)
+    assert result.feedback.alternatives[0].architecture_type == "router"
+    assert result.feedback.tradeoffs
+    assert result.feedback.fallback_used is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "reason_fragment"),
+    [
+        (
+            '{"architecture_type":"swarm","patterns":{"primary":"swarm","secondary":[]},"justification":"x"}',
+            "Unsupported architecture_type",
+        ),
+        (
+            '{"architecture_type":"router","patterns":"router","justification":"x"}',
+            "malformed patterns",
+        ),
+        (
+            '{"architecture_type":"router","patterns":{"primary":"router","secondary":[]},"justification":"  "}',
+            "non-empty justification",
+        ),
+    ],
+)
+async def test_architecture_selector_falls_back_on_invalid_payload(
+    payload, reason_fragment, monkeypatch
+):
+    """ArchitectureSelector should surface fallback feedback for invalid model payloads."""
+    monkeypatch.setattr(
+        architecture_selector,
+        "ChatOpenAI",
+        make_stub_llm(payload),
+    )
+    selector = architecture_selector.ArchitectureSelector()
+    constraints = [Constraint(type="goal", value="x", priority=5)]
+    result = await selector.select_architecture(constraints, [])
+    assert result.architecture_type == "router"
+    assert result.patterns.primary == "router"
+    assert result.feedback.fallback_used is True
+    assert result.feedback.fallback_reason
+    assert any(reason_fragment in error for error in result.feedback.validation_errors)
+
+
+@pytest.mark.asyncio
+async def test_architecture_selector_normalizes_pattern_primary(monkeypatch):
+    """ArchitectureSelector should normalize the primary pattern to match architecture_type."""
+    payload = """
+    {
+      "architecture_type": "autoagent",
+      "patterns": {"primary": "router", "secondary": ["subagents"]},
+      "justification": "AutoAgent best fits the planner/executor/critic loop.",
+      "feedback": {
+        "confidence": 0.73
+      }
+    }
+    """
+    monkeypatch.setattr(
+        architecture_selector,
+        "ChatOpenAI",
+        make_stub_llm(payload),
+    )
+    selector = architecture_selector.ArchitectureSelector()
+    constraints = [Constraint(type="goal", value="x", priority=5)]
+    result = await selector.select_architecture(constraints, [])
+    assert result.architecture_type == "autoagent"
+    assert result.patterns.primary == "autoagent"
+    assert any(
+        "primary pattern did not match architecture_type" in error
+        for error in result.feedback.validation_errors
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -21,7 +21,12 @@ from langgraph_system_generator.generator.nodes import (
     static_qa_node,
     tooling_plan_node,
 )
-from langgraph_system_generator.generator.state import CellSpec, Constraint, QAReport
+from langgraph_system_generator.generator.state import (
+    ArchitectureFeedback,
+    CellSpec,
+    Constraint,
+    QAReport,
+)
 from langgraph_system_generator.utils.config import GenerationConfig
 
 
@@ -124,9 +129,32 @@ async def test_architecture_selection_node_defaults_when_missing(monkeypatch):
 
     result = await architecture_selection_node({"constraints": [], "docs_context": []})
 
-    assert result["selected_patterns"] == {}
+    assert result["selected_patterns"] == {"primary": "router", "secondary": []}
     assert result["architecture_type"] == "router"
     assert result["architecture_justification"] == "Because"
+    assert result["architecture_feedback"].fallback_used is False
+
+
+@pytest.mark.asyncio
+async def test_architecture_selection_node_surfaces_selector_fallback_feedback(monkeypatch):
+    payload = '{"architecture_type":"swarm","patterns":{"primary":"swarm","secondary":[]},"justification":"x"}'
+
+    monkeypatch.setattr(
+        architecture_selector,
+        "ChatOpenAI",
+        make_stub_llm(payload),
+    )
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.agents.architecture_selector.DocsRetriever.retrieve_for_pattern",
+        lambda self, pattern_name: [],
+    )
+
+    result = await architecture_selection_node({"constraints": [], "docs_context": []})
+
+    assert result["architecture_type"] == "router"
+    assert result["selected_patterns"] == {"primary": "router", "secondary": []}
+    assert result["architecture_feedback"].fallback_used is True
+    assert result["architecture_feedback"].validation_errors
 
 
 @pytest.mark.asyncio
@@ -142,6 +170,9 @@ async def test_architecture_selection_node_honors_agent_type_override():
     assert result["selected_patterns"] == {"primary": "subagents", "secondary": []}
     assert result["architecture_type"] == "subagents"
     assert "agent_type override" in result["architecture_justification"]
+    assert result["architecture_feedback"].fallback_used is False
+    assert result["architecture_feedback"].confidence == pytest.approx(1.0)
+    assert result["architecture_feedback"].tradeoffs
 
 
 @pytest.mark.asyncio
@@ -157,6 +188,7 @@ async def test_architecture_selection_node_honors_autoagent_override():
     assert result["selected_patterns"] == {"primary": "autoagent", "secondary": []}
     assert result["architecture_type"] == "autoagent"
     assert "agent_type override" in result["architecture_justification"]
+    assert result["architecture_feedback"].fallback_used is False
 
 
 @pytest.mark.asyncio
@@ -481,6 +513,11 @@ async def test_package_outputs_node_manifest_fields():
         "constraints": [Constraint(type="goal", value="Test", priority=1)],
         "selected_patterns": {"primary": "hybrid"},
         "architecture_type": None,
+        "architecture_feedback": ArchitectureFeedback(
+            fallback_used=True,
+            fallback_reason="Validation failed.",
+            validation_errors=["Unsupported architecture_type 'swarm'."],
+        ),
     }
     result = await package_outputs_node(state)
 
@@ -488,4 +525,5 @@ async def test_package_outputs_node_manifest_fields():
     assert manifest["cell_count"] == "1"
     assert manifest["constraints_count"] == "1"
     assert manifest["architecture_type"] == "hybrid"
+    assert manifest["architecture_feedback"]["fallback_used"] is True
     assert result["generation_complete"] is True


### PR DESCRIPTION
## Summary
- add typed ArchitectureSelector result and advisory architecture feedback
- validate and normalize architecture selection output with explicit router fallback metadata
- surface architecture feedback through generator state, manifests, CLI/API warnings, and docs

## Testing
- pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py -q
- pytest tests/unit -q
- pytest --asyncio-mode=auto -q

Advances #191
Addresses #192
Addresses #194
Addresses #196
