### PR TITLE
Finish the remaining ArchitectureSelector epic

### DIFF
--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -24,6 +24,9 @@ from langgraph_system_generator.generator.state import (
     NotebookPlan,
     RequirementsFeedback,
 )
+from langgraph_system_generator.generator.architecture_registry import (
+    get_default_architecture_registry,
+)
 from langgraph_system_generator.utils.error_handling import GenerationError
 from langgraph_system_generator.utils.config import GenerationConfig, settings
 from langgraph_system_generator.utils.generation_options import (
@@ -406,7 +409,7 @@ def _infer_stub_architecture(prompt: str) -> tuple[str, str]:
     )
 
 
-def _load_patterns() -> tuple[Any, Any, Any]:
+def _load_patterns() -> tuple[Any, Any, Any, Any]:
     """Import pattern generators lazily to preserve minimal installs."""
     patterns_module = require_optional_module(
         "langgraph_system_generator.patterns",
@@ -416,6 +419,7 @@ def _load_patterns() -> tuple[Any, Any, Any]:
     return (
         patterns_module.RouterPattern,
         patterns_module.SubagentsPattern,
+        patterns_module.HybridPattern,
         patterns_module.AutoAgentPattern,
     )
 
@@ -432,11 +436,13 @@ def _load_generator_graph() -> Any:
 
 def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, Any]:
     """Create a deterministic, offline-friendly generation result."""
-    RouterPattern, SubagentsPattern, AutoAgentPattern = _load_patterns()
+    RouterPattern, SubagentsPattern, HybridPattern, AutoAgentPattern = _load_patterns()
+    architecture_registry = get_default_architecture_registry()
 
     normalized_agent_type = normalize_agent_type(agent_type)
     if normalized_agent_type in SUPPORTED_AGENT_TYPES:
         architecture_type = normalized_agent_type
+        _, secondary_patterns = architecture_registry.normalize_patterns(architecture_type)
         justification = (
             f"{normalized_agent_type.title()} pattern selected from the requested "
             "agent_type override."
@@ -446,14 +452,17 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
             tradeoffs=[
                 "Selection was forced by request-scoped agent_type override; heuristic ranking was skipped."
             ],
+            docs_considered=architecture_registry.docs_queries_for(architecture_type),
         )
     else:
         architecture_type, justification = _infer_stub_architecture(prompt)
+        _, secondary_patterns = architecture_registry.normalize_patterns(architecture_type)
         architecture_feedback = ArchitectureFeedback(
             confidence=0.45,
             tradeoffs=[
                 "Stub mode uses heuristic architecture inference instead of live architecture ranking."
             ],
+            docs_considered=architecture_registry.docs_queries_for(architecture_type),
         )
 
     constraints = [
@@ -588,6 +597,73 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
                 section="graph",
             )
         )
+    elif architecture_type == "hybrid":
+        direct_specialists = ["specialist_1"]
+        team_workers = ["researcher", "reviewer"]
+        direct_descriptions = {
+            "specialist_1": "Handle direct specialist work without team coordination",
+        }
+        worker_descriptions = {
+            "researcher": "Gather supporting information",
+            "reviewer": "Review worker output before finishing",
+        }
+
+        cells.append(
+            CellSpec(
+                cell_type="code",
+                content=HybridPattern.generate_state_code(),
+                section="state_definition",
+            )
+        )
+        cells.append(
+            CellSpec(
+                cell_type="code",
+                content=HybridPattern.generate_router_node_code(direct_specialists),
+                section="nodes",
+            )
+        )
+        for specialist in direct_specialists:
+            cells.append(
+                CellSpec(
+                    cell_type="code",
+                    content=HybridPattern.generate_direct_specialist_code(
+                        specialist,
+                        direct_descriptions[specialist],
+                    ),
+                    section="nodes",
+                )
+            )
+        cells.append(
+            CellSpec(
+                cell_type="code",
+                content=HybridPattern.generate_supervisor_code(
+                    team_workers,
+                    worker_descriptions,
+                ),
+                section="nodes",
+            )
+        )
+        for worker in team_workers:
+            cells.append(
+                CellSpec(
+                    cell_type="code",
+                    content=HybridPattern.generate_worker_code(
+                        worker,
+                        worker_descriptions[worker],
+                    ),
+                    section="nodes",
+                )
+            )
+        cells.append(
+            CellSpec(
+                cell_type="code",
+                content=HybridPattern.generate_graph_code(
+                    direct_specialists,
+                    team_workers,
+                ),
+                section="graph",
+            )
+        )
     elif architecture_type == "autoagent":
         workers = ["planner", "executor", "critic"]
         worker_descriptions = {
@@ -648,7 +724,10 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
             available_constraint_types=_available_constraint_types(),
         ),
         "architecture_feedback": architecture_feedback,
-        "selected_patterns": {"primary": architecture_type, "secondary": []},
+        "selected_patterns": {
+            "primary": architecture_type,
+            "secondary": secondary_patterns,
+        },
         "docs_context": [],
         "notebook_plan": plan,
         "architecture_type": plan.architecture_type,

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -452,7 +452,7 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
             tradeoffs=[
                 "Selection was forced by request-scoped agent_type override; heuristic ranking was skipped."
             ],
-            docs_considered=architecture_registry.docs_queries_for(architecture_type),
+            docs_considered=[],
         )
     else:
         architecture_type, justification = _infer_stub_architecture(prompt)
@@ -462,7 +462,7 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
             tradeoffs=[
                 "Stub mode uses heuristic architecture inference instead of live architecture ranking."
             ],
-            docs_considered=architecture_registry.docs_queries_for(architecture_type),
+            docs_considered=[],
         )
 
     constraints = [

--- a/src/langgraph_system_generator/generator/agents/architecture_selector.py
+++ b/src/langgraph_system_generator/generator/agents/architecture_selector.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import logging
 from typing import Any, Dict, List
 
@@ -60,7 +62,7 @@ class ArchitectureSelector:
     ) -> ArchitectureSelectionResult:
         """Select router vs subagents vs hybrid vs autoagent pattern."""
 
-        prompt_docs = self._select_prompt_docs(docs_context)
+        prompt_docs = await self._select_prompt_docs(docs_context)
         docs_considered = [self._doc_label(doc) for doc in prompt_docs]
 
         constraints_text = "\n".join(
@@ -150,12 +152,19 @@ Recommend the best architecture."""
             "relevance_score": 0.0,
         }
 
-    def _doc_key(self, doc: Dict[str, Any]) -> tuple[str, str]:
+    def _doc_key(self, doc: Dict[str, Any]) -> tuple[str, str, str]:
         """Return the dedupe key for selector prompt docs."""
 
         source = str(doc.get("source") or "").strip()
         heading = str(doc.get("heading") or "").strip()
-        return source, heading
+        content_fallback = ""
+        if not source or not heading:
+            content = str(doc.get("content") or "").strip()
+            if content:
+                content_fallback = hashlib.sha1(
+                    content.encode("utf-8", "ignore")
+                ).hexdigest()[:12]
+        return source, heading, content_fallback
 
     def _doc_score(self, doc: Dict[str, Any]) -> float:
         """Return a sortable relevance score for a prompt doc."""
@@ -165,13 +174,18 @@ Recommend the best architecture."""
         except (TypeError, ValueError):
             return 0.0
 
-    def _select_prompt_docs(self, docs_context: List[DocSnippet]) -> List[Dict[str, Any]]:
+    async def _select_prompt_docs(
+        self,
+        docs_context: List[DocSnippet],
+    ) -> List[Dict[str, Any]]:
         """Collect, weight, dedupe, and cap selector prompt docs."""
 
+        prompt_limit = max(1, int(settings.architecture_prompt_doc_limit))
         normalized_docs: list[Dict[str, Any]] = []
         if self.docs_retriever:
             query_overrides = settings.architecture_pattern_doc_queries
             weight_overrides = settings.architecture_pattern_doc_weights
+            query_specs: list[tuple[str, float]] = []
             for architecture_id in self.architecture_registry.supported_architecture_types():
                 queries = self.architecture_registry.docs_queries_for(
                     architecture_id,
@@ -182,21 +196,31 @@ Recommend the best architecture."""
                     weight_overrides=weight_overrides,
                 )
                 for query in queries:
-                    for doc in self.docs_retriever.retrieve(query, k=10) or []:
+                    query_specs.append((query, weight))
+
+            if query_specs:
+                retrieved_groups = await asyncio.gather(
+                    *[
+                        asyncio.to_thread(self.docs_retriever.retrieve, query, prompt_limit)
+                        for query, _weight in query_specs
+                    ]
+                )
+                for (_query, weight), docs in zip(query_specs, retrieved_groups):
+                    for doc in docs or []:
                         normalized = self._normalize_doc(doc)
                         normalized["weighted_relevance_score"] = self._doc_score(normalized) * weight
                         normalized_docs.append(normalized)
-        else:
+
+        if not normalized_docs:
             normalized_docs = [self._normalize_doc(doc) for doc in docs_context]
 
-        deduped: dict[tuple[str, str], Dict[str, Any]] = {}
+        deduped: dict[tuple[str, str, str], Dict[str, Any]] = {}
         for doc in normalized_docs:
             key = self._doc_key(doc)
             existing = deduped.get(key)
             if existing is None or self._doc_score(doc) > self._doc_score(existing):
                 deduped[key] = doc
 
-        prompt_limit = max(1, int(settings.architecture_prompt_doc_limit))
         ranked_docs = sorted(
             deduped.values(),
             key=lambda item: (self._doc_score(item), self._doc_label(item)),

--- a/src/langgraph_system_generator/generator/agents/architecture_selector.py
+++ b/src/langgraph_system_generator/generator/agents/architecture_selector.py
@@ -10,6 +10,10 @@ from langchain_openai import ChatOpenAI
 from pydantic import ValidationError
 
 from langgraph_system_generator.generator.agents._llm import build_chat_llm
+from langgraph_system_generator.generator.architecture_registry import (
+    ArchitectureRegistry,
+    get_default_architecture_registry,
+)
 from langgraph_system_generator.generator.state import (
     ArchitectureAlternative,
     ArchitectureFeedback,
@@ -20,7 +24,7 @@ from langgraph_system_generator.generator.state import (
 )
 from langgraph_system_generator.generator.utils import extract_json_from_llm_response
 from langgraph_system_generator.rag.retriever import DocsRetriever
-from langgraph_system_generator.utils.config import ModelConfig
+from langgraph_system_generator.utils.config import ModelConfig, settings
 from langgraph_system_generator.utils.generation_options import (
     SUPPORTED_AGENT_TYPES,
     normalize_agent_type,
@@ -37,6 +41,7 @@ class ArchitectureSelector:
         docs_retriever: DocsRetriever | None = None,
         model: str | None = None,
         model_config: ModelConfig | None = None,
+        architecture_registry: ArchitectureRegistry | None = None,
     ):
         self.llm = build_chat_llm(
             model=model,
@@ -44,28 +49,18 @@ class ArchitectureSelector:
             chat_openai_class=ChatOpenAI,
         )
         self.docs_retriever = docs_retriever
+        self.architecture_registry = (
+            architecture_registry.clone()
+            if architecture_registry is not None
+            else get_default_architecture_registry().clone()
+        )
 
     async def select_architecture(
         self, constraints: List[Constraint], docs_context: List[DocSnippet]
     ) -> ArchitectureSelectionResult:
         """Select router vs subagents vs hybrid vs autoagent pattern."""
 
-        pattern_docs = []
-        if self.docs_retriever:
-            pattern_docs.extend(self.docs_retriever.retrieve_for_pattern("router") or [])
-            pattern_docs.extend(
-                self.docs_retriever.retrieve_for_pattern("subagents") or []
-            )
-            pattern_docs.extend(
-                self.docs_retriever.retrieve_for_pattern("autoagent") or []
-            )
-            pattern_docs.extend(
-                self.docs_retriever.retrieve_for_pattern("supervisor") or []
-            )
-
-        docs_list = pattern_docs or docs_context
-        normalized_docs = [self._normalize_doc(doc) for doc in docs_list]
-        prompt_docs = normalized_docs[:5]
+        prompt_docs = self._select_prompt_docs(docs_context)
         docs_considered = [self._doc_label(doc) for doc in prompt_docs]
 
         constraints_text = "\n".join(
@@ -79,12 +74,11 @@ class ArchitectureSelector:
         )
 
         selection_prompt = SystemMessage(
-            content="""You are an expert in LangGraph architectures.
-Based on the requirements and official documentation, recommend the best pattern:
-- **router**: Single router that classifies inputs and routes to specialist functions
-- **subagents**: Supervisor coordinating multiple subagent workers with their own contexts
-- **hybrid**: Combination of router and subagents for complex workflows
-- **autoagent**: Coordinator-driven planner/executor/critic team for iterative autonomous execution
+            content=f"""You are an expert in LangGraph architectures.
+Based on the requirements and official documentation, recommend the best pattern.
+
+Registered architecture catalog:
+{self.architecture_registry.render_selector_prompt_catalog()}
 
 Consider:
 - Complexity of task decomposition
@@ -94,26 +88,26 @@ Consider:
 - Scalability requirements
 
 Return a JSON object with this structure:
-{
+{{
   "architecture_type": "router" | "subagents" | "hybrid" | "autoagent",
-  "patterns": {
+  "patterns": {{
     "primary": "pattern_name",
     "secondary": ["additional_patterns"]
-  },
+  }},
   "justification": "detailed explanation of why this architecture was chosen",
-  "feedback": {
+  "feedback": {{
     "confidence": 0.0,
     "alternatives": [
-      {
+      {{
         "architecture_type": "router",
         "score": 0.0,
         "rationale": "why this alternative ranked lower"
-      }
+      }}
     ],
     "tradeoffs": ["short tradeoff statement"]
-  }
-}"""
-        )
+  }}
+}}"""
+            )
 
         user_message = HumanMessage(
             content=f"""Requirements:
@@ -156,6 +150,60 @@ Recommend the best architecture."""
             "relevance_score": 0.0,
         }
 
+    def _doc_key(self, doc: Dict[str, Any]) -> tuple[str, str]:
+        """Return the dedupe key for selector prompt docs."""
+
+        source = str(doc.get("source") or "").strip()
+        heading = str(doc.get("heading") or "").strip()
+        return source, heading
+
+    def _doc_score(self, doc: Dict[str, Any]) -> float:
+        """Return a sortable relevance score for a prompt doc."""
+
+        try:
+            return float(doc.get("weighted_relevance_score", doc.get("relevance_score", 0.0)))
+        except (TypeError, ValueError):
+            return 0.0
+
+    def _select_prompt_docs(self, docs_context: List[DocSnippet]) -> List[Dict[str, Any]]:
+        """Collect, weight, dedupe, and cap selector prompt docs."""
+
+        normalized_docs: list[Dict[str, Any]] = []
+        if self.docs_retriever:
+            query_overrides = settings.architecture_pattern_doc_queries
+            weight_overrides = settings.architecture_pattern_doc_weights
+            for architecture_id in self.architecture_registry.supported_architecture_types():
+                queries = self.architecture_registry.docs_queries_for(
+                    architecture_id,
+                    query_overrides=query_overrides,
+                )
+                weight = self.architecture_registry.docs_weight_for(
+                    architecture_id,
+                    weight_overrides=weight_overrides,
+                )
+                for query in queries:
+                    for doc in self.docs_retriever.retrieve(query, k=10) or []:
+                        normalized = self._normalize_doc(doc)
+                        normalized["weighted_relevance_score"] = self._doc_score(normalized) * weight
+                        normalized_docs.append(normalized)
+        else:
+            normalized_docs = [self._normalize_doc(doc) for doc in docs_context]
+
+        deduped: dict[tuple[str, str], Dict[str, Any]] = {}
+        for doc in normalized_docs:
+            key = self._doc_key(doc)
+            existing = deduped.get(key)
+            if existing is None or self._doc_score(doc) > self._doc_score(existing):
+                deduped[key] = doc
+
+        prompt_limit = max(1, int(settings.architecture_prompt_doc_limit))
+        ranked_docs = sorted(
+            deduped.values(),
+            key=lambda item: (self._doc_score(item), self._doc_label(item)),
+            reverse=True,
+        )
+        return ranked_docs[:prompt_limit]
+
     def _doc_label(self, doc: Dict[str, Any]) -> str:
         heading = str(doc.get("heading") or "").strip()
         source = str(doc.get("source") or "").strip()
@@ -170,10 +218,11 @@ Recommend the best architecture."""
 
     def _normalize_architecture_type(self, value: Any) -> str:
         normalized = normalize_agent_type(value if isinstance(value, str) else None)
-        if normalized not in SUPPORTED_AGENT_TYPES:
+        selectable = set(self.architecture_registry.selectable_architecture_types())
+        if normalized not in selectable:
             raise ValueError(
                 f"Unsupported architecture_type '{value}'. "
-                f"Expected one of: {', '.join(sorted(SUPPORTED_AGENT_TYPES))}."
+                f"Expected one of: {', '.join(sorted(selectable))}."
             )
         return normalized
 
@@ -184,8 +233,14 @@ Recommend the best architecture."""
     ) -> tuple[ArchitecturePatternSelection, List[str]]:
         validation_errors: List[str] = []
         if raw_patterns in (None, ""):
+            _, normalized_secondary = self.architecture_registry.normalize_patterns(
+                architecture_type
+            )
             return (
-                ArchitecturePatternSelection(primary=architecture_type, secondary=[]),
+                ArchitecturePatternSelection(
+                    primary=architecture_type,
+                    secondary=normalized_secondary,
+                ),
                 validation_errors,
             )
         if not isinstance(raw_patterns, dict):
@@ -214,7 +269,10 @@ Recommend the best architecture."""
         if not isinstance(secondary, list):
             raise ValueError("Architecture selection returned malformed patterns payload.")
 
-        normalized_secondary: List[str] = []
+        _, normalized_secondary = self.architecture_registry.normalize_patterns(
+            normalized_primary,
+            secondary_patterns=secondary,
+        )
         for item in secondary:
             normalized_item = normalize_agent_type(item if isinstance(item, str) else None)
             if normalized_item is None:
@@ -224,12 +282,6 @@ Recommend the best architecture."""
                     "Architecture selection returned malformed patterns payload: "
                     f"unsupported secondary '{item}'."
                 )
-            if (
-                normalized_item == normalized_primary
-                or normalized_item in normalized_secondary
-            ):
-                continue
-            normalized_secondary.append(normalized_item)
 
         return (
             ArchitecturePatternSelection(
@@ -369,7 +421,10 @@ Recommend the best architecture."""
     ) -> ArchitectureSelectionResult:
         return ArchitectureSelectionResult(
             architecture_type="router",
-            patterns=ArchitecturePatternSelection(primary="router", secondary=[]),
+            patterns=ArchitecturePatternSelection(
+                primary="router",
+                secondary=self.architecture_registry.normalize_patterns("router")[1],
+            ),
             justification=(
                 "Default router pattern selected as a safe fallback because "
                 "architecture selection could not be validated."

--- a/src/langgraph_system_generator/generator/agents/graph_designer.py
+++ b/src/langgraph_system_generator/generator/agents/graph_designer.py
@@ -139,6 +139,10 @@ Design the workflow graph.""")
                         "name": "reviewer",
                         "purpose": "Review worker output and request refinements before finishing",
                     },
+                    {
+                        "name": "finish",
+                        "purpose": "Synthesize final results from all branches",
+                    },
                 ],
                 "edges": [
                     {"from": "specialist_1", "to": "finish"},

--- a/src/langgraph_system_generator/generator/agents/graph_designer.py
+++ b/src/langgraph_system_generator/generator/agents/graph_designer.py
@@ -41,6 +41,8 @@ class GraphDesigner:
         """
         architecture_type = architecture.get("architecture_type", "router")
         justification = architecture.get("justification", "")
+        selected_patterns = architecture.get("selected_patterns", {}) or {}
+        secondary_patterns = selected_patterns.get("secondary", [])
 
         constraints_text = "\n".join(
             [f"- [{c.type}] {c.value} (priority: {c.priority})" for c in constraints]
@@ -89,6 +91,7 @@ Return a JSON object with this structure:
 
         user_message = HumanMessage(content=f"""Architecture Type: {architecture_type}
 Architecture Justification: {justification}
+Selected Patterns: primary={selected_patterns.get("primary", architecture_type)}, secondary={secondary_patterns}
 
 Requirements:
 {constraints_text}
@@ -99,6 +102,8 @@ Design the workflow graph.""")
 
         try:
             result = extract_json_from_llm_response(response.content)
+            if selected_patterns.get("primary") == "hybrid":
+                result.setdefault("selected_patterns", selected_patterns)
             return result
         except (ValueError, KeyError, TypeError):
             # Fallback to a basic workflow
@@ -106,6 +111,62 @@ Design the workflow graph.""")
 
     def _fallback_design(self, architecture_type: str) -> Dict[str, Any]:
         """Provide a fallback design if LLM parsing fails."""
+        if architecture_type == "hybrid":
+            return {
+                "state_schema": {
+                    "messages": "List of messages",
+                    "route": "Selected router branch",
+                    "next_agent": "Next worker to call when the team path is chosen",
+                    "instructions": "Supervisor guidance for the selected worker",
+                    "results": "Direct specialist outputs",
+                    "task_results": "Worker-team outputs",
+                },
+                "nodes": [
+                    {"name": "router", "purpose": "Route to a direct specialist or the team path"},
+                    {
+                        "name": "specialist_1",
+                        "purpose": "Handle direct specialist work without team coordination",
+                    },
+                    {
+                        "name": "supervisor",
+                        "purpose": "Coordinate the worker team when deeper collaboration is needed",
+                    },
+                    {
+                        "name": "researcher",
+                        "purpose": "Gather supporting facts and intermediate context",
+                    },
+                    {
+                        "name": "reviewer",
+                        "purpose": "Review worker output and request refinements before finishing",
+                    },
+                ],
+                "edges": [
+                    {"from": "specialist_1", "to": "finish"},
+                    {"from": "researcher", "to": "supervisor"},
+                    {"from": "reviewer", "to": "supervisor"},
+                ],
+                "conditional_edges": [
+                    {
+                        "from": "router",
+                        "condition": "Route to a direct specialist or the worker team",
+                        "branches": {
+                            "specialist_1": "specialist_1",
+                            "team_path": "supervisor",
+                        },
+                    },
+                    {
+                        "from": "supervisor",
+                        "condition": "Route to next worker or finish after synthesis",
+                        "branches": {
+                            "researcher": "researcher",
+                            "reviewer": "reviewer",
+                            "FINISH": "finish",
+                        },
+                    },
+                ],
+                "entry_point": "router",
+                "checkpointing": True,
+            }
         if architecture_type in {"subagents", "autoagent"}:
             coordinator_name = (
                 "coordinator" if architecture_type == "autoagent" else "supervisor"

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -710,8 +710,11 @@ Generate the complete Python function implementation.""")
                 for token in {"research", "review", "worker", "planner", "critic"}
             )
         ]
-        if not direct_specialists and non_router_nodes:
-            direct_specialists = [str(non_router_nodes[0].get("name"))]
+        if not direct_specialists:
+            if non_router_nodes:
+                direct_specialists = [str(non_router_nodes[0].get("name"))]
+            else:
+                direct_specialists = ["specialist_1"]
 
         team_workers = [
             str(node.get("name"))
@@ -736,6 +739,16 @@ Generate the complete Python function implementation.""")
             for node in non_router_nodes
             if str(node.get("name")) in team_workers
         }
+        for specialist in direct_specialists:
+            direct_descriptions.setdefault(
+                specialist,
+                f"Handle {specialist} requests directly.",
+            )
+        for worker in team_workers:
+            worker_descriptions.setdefault(
+                worker,
+                f"{worker} specialist for the worker team.",
+            )
         return (
             direct_specialists,
             direct_descriptions,

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -15,6 +15,7 @@ from langgraph_system_generator.generator.state import CellSpec, NotebookPlan
 from langgraph_system_generator.patterns import (
     AutoAgentPattern,
     CritiqueLoopPattern,
+    HybridPattern,
     RouterPattern,
     SubagentsPattern,
 )
@@ -251,6 +252,8 @@ This notebook implements a LangGraph workflow using the **{plan.architecture_typ
             state_content = RouterPattern.generate_state_code(state_schema)
         elif architecture_type == "subagents":
             state_content = SubagentsPattern.generate_state_code(state_schema)
+        elif architecture_type == "hybrid":
+            state_content = HybridPattern.generate_state_code(state_schema)
         elif architecture_type == "autoagent":
             state_content = AutoAgentPattern.generate_state_code(state_schema)
         elif architecture_type == "critique_loop":
@@ -486,7 +489,13 @@ Generate the complete Python function implementation.""")
         architecture_type = workflow_design.get("architecture_type", "router")
 
         # Check if we should use pattern-based generation
-        if architecture_type in ["router", "subagents", "autoagent", "critique_loop"]:
+        if architecture_type in [
+            "router",
+            "subagents",
+            "hybrid",
+            "autoagent",
+            "critique_loop",
+        ]:
             # Use pattern library for architecture-specific nodes
             pattern_cells = self._generate_nodes_from_pattern(
                 nodes, architecture_type, workflow_design
@@ -684,6 +693,56 @@ Generate the complete Python function implementation.""")
     from langchain_core.messages import HumanMessage
 {chr(10).join(update_lines)}"""
 
+    @staticmethod
+    def _split_hybrid_nodes(
+        nodes: List[Dict[str, Any]],
+    ) -> tuple[List[str], Dict[str, str], List[str], Dict[str, str]]:
+        """Split hybrid nodes into direct-specialist and team-worker groups."""
+
+        non_router_nodes = [
+            node for node in nodes if node.get("name") not in {"router", "supervisor"}
+        ]
+        direct_specialists = [
+            str(node.get("name"))
+            for node in non_router_nodes
+            if not any(
+                token in str(node.get("name", "")).lower()
+                for token in {"research", "review", "worker", "planner", "critic"}
+            )
+        ]
+        if not direct_specialists and non_router_nodes:
+            direct_specialists = [str(non_router_nodes[0].get("name"))]
+
+        team_workers = [
+            str(node.get("name"))
+            for node in non_router_nodes
+            if str(node.get("name")) not in direct_specialists
+        ]
+        if len(team_workers) < 2:
+            fallback_workers = [
+                name
+                for name in ["researcher", "reviewer"]
+                if name not in direct_specialists and name not in team_workers
+            ]
+            team_workers.extend(fallback_workers[: 2 - len(team_workers)])
+
+        direct_descriptions = {
+            str(node.get("name")): str(node.get("purpose", ""))
+            for node in non_router_nodes
+            if str(node.get("name")) in direct_specialists
+        }
+        worker_descriptions = {
+            str(node.get("name")): str(node.get("purpose", ""))
+            for node in non_router_nodes
+            if str(node.get("name")) in team_workers
+        }
+        return (
+            direct_specialists,
+            direct_descriptions,
+            team_workers,
+            worker_descriptions,
+        )
+
     def _generate_nodes_from_pattern(
         self,
         nodes: List[Dict[str, Any]],
@@ -762,6 +821,56 @@ Generate the complete Python function implementation.""")
                             cell_type="code", content=subagent_code, section="nodes"
                         )
                     )
+        elif architecture_type == "hybrid":
+            (
+                direct_specialists,
+                direct_descriptions,
+                team_workers,
+                worker_descriptions,
+            ) = self._split_hybrid_nodes(nodes)
+
+            router_code = HybridPattern.generate_router_node_code(
+                direct_specialists,
+                model_config=model_config,
+            )
+            cells.append(
+                CellSpec(cell_type="code", content=router_code, section="nodes")
+            )
+
+            for specialist in direct_specialists:
+                specialist_code = HybridPattern.generate_direct_specialist_code(
+                    specialist,
+                    direct_descriptions.get(
+                        specialist,
+                        f"Handle {specialist} requests directly.",
+                    ),
+                    model_config=model_config,
+                )
+                cells.append(
+                    CellSpec(cell_type="code", content=specialist_code, section="nodes")
+                )
+
+            supervisor_code = HybridPattern.generate_supervisor_code(
+                team_workers,
+                worker_descriptions,
+                model_config=model_config,
+            )
+            cells.append(
+                CellSpec(cell_type="code", content=supervisor_code, section="nodes")
+            )
+
+            for worker in team_workers:
+                worker_code = HybridPattern.generate_worker_code(
+                    worker,
+                    worker_descriptions.get(
+                        worker,
+                        f"{worker} specialist for the worker team.",
+                    ),
+                    model_config=model_config,
+                )
+                cells.append(
+                    CellSpec(cell_type="code", content=worker_code, section="nodes")
+                )
         elif architecture_type == "autoagent":
             workers = [
                 node.get("name")
@@ -833,6 +942,12 @@ Generate the complete Python function implementation.""")
                 node.get("name") for node in nodes if node.get("name") != "supervisor"
             ]
             graph_code = SubagentsPattern.generate_graph_code(subagents)
+        elif architecture_type == "hybrid":
+            direct_specialists, _, team_workers, _ = self._split_hybrid_nodes(nodes)
+            graph_code = HybridPattern.generate_graph_code(
+                direct_specialists,
+                team_workers,
+            )
         elif architecture_type == "autoagent":
             workers = [
                 node.get("name")
@@ -970,6 +1085,18 @@ graph = workflow.compile(checkpointer=memory)"""
     "task_results": {},
     "dispatch_log": [],
     "iterations": 0,
+}"""
+        elif architecture_type == "hybrid":
+            initial_state_block = """initial_state: WorkflowState = {
+    "messages": [HumanMessage(content="Route simple work directly, or send deeper requests to the supervisor team.")],
+    "route": "",
+    "results": {},
+    "next_agent": "supervisor",
+    "instructions": "",
+    "task_results": {},
+    "dispatch_log": [],
+    "iterations": 0,
+    "final_output": "",
 }"""
         elif architecture_type == "critique_loop":
             initial_state_block = """initial_state: WorkflowState = {

--- a/src/langgraph_system_generator/generator/architecture_registry.py
+++ b/src/langgraph_system_generator/generator/architecture_registry.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Iterable, Mapping
 
+
 def _normalize_architecture_id(value: str) -> str:
     """Return a normalized architecture identifier."""
 
@@ -67,7 +68,7 @@ class ArchitectureRegistration:
                 self.default_secondary_patterns
             ),
             docs_queries=_normalize_queries(self.docs_queries),
-            docs_weight=float(self.docs_weight or 1.0),
+            docs_weight=1.0 if self.docs_weight is None else float(self.docs_weight),
             deterministic=bool(self.deterministic),
         )
 
@@ -127,6 +128,7 @@ class ArchitectureRegistry:
             if (
                 normalized
                 and normalized != normalized_primary
+                and normalized in self._registrations
                 and normalized not in normalized_secondary
             ):
                 normalized_secondary.append(normalized)

--- a/src/langgraph_system_generator/generator/architecture_registry.py
+++ b/src/langgraph_system_generator/generator/architecture_registry.py
@@ -1,0 +1,243 @@
+"""Internal registry for supported architecture-selection metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Iterable, Mapping
+
+def _normalize_architecture_id(value: str) -> str:
+    """Return a normalized architecture identifier."""
+
+    if value is None:
+        normalized = None
+    else:
+        normalized = str(value).strip().lower() or None
+    if not normalized:
+        raise ValueError("Architecture registrations must include a non-empty architecture_id.")
+    return normalized
+
+
+def _normalize_patterns(values: Iterable[str] | None) -> list[str]:
+    """Return an ordered, de-duplicated architecture-id list."""
+
+    normalized_patterns: list[str] = []
+    for raw_value in values or []:
+        normalized = str(raw_value or "").strip().lower() or None
+        if normalized and normalized not in normalized_patterns:
+            normalized_patterns.append(normalized)
+    return normalized_patterns
+
+
+def _normalize_queries(values: Iterable[str] | None) -> list[str]:
+    """Return an ordered, de-duplicated list of non-empty query strings."""
+
+    normalized_queries: list[str] = []
+    for raw_value in values or []:
+        text = str(raw_value or "").strip()
+        if text and text not in normalized_queries:
+            normalized_queries.append(text)
+    return normalized_queries
+
+
+@dataclass(frozen=True)
+class ArchitectureRegistration:
+    """Metadata describing a supported architecture selection option."""
+
+    architecture_id: str
+    selector_prompt_description: str
+    default_secondary_patterns: list[str] = field(default_factory=list)
+    docs_queries: list[str] = field(default_factory=list)
+    docs_weight: float = 1.0
+    deterministic: bool = True
+
+    def normalized(self) -> "ArchitectureRegistration":
+        """Return a normalized copy suitable for registry storage."""
+
+        architecture_id = _normalize_architecture_id(self.architecture_id)
+        description = str(self.selector_prompt_description or "").strip()
+        if not description:
+            raise ValueError(
+                f"Architecture registration '{architecture_id}' must include a prompt description."
+            )
+        return ArchitectureRegistration(
+            architecture_id=architecture_id,
+            selector_prompt_description=description,
+            default_secondary_patterns=_normalize_patterns(
+                self.default_secondary_patterns
+            ),
+            docs_queries=_normalize_queries(self.docs_queries),
+            docs_weight=float(self.docs_weight or 1.0),
+            deterministic=bool(self.deterministic),
+        )
+
+
+class ArchitectureRegistry:
+    """Mutable in-memory registry for architecture metadata."""
+
+    def __init__(self, registrations: Iterable[ArchitectureRegistration] | None = None):
+        self._registrations: dict[str, ArchitectureRegistration] = {}
+        for registration in registrations or []:
+            self.register(registration)
+
+    def clone(self) -> "ArchitectureRegistry":
+        """Return a shallow copy of the registry."""
+
+        return ArchitectureRegistry(self._registrations.values())
+
+    def register(self, registration: ArchitectureRegistration) -> ArchitectureRegistration:
+        """Register or replace an architecture entry."""
+
+        normalized = registration.normalized()
+        self._registrations[normalized.architecture_id] = normalized
+        return normalized
+
+    def get(self, architecture_id: str) -> ArchitectureRegistration:
+        """Return a registered architecture entry."""
+
+        normalized = _normalize_architecture_id(architecture_id)
+        return self._registrations[normalized]
+
+    def supported_architecture_types(self) -> list[str]:
+        """Return registered architecture identifiers in insertion order."""
+
+        return list(self._registrations.keys())
+
+    def selectable_architecture_types(self) -> list[str]:
+        """Return architectures that the current generator can produce deterministically."""
+
+        return [
+            architecture_id
+            for architecture_id, registration in self._registrations.items()
+            if registration.deterministic
+        ]
+
+    def normalize_patterns(
+        self,
+        architecture_id: str,
+        secondary_patterns: Iterable[str] | None = None,
+    ) -> tuple[str, list[str]]:
+        """Normalize a pattern selection against the registry defaults."""
+
+        normalized_primary = _normalize_architecture_id(architecture_id)
+        registration = self.get(normalized_primary)
+        normalized_secondary = list(registration.default_secondary_patterns)
+        for raw_value in secondary_patterns or []:
+            normalized = str(raw_value or "").strip().lower() or None
+            if (
+                normalized
+                and normalized != normalized_primary
+                and normalized not in normalized_secondary
+            ):
+                normalized_secondary.append(normalized)
+        return normalized_primary, normalized_secondary
+
+    def docs_queries_for(
+        self,
+        architecture_id: str,
+        query_overrides: Mapping[str, list[str]] | None = None,
+    ) -> list[str]:
+        """Return effective docs queries for an architecture."""
+
+        normalized = _normalize_architecture_id(architecture_id)
+        if query_overrides and normalized in query_overrides:
+            override_queries = _normalize_queries(query_overrides[normalized])
+            if override_queries:
+                return override_queries
+        return list(self.get(normalized).docs_queries)
+
+    def docs_weight_for(
+        self,
+        architecture_id: str,
+        weight_overrides: Mapping[str, float] | None = None,
+    ) -> float:
+        """Return the effective docs weight for an architecture."""
+
+        normalized = _normalize_architecture_id(architecture_id)
+        if weight_overrides and normalized in weight_overrides:
+            try:
+                return float(weight_overrides[normalized])
+            except (TypeError, ValueError):
+                return self.get(normalized).docs_weight
+        return self.get(normalized).docs_weight
+
+    def render_selector_prompt_catalog(self) -> str:
+        """Render a human-readable selector catalog from registry entries."""
+
+        lines = []
+        for architecture_id, registration in self._registrations.items():
+            determinism = (
+                "deterministic notebook generation supported"
+                if registration.deterministic
+                else "selector metadata only"
+            )
+            lines.append(
+                f"- **{architecture_id}**: {registration.selector_prompt_description} ({determinism})"
+            )
+        return "\n".join(lines)
+
+
+def _default_registrations() -> list[ArchitectureRegistration]:
+    """Return the built-in architecture catalog."""
+
+    return [
+        ArchitectureRegistration(
+            architecture_id="router",
+            selector_prompt_description=(
+                "Single router that classifies incoming work and dispatches it to direct specialists."
+            ),
+            default_secondary_patterns=[],
+            docs_queries=[
+                "LangGraph router pattern implementation best practices",
+                "LangGraph routing workflow conditional edges",
+            ],
+            docs_weight=1.0,
+            deterministic=True,
+        ),
+        ArchitectureRegistration(
+            architecture_id="subagents",
+            selector_prompt_description=(
+                "Supervisor coordinating multiple specialist workers that operate with their own focused contexts."
+            ),
+            default_secondary_patterns=[],
+            docs_queries=[
+                "LangGraph subagents supervisor pattern implementation best practices",
+                "LangGraph supervisor multi-agent workflow",
+            ],
+            docs_weight=1.0,
+            deterministic=True,
+        ),
+        ArchitectureRegistration(
+            architecture_id="hybrid",
+            selector_prompt_description=(
+                "Composed workflow that uses a router entry point plus a supervisor-led worker team for deeper branches."
+            ),
+            default_secondary_patterns=["router", "subagents"],
+            docs_queries=[
+                "LangGraph router supervisor hybrid workflow",
+                "LangGraph supervisor multi-agent workflow",
+            ],
+            docs_weight=1.15,
+            deterministic=True,
+        ),
+        ArchitectureRegistration(
+            architecture_id="autoagent",
+            selector_prompt_description=(
+                "Coordinator-driven planner/executor/critic team for iterative autonomous execution."
+            ),
+            default_secondary_patterns=[],
+            docs_queries=[
+                "LangGraph autoagent planner executor critic workflow",
+                "LangGraph plan execute critique loop",
+            ],
+            docs_weight=0.95,
+            deterministic=True,
+        ),
+    ]
+
+
+@lru_cache(maxsize=1)
+def get_default_architecture_registry() -> ArchitectureRegistry:
+    """Return the default built-in architecture registry."""
+
+    return ArchitectureRegistry(_default_registrations())

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -218,7 +218,6 @@ async def architecture_selection_node(state: GeneratorState) -> Dict[str, Any]:
         primary, secondary = ARCHITECTURE_REGISTRY.normalize_patterns(
             requested_architecture
         )
-        docs_metadata = ARCHITECTURE_REGISTRY.docs_queries_for(primary)
         return {
             "selected_patterns": {"primary": primary, "secondary": secondary},
             "architecture_type": primary,
@@ -230,7 +229,7 @@ async def architecture_selection_node(state: GeneratorState) -> Dict[str, Any]:
                 tradeoffs=[
                     "Selection was forced by request-scoped agent_type override; automatic ranking was skipped."
                 ],
-                docs_considered=docs_metadata,
+                docs_considered=[],
             ),
         }
 

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -17,6 +17,9 @@ from langgraph_system_generator.generator.agents import (
     RequirementsAnalyst,
     ToolchainEngineer,
 )
+from langgraph_system_generator.generator.architecture_registry import (
+    get_default_architecture_registry,
+)
 from langgraph_system_generator.generator.state import (
     ArchitectureFeedback,
     CellSpec,
@@ -45,6 +48,7 @@ logger = logging.getLogger(__name__)
 
 RUNTIME_UNAVAILABLE_PREFIX = "runtime validation unavailable"
 TRUSTED_SMOKE_TEST_SCOPE = "trusted_smoke_test"
+ARCHITECTURE_REGISTRY = get_default_architecture_registry()
 
 
 def _resolve_model_config(state: GeneratorState):
@@ -211,17 +215,22 @@ async def architecture_selection_node(state: GeneratorState) -> Dict[str, Any]:
     """
     requested_architecture = _requested_architecture_type(state)
     if requested_architecture:
+        primary, secondary = ARCHITECTURE_REGISTRY.normalize_patterns(
+            requested_architecture
+        )
+        docs_metadata = ARCHITECTURE_REGISTRY.docs_queries_for(primary)
         return {
-            "selected_patterns": {"primary": requested_architecture, "secondary": []},
-            "architecture_type": requested_architecture,
+            "selected_patterns": {"primary": primary, "secondary": secondary},
+            "architecture_type": primary,
             "architecture_justification": (
-                f"Architecture forced by request-scoped agent_type override: {requested_architecture}."
+                f"Architecture forced by request-scoped agent_type override: {primary}."
             ),
             "architecture_feedback": ArchitectureFeedback(
                 confidence=1.0,
                 tradeoffs=[
                     "Selection was forced by request-scoped agent_type override; automatic ranking was skipped."
                 ],
+                docs_considered=docs_metadata,
             ),
         }
 
@@ -272,9 +281,12 @@ async def graph_design_node(state: GeneratorState) -> Dict[str, Any]:
     architecture = {
         "architecture_type": architecture_type,
         "justification": state["architecture_justification"],
+        "selected_patterns": selected_patterns,
     }
 
     workflow_design = await designer.design_workflow(architecture, state["constraints"])
+    if selected_patterns.get("primary") == "hybrid":
+        workflow_design.setdefault("selected_patterns", selected_patterns)
 
     # Create notebook plan
     notebook_plan = NotebookPlan(

--- a/src/langgraph_system_generator/patterns/__init__.py
+++ b/src/langgraph_system_generator/patterns/__init__.py
@@ -8,11 +8,13 @@ code-generation classes.
 
 from langgraph_system_generator.patterns.critique_loops import CritiqueLoopPattern
 from langgraph_system_generator.patterns.autoagent import AutoAgentPattern
+from langgraph_system_generator.patterns.hybrid import HybridPattern
 from langgraph_system_generator.patterns.router import RouterPattern
 from langgraph_system_generator.patterns.subagents import SubagentsPattern
 
 __all__ = [
     "AutoAgentPattern",
+    "HybridPattern",
     "RouterPattern",
     "SubagentsPattern",
     "CritiqueLoopPattern",

--- a/src/langgraph_system_generator/patterns/hybrid.py
+++ b/src/langgraph_system_generator/patterns/hybrid.py
@@ -1,0 +1,190 @@
+"""Hybrid pattern generator combining router and supervisor/team flows."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Union
+
+from langgraph_system_generator.patterns.router import RouterPattern
+from langgraph_system_generator.patterns.subagents import SubagentsPattern
+from langgraph_system_generator.patterns.utils import (
+    render_additional_fields,
+    sanitize_identifier,
+)
+from langgraph_system_generator.utils.config import ModelConfig
+
+
+class HybridPattern:
+    """Template generator for mixed direct-routing plus worker-team workflows."""
+
+    @staticmethod
+    def generate_state_code(additional_fields: Optional[Dict[str, str]] = None) -> str:
+        """Generate a TypedDict state schema for hybrid workflows."""
+
+        additional = render_additional_fields(additional_fields)
+        return f'''import operator
+from typing import Annotated, Dict, List
+from typing_extensions import TypedDict
+
+from langchain_core.messages import BaseMessage
+from langgraph.graph.message import add_messages
+
+
+def merge_dicts(left: Dict[str, str], right: Dict[str, str]) -> Dict[str, str]:
+    """Reducer used to merge hybrid workflow outputs."""
+    merged = dict(left or {{}})
+    merged.update(right or {{}})
+    return merged
+
+
+class WorkflowState(TypedDict, total=False):
+    """State schema for a hybrid router plus worker-team workflow."""
+
+    messages: Annotated[List[BaseMessage], add_messages]
+    route: str
+    route_reasoning: str
+    route_history: Annotated[List[str], operator.add]
+    next_agent: str
+    instructions: str
+    iterations: int
+    dispatch_log: Annotated[List[str], operator.add]
+    results: Annotated[Dict[str, str], merge_dicts]
+    task_results: Annotated[Dict[str, str], merge_dicts]
+    final_output: str
+{additional}'''
+
+    @staticmethod
+    def generate_router_node_code(
+        direct_specialists: List[str],
+        model_config: Optional[Union[ModelConfig, dict]] = None,
+    ) -> str:
+        """Generate a router capable of choosing direct work or the team path."""
+
+        routes = [*direct_specialists, "team_path"]
+        return RouterPattern.generate_router_node_code(
+            routes=routes,
+            model_config=model_config,
+        )
+
+    @staticmethod
+    def generate_direct_specialist_code(
+        specialist_name: str,
+        specialist_purpose: str,
+        model_config: Optional[Union[ModelConfig, dict]] = None,
+    ) -> str:
+        """Generate a direct specialist node implementation."""
+
+        return RouterPattern.generate_route_node_code(
+            specialist_name,
+            specialist_purpose,
+            model_config=model_config,
+        )
+
+    @staticmethod
+    def generate_supervisor_code(
+        team_workers: List[str],
+        worker_descriptions: Optional[Dict[str, str]] = None,
+        model_config: Optional[Union[ModelConfig, dict]] = None,
+    ) -> str:
+        """Generate the supervisor node for the worker-team branch."""
+
+        return SubagentsPattern.generate_supervisor_code(
+            subagents=team_workers,
+            subagent_descriptions=worker_descriptions,
+            model_config=model_config,
+        )
+
+    @staticmethod
+    def generate_worker_code(
+        worker_name: str,
+        worker_description: str,
+        model_config: Optional[Union[ModelConfig, dict]] = None,
+    ) -> str:
+        """Generate a worker node implementation."""
+
+        return SubagentsPattern.generate_subagent_code(
+            agent_name=worker_name,
+            agent_description=worker_description,
+            model_config=model_config,
+        )
+
+    @staticmethod
+    def generate_graph_code(
+        direct_specialists: List[str],
+        team_workers: List[str],
+        max_iterations: int = 10,
+    ) -> str:
+        """Generate graph wiring for the hybrid workflow."""
+
+        direct_specialist_nodes = direct_specialists or ["specialist_1"]
+        team_worker_nodes = team_workers or ["researcher", "reviewer"]
+        direct_node_additions = "\n".join(
+            f'workflow.add_node("{name}", {sanitize_identifier(name)}_node)'
+            for name in direct_specialist_nodes
+        )
+        worker_node_additions = "\n".join(
+            f'workflow.add_node("{name}", {sanitize_identifier(name)}_node)'
+            for name in team_worker_nodes
+        )
+        router_branch_map = ", ".join(
+            [f'"{name}": "{name}"' for name in direct_specialist_nodes]
+            + ['"team_path": "supervisor"', '"END": END']
+        )
+        direct_finish_edges = "\n".join(
+            f'workflow.add_edge("{name}", "finish")' for name in direct_specialist_nodes
+        )
+        worker_return_edges = "\n".join(
+            f'workflow.add_edge("{name}", "supervisor")' for name in team_worker_nodes
+        )
+
+        return f'''from langgraph.graph import END, START, StateGraph
+from langgraph.checkpoint.memory import InMemorySaver
+
+
+def route_from_router(state: WorkflowState) -> str:
+    """Route either to a direct specialist or the supervisor team path."""
+    route = state.get("route", "")
+    if route == "team_path":
+        return "team_path"
+    if route in {{{", ".join(repr(name) for name in direct_specialist_nodes)}}}:
+        return route
+    return "END"
+
+
+def finish_node(state: WorkflowState) -> dict:
+    """Merge direct specialist and worker-team outputs into a final answer."""
+    direct_results = state.get("results", {{}})
+    team_results = state.get("task_results", {{}})
+    sections = []
+    for agent, output in direct_results.items():
+        sections.append(f"## {{agent}}\\n{{output}}")
+    for agent, output in team_results.items():
+        sections.append(f"## {{agent}}\\n{{output}}")
+    final_output = "\\n\\n".join(sections) if sections else "No workflow results were produced."
+    return {{
+        "final_output": final_output,
+        "messages": [],
+    }}
+
+
+workflow = StateGraph(WorkflowState)
+checkpointer = InMemorySaver()
+
+workflow.add_node("router", router_node)
+{direct_node_additions}
+workflow.add_node("supervisor", supervisor_node)
+{worker_node_additions}
+workflow.add_node("finish", finish_node)
+
+workflow.add_edge(START, "router")
+workflow.add_conditional_edges(
+    "router",
+    route_from_router,
+    {{{router_branch_map}}},
+)
+{direct_finish_edges}
+{worker_return_edges}
+workflow.add_edge("finish", END)
+
+graph = workflow.compile(checkpointer=checkpointer)
+
+MAX_ITERATIONS = {max_iterations}'''

--- a/src/langgraph_system_generator/patterns/hybrid.py
+++ b/src/langgraph_system_generator/patterns/hybrid.py
@@ -7,10 +7,21 @@ from typing import Dict, List, Optional, Union
 from langgraph_system_generator.patterns.router import RouterPattern
 from langgraph_system_generator.patterns.subagents import SubagentsPattern
 from langgraph_system_generator.patterns.utils import (
+    double_quoted_literal,
     render_additional_fields,
     sanitize_identifier,
 )
 from langgraph_system_generator.utils.config import ModelConfig
+
+
+def _hybrid_specs(
+    values: List[str] | None,
+    default: List[str],
+) -> List[tuple[str, str]]:
+    """Return ``(label, node_name)`` pairs for hybrid direct or worker nodes."""
+
+    labels = list(values or default)
+    return [(label, sanitize_identifier(label)) for label in labels]
 
 
 class HybridPattern:
@@ -115,25 +126,39 @@ class WorkflowState(TypedDict, total=False):
     ) -> str:
         """Generate graph wiring for the hybrid workflow."""
 
-        direct_specialist_nodes = direct_specialists or ["specialist_1"]
-        team_worker_nodes = team_workers or ["researcher", "reviewer"]
+        direct_specialist_specs = _hybrid_specs(
+            direct_specialists,
+            ["specialist_1"],
+        )
+        team_worker_specs = _hybrid_specs(
+            team_workers,
+            ["researcher", "reviewer"],
+        )
         direct_node_additions = "\n".join(
-            f'workflow.add_node("{name}", {sanitize_identifier(name)}_node)'
-            for name in direct_specialist_nodes
+            f'workflow.add_node("{node_name}", {node_name}_node)'
+            for _, node_name in direct_specialist_specs
         )
         worker_node_additions = "\n".join(
-            f'workflow.add_node("{name}", {sanitize_identifier(name)}_node)'
-            for name in team_worker_nodes
+            f'workflow.add_node("{node_name}", {node_name}_node)'
+            for _, node_name in team_worker_specs
         )
         router_branch_map = ", ".join(
-            [f'"{name}": "{name}"' for name in direct_specialist_nodes]
+            [
+                f"{double_quoted_literal(label)}: {double_quoted_literal(node_name)}"
+                for label, node_name in direct_specialist_specs
+            ]
             + ['"team_path": "supervisor"', '"END": END']
         )
         direct_finish_edges = "\n".join(
-            f'workflow.add_edge("{name}", "finish")' for name in direct_specialist_nodes
+            f'workflow.add_edge("{node_name}", "finish")'
+            for _, node_name in direct_specialist_specs
         )
         worker_return_edges = "\n".join(
-            f'workflow.add_edge("{name}", "supervisor")' for name in team_worker_nodes
+            f'workflow.add_edge("{node_name}", "supervisor")'
+            for _, node_name in team_worker_specs
+        )
+        direct_route_labels = ", ".join(
+            double_quoted_literal(label) for label, _ in direct_specialist_specs
         )
 
         return f'''from langgraph.graph import END, START, StateGraph
@@ -145,7 +170,7 @@ def route_from_router(state: WorkflowState) -> str:
     route = state.get("route", "")
     if route == "team_path":
         return "team_path"
-    if route in {{{", ".join(repr(name) for name in direct_specialist_nodes)}}}:
+    if route in {{{direct_route_labels}}}:
         return route
     return "END"
 

--- a/src/langgraph_system_generator/utils/config.py
+++ b/src/langgraph_system_generator/utils/config.py
@@ -136,6 +136,24 @@ class Settings(BaseSettings):
         default_factory=list,
         description="Optional extra requirement constraint types made available during intake.",
     )
+    architecture_pattern_doc_queries: Annotated[dict[str, list[str]], NoDecode] = Field(
+        default_factory=dict,
+        description=(
+            "Optional JSON object mapping architecture ids to query lists that override "
+            "the default selector docs queries."
+        ),
+    )
+    architecture_pattern_doc_weights: Annotated[dict[str, float], NoDecode] = Field(
+        default_factory=dict,
+        description=(
+            "Optional JSON object mapping architecture ids to docs weighting multipliers."
+        ),
+    )
+    architecture_prompt_doc_limit: int = Field(
+        default=8,
+        ge=1,
+        description="Maximum number of weighted docs snippets included in the architecture selector prompt.",
+    )
 
     @field_validator("requirements_constraint_types", mode="before")
     @classmethod
@@ -162,6 +180,83 @@ class Settings(BaseSettings):
             return [item.strip() for item in stripped.split(",") if item.strip()]
         return value
 
+    @field_validator("architecture_pattern_doc_queries", mode="before")
+    @classmethod
+    def _parse_architecture_pattern_doc_queries(cls, value):
+        """Accept JSON objects mapping architecture ids to query lists."""
+        if value in (None, ""):
+            return {}
+        if isinstance(value, dict):
+            parsed = value
+        elif isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return {}
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Invalid JSON in architecture_pattern_doc_queries: {exc}"
+                ) from exc
+        else:
+            return value
+
+        if not isinstance(parsed, dict):
+            raise ValueError("architecture_pattern_doc_queries must decode to an object")
+
+        normalized: dict[str, list[str]] = {}
+        for raw_key, raw_queries in parsed.items():
+            key = str(raw_key or "").strip().lower()
+            if not key:
+                continue
+            if isinstance(raw_queries, str):
+                queries = [raw_queries]
+            elif isinstance(raw_queries, list):
+                queries = raw_queries
+            else:
+                raise ValueError(
+                    "architecture_pattern_doc_queries values must be strings or lists"
+                )
+            normalized[key] = [str(query).strip() for query in queries if str(query).strip()]
+        return normalized
+
+    @field_validator("architecture_pattern_doc_weights", mode="before")
+    @classmethod
+    def _parse_architecture_pattern_doc_weights(cls, value):
+        """Accept JSON objects mapping architecture ids to weighting multipliers."""
+        if value in (None, ""):
+            return {}
+        if isinstance(value, dict):
+            parsed = value
+        elif isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return {}
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Invalid JSON in architecture_pattern_doc_weights: {exc}"
+                ) from exc
+        else:
+            return value
+
+        if not isinstance(parsed, dict):
+            raise ValueError("architecture_pattern_doc_weights must decode to an object")
+
+        normalized: dict[str, float] = {}
+        for raw_key, raw_weight in parsed.items():
+            key = str(raw_key or "").strip().lower()
+            if not key:
+                continue
+            try:
+                normalized[key] = float(raw_weight)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"architecture_pattern_doc_weights[{raw_key!r}] must be numeric"
+                ) from exc
+        return normalized
+
 
 _DEFAULT_ENV_FILE = object()
 _TEST_SETTINGS_ENV_KEYS = (
@@ -175,6 +270,9 @@ _TEST_SETTINGS_ENV_KEYS = (
     "MAX_REPAIR_ATTEMPTS",
     "DEFAULT_BUDGET_TOKENS",
     "REQUIREMENTS_CONSTRAINT_TYPES",
+    "ARCHITECTURE_PATTERN_DOC_QUERIES",
+    "ARCHITECTURE_PATTERN_DOC_WEIGHTS",
+    "ARCHITECTURE_PROMPT_DOC_LIMIT",
 )
 
 

--- a/src/langgraph_system_generator/utils/generation_options.py
+++ b/src/langgraph_system_generator/utils/generation_options.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from langgraph_system_generator.generator.architecture_registry import (
+    get_default_architecture_registry,
+)
 
 SUPPORTED_OPENAI_MODELS = frozenset(
     {"gpt-5.2", "gpt-5-mini", "gpt-5-nano", "gpt-5.1"}
 )
 
-SUPPORTED_AGENT_TYPES = frozenset({"router", "subagents", "hybrid", "autoagent"})
+SUPPORTED_AGENT_TYPES = frozenset(
+    get_default_architecture_registry().selectable_architecture_types()
+)
 
 
 def normalize_optional_string(value: str | None) -> str | None:

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -138,6 +138,42 @@ async def test_generate_artifacts_stub_autoagent_override(
 
 
 @pytest.mark.asyncio
+async def test_generate_artifacts_stub_hybrid_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_generate_artifacts_stub_hybrid")
+
+    import importlib
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.cli as cli_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(cli_module)
+
+    output_dir = constants_module._BASE_OUTPUT / "test_stub_hybrid"
+    artifacts: GenerationArtifacts = await cli_module.generate_artifacts(
+        "Build a workflow that mixes direct routing with a worker team",
+        output_dir=str(output_dir),
+        mode="stub",
+        agent_type="hybrid",
+    )
+
+    graph_cells = [
+        cell
+        for cell in artifacts["result"]["generated_cells"]
+        if cell["section"] == "graph"
+    ]
+    assert artifacts["manifest"]["architecture_type"] == "hybrid"
+    assert artifacts["manifest"]["agent_type"] == "hybrid"
+    assert artifacts["result"]["architecture_type"] == "hybrid"
+    assert graph_cells
+    assert 'workflow.add_node("router", router_node)' in graph_cells[0]["content"]
+    assert 'workflow.add_node("supervisor", supervisor_node)' in graph_cells[0]["content"]
+
+
+@pytest.mark.asyncio
 async def test_generate_artifacts_default_formats_include_markdown(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -52,8 +52,10 @@ async def test_generate_artifacts_stub(tmp_path: Path, monkeypatch: pytest.Monke
     assert artifacts["manifest"]["cell_count"] > 0
     assert artifacts["manifest"]["requirements_feedback"]["fallback_used"] is False
     assert artifacts["manifest"]["architecture_feedback"]["fallback_used"] is False
+    assert artifacts["manifest"]["architecture_feedback"]["docs_considered"] == []
     assert artifacts["result"]["requirements_feedback"]["fallback_used"] is False
     assert artifacts["result"]["architecture_feedback"]["fallback_used"] is False
+    assert artifacts["result"]["architecture_feedback"]["docs_considered"] == []
     assert Path(artifacts["manifest_path"]).exists()
     assert artifacts["result"]["generation_complete"] is True
 

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -21,6 +21,7 @@ from langgraph_system_generator.generator.architecture_registry import (
 from langgraph_system_generator.generator.state import (
     ArchitectureSelectionResult,
     Constraint,
+    DocSnippet,
 )
 from langgraph_system_generator.utils.config import ModelConfig
 
@@ -99,6 +100,28 @@ def test_architecture_registry_includes_builtin_architectures():
     hybrid = registry.get("hybrid")
     assert hybrid.default_secondary_patterns == ["router", "subagents"]
     assert hybrid.deterministic is True
+
+
+def test_architecture_registry_preserves_zero_docs_weight_and_filters_unknown_patterns():
+    """Registry normalization should preserve explicit zero weights and drop unknown patterns."""
+
+    registry = get_default_architecture_registry().clone()
+    registry.register(
+        ArchitectureRegistration(
+            architecture_id="custom_router",
+            selector_prompt_description="Custom router variant.",
+            docs_queries=["custom router docs"],
+            docs_weight=0.0,
+        )
+    )
+
+    assert registry.get("custom_router").docs_weight == 0.0
+    primary, secondary = registry.normalize_patterns(
+        "hybrid",
+        secondary_patterns=["router", "unknown", "subagents", "router"],
+    )
+    assert primary == "hybrid"
+    assert secondary == ["router", "subagents"]
 
 
 @pytest.mark.asyncio
@@ -501,12 +524,121 @@ async def test_architecture_selector_uses_registry_weighted_docs_and_limit(monke
         "Light autoagent doc",
         "Hybrid routing doc",
     }
+    assert {k for _, k in retriever.queries} == {2}
     assert result.feedback.docs_considered == [
         "shared.md#Overview",
         "subagents.md#Team",
     ]
     assert "Subagent team guidance should win the dedupe race." in captured_messages[0][1].content
     assert "AutoAgent notes." not in captured_messages[0][1].content
+
+
+@pytest.mark.asyncio
+async def test_architecture_selector_uses_docs_context_when_registry_retrieval_is_empty(
+    monkeypatch,
+):
+    """Selector should fall back to the existing docs_context when weighted retrieval is empty."""
+
+    captured_messages = []
+    retriever = StubDocsRetriever({})
+    monkeypatch.setattr(
+        architecture_selector,
+        "ChatOpenAI",
+        make_recording_llm(
+            """
+            {
+              "architecture_type": "router",
+              "patterns": {"primary": "router", "secondary": []},
+              "justification": "Router is enough for this task."
+            }
+            """,
+            captured_messages,
+        ),
+    )
+
+    selector = architecture_selector.ArchitectureSelector(docs_retriever=retriever)
+    docs_context = [
+        DocSnippet(
+            content="Existing RAG docs should still inform the selector prompt.",
+            source="rag.md",
+            heading="Useful",
+            relevance_score=0.7,
+        )
+    ]
+    result = await selector.select_architecture(
+        [Constraint(type="goal", value="Route requests reliably", priority=5)],
+        docs_context,
+    )
+
+    assert result.feedback.docs_considered == ["rag.md#Useful"]
+    assert "Existing RAG docs should still inform the selector prompt." in captured_messages[0][1].content
+
+
+@pytest.mark.asyncio
+async def test_architecture_selector_dedupes_blank_metadata_by_content(monkeypatch):
+    """Distinct blank-metadata snippets should survive prompt-doc dedupe."""
+
+    captured_messages = []
+    retriever = StubDocsRetriever(
+        {
+            "Blank metadata docs": [
+                {
+                    "content": "First blank metadata doc",
+                    "source": "",
+                    "heading": "",
+                    "relevance_score": 0.8,
+                },
+                {
+                    "content": "Second blank metadata doc",
+                    "source": "",
+                    "heading": "",
+                    "relevance_score": 0.7,
+                },
+            ]
+        }
+    )
+    monkeypatch.setattr(
+        architecture_selector,
+        "settings",
+        architecture_selector.settings.model_copy(
+            update={
+                "architecture_pattern_doc_queries": {
+                    "router": ["Blank metadata docs"],
+                    "subagents": [],
+                    "autoagent": [],
+                    "hybrid": [],
+                },
+                "architecture_prompt_doc_limit": 5,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        architecture_selector,
+        "ChatOpenAI",
+        make_recording_llm(
+            """
+            {
+              "architecture_type": "router",
+              "patterns": {"primary": "router", "secondary": []},
+              "justification": "Router remains the best fit."
+            }
+            """,
+            captured_messages,
+        ),
+    )
+
+    selector = architecture_selector.ArchitectureSelector(docs_retriever=retriever)
+    result = await selector.select_architecture(
+        [Constraint(type="goal", value="Handle metadata-poor docs", priority=5)],
+        [],
+    )
+
+    assert result.feedback.docs_considered == [
+        "First blank metadata doc",
+        "Second blank metadata doc",
+    ]
+    assert "First blank metadata doc" in captured_messages[0][1].content
+    assert "Second blank metadata doc" in captured_messages[0][1].content
 
 
 @pytest.mark.asyncio
@@ -611,8 +743,13 @@ async def test_graph_designer_fallback(arch_type, monkeypatch):
     assert result == expected
 
 
-def test_graph_designer_hybrid_fallback_contains_router_supervisor_and_team():
+def test_graph_designer_hybrid_fallback_contains_router_supervisor_and_team(monkeypatch):
     """Hybrid fallback should produce a real mixed routing/team workflow shape."""
+    monkeypatch.setattr(
+        graph_designer,
+        "ChatOpenAI",
+        make_stub_llm("invalid"),
+    )
     designer = graph_designer.GraphDesigner()
 
     result = designer._fallback_design("hybrid")
@@ -620,9 +757,15 @@ def test_graph_designer_hybrid_fallback_contains_router_supervisor_and_team():
     node_names = [node["name"] for node in result["nodes"]]
     assert node_names.count("router") == 1
     assert node_names.count("supervisor") == 1
+    assert node_names.count("finish") == 1
     assert len([name for name in node_names if name.startswith("specialist_")]) >= 1
     assert len(
-        [name for name in node_names if name not in {"router", "supervisor"} and not name.startswith("specialist_")]
+        [
+            name
+            for name in node_names
+            if name not in {"router", "supervisor", "finish"}
+            and not name.startswith("specialist_")
+        ]
     ) >= 2
     router_edges = [edge for edge in result["conditional_edges"] if edge["from"] == "router"]
     supervisor_edges = [

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -14,6 +14,10 @@ from langgraph_system_generator.generator.agents import (
     requirements_analyst,
     toolchain_engineer,
 )
+from langgraph_system_generator.generator.architecture_registry import (
+    ArchitectureRegistration,
+    get_default_architecture_registry,
+)
 from langgraph_system_generator.generator.state import (
     ArchitectureSelectionResult,
     Constraint,
@@ -66,6 +70,35 @@ def make_recording_llm(content: str, captured_messages: list):
             return DummyResponse(self._content)
 
     return RecordingLLM
+
+
+class StubDocsRetriever:
+    """Simple docs retriever stub that records raw query usage."""
+
+    def __init__(self, query_results: dict[str, list[dict]]):
+        self.query_results = query_results
+        self.queries: list[tuple[str, int]] = []
+
+    def retrieve(self, query: str, k: int = 5):
+        self.queries.append((query, k))
+        return list(self.query_results.get(query, []))
+
+
+def test_architecture_registry_includes_builtin_architectures():
+    """Built-in architecture support should come from the shared registry."""
+
+    registry = get_default_architecture_registry()
+
+    assert set(registry.supported_architecture_types()) == {
+        "router",
+        "subagents",
+        "hybrid",
+        "autoagent",
+    }
+
+    hybrid = registry.get("hybrid")
+    assert hybrid.default_secondary_patterns == ["router", "subagents"]
+    assert hybrid.deterministic is True
 
 
 @pytest.mark.asyncio
@@ -375,6 +408,193 @@ async def test_architecture_selector_normalizes_pattern_primary(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_architecture_selector_uses_registry_weighted_docs_and_limit(monkeypatch):
+    """ArchitectureSelector should use registry-driven queries, weights, dedupe, and cap."""
+    captured_messages = []
+    retriever = StubDocsRetriever(
+        {
+            "Custom router override": [
+                {
+                    "content": "Router overview from override docs.",
+                    "source": "shared.md",
+                    "heading": "Overview",
+                    "relevance_score": 0.7,
+                }
+            ],
+            "Weighted subagents doc": [
+                {
+                    "content": "Subagent team guidance should win the dedupe race.",
+                    "source": "shared.md",
+                    "heading": "Overview",
+                    "relevance_score": 0.8,
+                },
+                {
+                    "content": "Worker-team coordination details.",
+                    "source": "subagents.md",
+                    "heading": "Team",
+                    "relevance_score": 0.4,
+                },
+            ],
+            "Light autoagent doc": [
+                {
+                    "content": "AutoAgent notes.",
+                    "source": "autoagent.md",
+                    "heading": "Planner",
+                    "relevance_score": 0.95,
+                }
+            ],
+            "Hybrid routing doc": [
+                {
+                    "content": "Hybrid router + supervisor guidance.",
+                    "source": "hybrid.md",
+                    "heading": "Composition",
+                    "relevance_score": 0.2,
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(
+        architecture_selector,
+        "settings",
+        architecture_selector.settings.model_copy(
+            update={
+                "architecture_pattern_doc_queries": {
+                    "router": ["Custom router override"],
+                    "subagents": ["Weighted subagents doc"],
+                    "autoagent": ["Light autoagent doc"],
+                    "hybrid": ["Hybrid routing doc"],
+                },
+                "architecture_pattern_doc_weights": {
+                    "router": 1.0,
+                    "subagents": 3.0,
+                    "autoagent": 0.1,
+                    "hybrid": 0.5,
+                },
+                "architecture_prompt_doc_limit": 2,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        architecture_selector,
+        "ChatOpenAI",
+        make_recording_llm(
+            """
+            {
+              "architecture_type": "router",
+              "patterns": {"primary": "router", "secondary": []},
+              "justification": "A router is sufficient here."
+            }
+            """,
+            captured_messages,
+        ),
+    )
+
+    selector = architecture_selector.ArchitectureSelector(docs_retriever=retriever)
+    result = await selector.select_architecture(
+        [Constraint(type="goal", value="Route requests", priority=5)],
+        [],
+    )
+
+    assert {query for query, _k in retriever.queries} >= {
+        "Custom router override",
+        "Weighted subagents doc",
+        "Light autoagent doc",
+        "Hybrid routing doc",
+    }
+    assert result.feedback.docs_considered == [
+        "shared.md#Overview",
+        "subagents.md#Team",
+    ]
+    assert "Subagent team guidance should win the dedupe race." in captured_messages[0][1].content
+    assert "AutoAgent notes." not in captured_messages[0][1].content
+
+
+@pytest.mark.asyncio
+async def test_architecture_selector_uses_programmatically_registered_metadata(monkeypatch):
+    """Programmatic registry entries should participate in selector prompt/doc metadata."""
+    captured_messages = []
+    retriever = StubDocsRetriever(
+        {
+            "LangGraph research team orchestration": [
+                {
+                    "content": "Research team docs.",
+                    "source": "custom.md",
+                    "heading": "Research Team",
+                    "relevance_score": 0.6,
+                }
+            ]
+        }
+    )
+    registry = get_default_architecture_registry().clone()
+    registry.register(
+        ArchitectureRegistration(
+            architecture_id="research_team",
+            selector_prompt_description="Research team architecture for discovery-heavy workflows.",
+            default_secondary_patterns=["router"],
+            docs_queries=["LangGraph research team orchestration"],
+            docs_weight=1.2,
+            deterministic=False,
+        )
+    )
+    monkeypatch.setattr(
+        architecture_selector,
+        "ChatOpenAI",
+        make_recording_llm(
+            """
+            {
+              "architecture_type": "router",
+              "patterns": {"primary": "router", "secondary": []},
+              "justification": "Router remains the best fit."
+            }
+            """,
+            captured_messages,
+        ),
+    )
+
+    selector = architecture_selector.ArchitectureSelector(
+        docs_retriever=retriever,
+        architecture_registry=registry,
+    )
+    await selector.select_architecture(
+        [Constraint(type="goal", value="Investigate research-heavy tasks", priority=5)],
+        [],
+    )
+
+    assert any(query == "LangGraph research team orchestration" for query, _k in retriever.queries)
+    assert "research_team" in captured_messages[0][0].content
+    assert "Research team architecture for discovery-heavy workflows." in captured_messages[0][0].content
+
+
+@pytest.mark.asyncio
+async def test_architecture_selector_normalizes_hybrid_secondary_patterns(monkeypatch):
+    """Hybrid selections should normalize to router plus subagents secondary patterns."""
+    payload = """
+    {
+      "architecture_type": "hybrid",
+      "patterns": {"primary": "hybrid", "secondary": ["router"]},
+      "justification": "Hybrid mixes direct routing with a supervisor team.",
+      "feedback": {
+        "confidence": 0.67
+      }
+    }
+    """
+    monkeypatch.setattr(
+        architecture_selector,
+        "ChatOpenAI",
+        make_stub_llm(payload),
+    )
+    selector = architecture_selector.ArchitectureSelector()
+    result = await selector.select_architecture(
+        [Constraint(type="goal", value="Mix direct specialists with a team path", priority=5)],
+        [],
+    )
+
+    assert result.architecture_type == "hybrid"
+    assert result.patterns.primary == "hybrid"
+    assert result.patterns.secondary == ["router", "subagents"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("arch_type", ["router", "subagents"])
 async def test_graph_designer_fallback(arch_type, monkeypatch):
     """GraphDesigner falls back to the correct design when parsing fails."""
@@ -389,6 +609,30 @@ async def test_graph_designer_fallback(arch_type, monkeypatch):
     expected = designer._fallback_design(arch_type)
     result = await designer.design_workflow(architecture, constraints)
     assert result == expected
+
+
+def test_graph_designer_hybrid_fallback_contains_router_supervisor_and_team():
+    """Hybrid fallback should produce a real mixed routing/team workflow shape."""
+    designer = graph_designer.GraphDesigner()
+
+    result = designer._fallback_design("hybrid")
+
+    node_names = [node["name"] for node in result["nodes"]]
+    assert node_names.count("router") == 1
+    assert node_names.count("supervisor") == 1
+    assert len([name for name in node_names if name.startswith("specialist_")]) >= 1
+    assert len(
+        [name for name in node_names if name not in {"router", "supervisor"} and not name.startswith("specialist_")]
+    ) >= 2
+    router_edges = [edge for edge in result["conditional_edges"] if edge["from"] == "router"]
+    supervisor_edges = [
+        edge for edge in result["conditional_edges"] if edge["from"] == "supervisor"
+    ]
+    assert router_edges
+    assert "team_path" in router_edges[0]["branches"]
+    assert router_edges[0]["branches"]["team_path"] == "supervisor"
+    assert supervisor_edges
+    assert "FINISH" in supervisor_edges[0]["branches"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -192,6 +192,26 @@ async def test_architecture_selection_node_honors_autoagent_override():
 
 
 @pytest.mark.asyncio
+async def test_architecture_selection_node_honors_hybrid_override():
+    result = await architecture_selection_node(
+        {
+            "constraints": [],
+            "docs_context": [],
+            "generation_config": GenerationConfig(agent_type="hybrid"),
+        }
+    )
+
+    assert result["selected_patterns"] == {
+        "primary": "hybrid",
+        "secondary": ["router", "subagents"],
+    }
+    assert result["architecture_type"] == "hybrid"
+    assert "agent_type override" in result["architecture_justification"]
+    assert result["architecture_feedback"].fallback_used is False
+    assert result["architecture_feedback"].docs_considered
+
+
+@pytest.mark.asyncio
 async def test_graph_design_node_defaults_architecture_type(monkeypatch):
     payload = '{"nodes":["a","b"]}'
 

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -208,7 +208,7 @@ async def test_architecture_selection_node_honors_hybrid_override():
     assert result["architecture_type"] == "hybrid"
     assert "agent_type override" in result["architecture_justification"]
     assert result["architecture_feedback"].fallback_used is False
-    assert result["architecture_feedback"].docs_considered
+    assert result["architecture_feedback"].docs_considered == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -50,6 +50,15 @@ class DummyLLM:
             "revision_count: int",
             ['"revision_count": 0', '"quality_score": 0.0', '"approved": False'],
         ),
+        (
+            "hybrid",
+            "next_agent: str",
+            [
+                '"route": ""',
+                '"next_agent": "supervisor"',
+                '"task_results": {}',
+            ],
+        ),
     ],
 )
 async def test_compose_notebook_sections_and_packages(
@@ -78,6 +87,14 @@ async def test_compose_notebook_sections_and_packages(
         nodes = [
             {"name": "supervisor", "purpose": "Coordinate agents"},
             {"name": "researcher", "purpose": "Research documents"},
+        ]
+    elif architecture_type == "hybrid":
+        nodes = [
+            {"name": "router", "purpose": "Route requests"},
+            {"name": "specialist_1", "purpose": "Handle direct specialist work"},
+            {"name": "supervisor", "purpose": "Coordinate worker team"},
+            {"name": "researcher", "purpose": "Research documents"},
+            {"name": "reviewer", "purpose": "Review worker output"},
         ]
     else:
         nodes = [
@@ -168,6 +185,16 @@ async def test_compose_notebook_sections_and_packages(
     assert "stream" in execution_cell.content or "invoke" in execution_cell.content
     for marker in expected_execution_markers:
         assert marker in execution_cell.content
+
+    if architecture_type == "hybrid":
+        assert "route: str" in state_cells[0].content
+        assert 'workflow.add_node("router", router_node)' in graph_cells[0].content
+        assert 'workflow.add_node("supervisor", supervisor_node)' in graph_cells[0].content
+        assert 'workflow.add_edge("specialist_1", "finish")' in graph_cells[0].content
+        node_source = "\n\n".join(cell.content for cell in cells if cell.section == "nodes")
+        assert "def router_node" in node_source
+        assert "def supervisor_node" in node_source
+        assert "def reviewer_node" in node_source
 
     sections = {cell.section for cell in cells}
     assert {"intro", "setup", "state", "tools", "graph", "execution"}.issubset(
@@ -292,7 +319,7 @@ def test_graph_fallback_uses_sanitized_function_references(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "architecture_type",
-    ["router", "subagents", "critique_loop", "autoagent"],
+    ["router", "subagents", "critique_loop", "autoagent", "hybrid"],
 )
 async def test_pattern_nodes_use_request_scoped_model_config(
     monkeypatch: pytest.MonkeyPatch,
@@ -327,6 +354,14 @@ async def test_pattern_nodes_use_request_scoped_model_config(
         ]
     elif architecture_type == "autoagent":
         nodes = [{"name": "planner", "purpose": "Plan the work"}]
+    elif architecture_type == "hybrid":
+        nodes = [
+            {"name": "router", "purpose": "Route requests"},
+            {"name": "specialist_1", "purpose": "Handle direct specialist work"},
+            {"name": "supervisor", "purpose": "Coordinate worker team"},
+            {"name": "researcher", "purpose": "Research documents"},
+            {"name": "reviewer", "purpose": "Review worker output"},
+        ]
     else:
         nodes = [
             {"name": "generate", "purpose": "Generate an initial draft"},

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -219,6 +219,103 @@ async def test_compose_notebook_sections_and_packages(
         prev_expected_pos = current_expected_pos
 
 
+@pytest.mark.asyncio
+async def test_compose_notebook_hybrid_sparse_nodes_keep_defaults_aligned(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Sparse hybrid designs should emit matching fallback nodes and graph wiring."""
+
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+
+    plan = NotebookPlan(
+        title="Sparse Hybrid",
+        sections=["Setup", "Workflow", "Execution"],
+        patterns_used=["hybrid"],
+        architecture_type="hybrid",
+    )
+    workflow_design = {
+        "architecture_type": "hybrid",
+        "state_schema": {},
+        "nodes": [
+            {"name": "router", "purpose": "Route requests"},
+            {"name": "supervisor", "purpose": "Coordinate workers"},
+        ],
+    }
+
+    cells = await composer.compose_notebook(
+        notebook_plan=plan,
+        workflow_design=workflow_design,
+        tools=[],
+        architecture={"architecture_type": "hybrid", "justification": "Fallback hybrid."},
+    )
+
+    node_source = "\n\n".join(cell.content for cell in cells if cell.section == "nodes")
+    graph_code = next(
+        cell.content
+        for cell in cells
+        if cell.section == "graph" and cell.cell_type == "code"
+    )
+
+    assert "def specialist_1_node" in node_source
+    assert "def researcher_node" in node_source
+    assert "def reviewer_node" in node_source
+    assert 'workflow.add_node("specialist_1", specialist_1_node)' in graph_code
+    assert 'workflow.add_node("researcher", researcher_node)' in graph_code
+    assert 'workflow.add_node("reviewer", reviewer_node)' in graph_code
+    assert 'workflow.add_edge("specialist_1", "finish")' in graph_code
+
+
+@pytest.mark.asyncio
+async def test_compose_notebook_hybrid_sanitizes_worker_and_specialist_graph_ids(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Hybrid graph wiring should use sanitized node ids for direct and worker paths."""
+
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+
+    plan = NotebookPlan(
+        title="Hybrid Sanitization",
+        sections=["Setup", "Workflow", "Execution"],
+        patterns_used=["hybrid"],
+        architecture_type="hybrid",
+    )
+    workflow_design = {
+        "architecture_type": "hybrid",
+        "state_schema": {},
+        "nodes": [
+            {"name": "router", "purpose": "Route requests"},
+            {"name": "supervisor", "purpose": "Coordinate workers"},
+            {"name": "fact checker", "purpose": "Handle direct fact checking"},
+            {"name": "review lead", "purpose": "Review worker output"},
+            {"name": "research analyst", "purpose": "Gather supporting facts"},
+        ],
+    }
+
+    cells = await composer.compose_notebook(
+        notebook_plan=plan,
+        workflow_design=workflow_design,
+        tools=[],
+        architecture={"architecture_type": "hybrid", "justification": "Hybrid sanitization."},
+    )
+
+    node_source = "\n\n".join(cell.content for cell in cells if cell.section == "nodes")
+    graph_code = next(
+        cell.content
+        for cell in cells
+        if cell.section == "graph" and cell.cell_type == "code"
+    )
+
+    assert "def fact_checker_node" in node_source
+    assert "def review_lead_node" in node_source
+    assert "def research_analyst_node" in node_source
+    assert 'workflow.add_node("fact_checker", fact_checker_node)' in graph_code
+    assert 'workflow.add_node("review_lead", review_lead_node)' in graph_code
+    assert 'workflow.add_node("research_analyst", research_analyst_node)' in graph_code
+    assert '"fact checker": "fact_checker"' in graph_code
+
+
 def test_generate_node_implementation_falls_back_to_meaningful_state_updates(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/unit/test_patterns.py
+++ b/tests/unit/test_patterns.py
@@ -7,6 +7,7 @@ import ast
 from langgraph_system_generator.patterns import (
     AutoAgentPattern,
     CritiqueLoopPattern,
+    HybridPattern,
     RouterPattern,
     SubagentsPattern,
 )
@@ -254,6 +255,35 @@ class TestAutoAgentPattern:
         assert 'workflow.add_node("supervisor", supervisor_node)' in code
         assert 'workflow.add_node("planner", planner_node)' in code
         assert 'workflow.add_edge("planner", "supervisor")' in code
+
+
+class TestHybridPattern:
+    """Tests for HybridPattern code generation."""
+
+    def test_generate_graph_code_uses_sanitized_ids_for_direct_and_worker_nodes(self):
+        """Hybrid graph wiring should align sanitized node ids with routing targets."""
+
+        code = HybridPattern.generate_graph_code(
+            ["fact checker"],
+            ["review lead", "research analyst"],
+        )
+
+        assert 'workflow.add_node("fact_checker", fact_checker_node)' in code
+        assert 'workflow.add_node("review_lead", review_lead_node)' in code
+        assert 'workflow.add_node("research_analyst", research_analyst_node)' in code
+        assert 'workflow.add_edge("fact_checker", "finish")' in code
+        assert 'workflow.add_edge("review_lead", "supervisor")' in code
+        assert 'workflow.add_edge("research_analyst", "supervisor")' in code
+        assert '"fact checker": "fact_checker"' in code
+
+    def test_generate_graph_code_keeps_finish_node_when_defaults_are_used(self):
+        """Hybrid graph defaults should still include the finish node and route."""
+
+        code = HybridPattern.generate_graph_code([], [])
+
+        assert 'workflow.add_node("finish", finish_node)' in code
+        assert 'workflow.add_edge("finish", END)' in code
+        assert 'workflow.add_node("specialist_1", specialist_1_node)' in code
 
 
 class TestCritiqueLoopPattern:


### PR DESCRIPTION
## Summary
- add a shared architecture registry that drives selector metadata and supported architecture validation
- make architecture docs retrieval configurable through internal settings with weighted, deduped prompt selection
- add a real HybridPattern and use it for stub generation and notebook composition instead of the generic fallback path

## Testing
- pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes.py tests/unit/test_generator_nodes_additional.py tests/unit/test_generator_notebook_composer.py tests/unit/test_cli_api.py -q
- pytest tests/unit -q
- pytest --asyncio-mode=auto -q
- python -m ruff check src/langgraph_system_generator/generator/architecture_registry.py src/langgraph_system_generator/generator/agents/architecture_selector.py src/langgraph_system_generator/generator/agents/graph_designer.py src/langgraph_system_generator/generator/agents/notebook_composer.py src/langgraph_system_generator/patterns/hybrid.py src/langgraph_system_generator/patterns/__init__.py src/langgraph_system_generator/cli.py src/langgraph_system_generator/generator/nodes.py src/langgraph_system_generator/utils/config.py tests/unit/test_generator_agents.py tests/unit/test_generator_nodes_additional.py tests/unit/test_generator_notebook_composer.py tests/unit/test_cli_api.py

Closes #193
Closes #195
Closes #191