### PR TITLE
Complete GraphDesigner epic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ These node functions are the clearest map of the runtime lifecycle:
 | Intake | `intake_node` | `RequirementsAnalyst` | `constraints`, `requirements_feedback` |
 | Retrieval | `rag_retrieval_node` | `DocsRetriever` | `docs_context` |
 | Architecture selection | `architecture_selection_node` | `ArchitectureSelector` | `selected_patterns`, `architecture_type`, `architecture_justification`, `architecture_feedback` |
-| Workflow design | `graph_design_node` | `GraphDesigner` | `workflow_design`, `notebook_plan` |
+| Workflow design | `graph_design_node` | `GraphDesigner` | `workflow_design`, `graph_design_feedback`, `graph_exports`, `notebook_plan` |
 | Tool planning | `tooling_plan_node` | `ToolchainEngineer` | `tools_plan` |
 | Notebook assembly | `notebook_assembly_node` | `NotebookComposer` | `generated_cells` |
 | Static QA | `static_qa_node` | validators under `src/langgraph_system_generator/qa/` | `qa_reports`, `qa_history` |
@@ -115,6 +115,9 @@ Important patterns:
 - `repair_attempts` bounds retry behavior.
 - `artifacts_manifest` and `generation_complete` are the final packaging
   outputs expected by the CLI and API.
+- `workflow_design` remains the backward-compatible downstream graph payload,
+  while `graph_design_feedback` and `graph_exports` carry validation/fallback
+  metadata plus Mermaid/schema exports for manifests and notebooks.
 
 When adding a new runtime agent or stage:
 
@@ -173,6 +176,24 @@ Use this checklist before writing code:
 5. Add or update focused tests under `tests/unit/` or `tests/patterns/`.
 6. Update documentation if the public workflow, outputs, or contributor
    expectations changed.
+
+### GraphDesigner-specific expectations
+
+`GraphDesigner.design_workflow()` now returns a typed `GraphDesignResult`, not a
+raw dict. Keep these conventions aligned when changing graph design behavior:
+
+- normalize and validate every live-model graph before it reaches downstream
+  notebook/tooling stages
+- prefer deterministic registry-backed fallbacks over partial graph output when
+  validation fails
+- keep `workflow_design` backward-compatible for `ToolchainEngineer` and
+  `NotebookComposer`
+- surface recoverable graph issues through `graph_design_feedback` and
+  `graph_exports` instead of silently discarding them
+- register new architecture-specific graph behavior through
+  `src/langgraph_system_generator/generator/graph_design_registry.py`
+  and `GRAPH_DESIGNER_PLUGIN_MODULES` rather than hardcoding more branches into
+  the agent
 
 ### Minimal runtime-agent skeleton
 

--- a/docs/wiki/Architecture-Deep-Dive.md
+++ b/docs/wiki/Architecture-Deep-Dive.md
@@ -128,32 +128,62 @@ Selects the most appropriate multi-agent pattern:
 
 #### 4. Workflow Design
 **Input**: Architecture + Constraints + Docs  
-**Output**: Detailed workflow specification
+**Output**: Detailed workflow specification plus advisory graph-design feedback and exports
 
 Designs the specific graph structure, nodes, and edges:
 
 ```python
 {
   "workflow_design": {
+    "architecture_type": "router",
+    "state_schema": {
+      "messages": "Conversation state",
+      "route": "Selected route"
+    },
     "nodes": [
-      {"name": "router", "type": "classifier", "purpose": "Route to appropriate handler"},
-      {"name": "technical_support", "type": "handler", "purpose": "Handle technical queries"},
-      {"name": "billing_support", "type": "handler", "purpose": "Handle billing queries"},
-      {"name": "general_support", "type": "handler", "purpose": "Handle general queries"}
+      {"name": "router", "purpose": "Route to appropriate handler"},
+      {"name": "technical_support", "purpose": "Handle technical queries"},
+      {"name": "billing_support", "purpose": "Handle billing queries"},
+      {"name": "general_support", "purpose": "Handle general queries"}
     ],
     "edges": [
-      {"from": "router", "to": "technical_support", "condition": "route == 'technical'"},
-      {"from": "router", "to": "billing_support", "condition": "route == 'billing'"},
-      {"from": "router", "to": "general_support", "condition": "route == 'general'"}
+      {"from": "technical_support", "to": "finish"},
+      {"from": "billing_support", "to": "finish"},
+      {"from": "general_support", "to": "finish"}
+    ],
+    "conditional_edges": [
+      {
+        "from": "router",
+        "condition": "route == 'technical' | 'billing' | 'general'",
+        "branches": {
+          "technical": "technical_support",
+          "billing": "billing_support",
+          "general": "general_support"
+        }
+      }
     ],
     "entry_point": "router",
-    "graph_type": "conditional"
+    "checkpointing": false,
+    "graph_exports": {
+      "mermaid": "flowchart TD ...",
+      "schema": {
+        "entry_point": "router",
+        "terminal_nodes": ["finish"],
+        "validation_summary": {"errors": [], "warnings": []}
+      }
+    }
+  },
+  "graph_design_feedback": {
+    "fallback_used": false,
+    "validation_errors": [],
+    "warnings": [],
+    "composition_strategy": "router_direct"
   }
 }
 ```
 
 **Agent**: `GraphDesigner`  
-**LLM-Powered**: Yes (live mode) / Template-based (stub mode)
+**LLM-Powered**: Yes (live mode) / Deterministic registry-backed fallback (stub mode and recovery)
 
 #### 5. Tool Planning
 **Input**: Workflow design + Constraints  
@@ -357,6 +387,9 @@ class GeneratorState(TypedDict):
     # Extracted requirements
     constraints: Annotated[List[Constraint], operator.add]
     requirements_feedback: RequirementsFeedback
+    architecture_feedback: ArchitectureFeedback
+    graph_design_feedback: GraphDesignFeedback
+    graph_exports: GraphExportBundle
     selected_patterns: Dict[str, Any]
     
     # RAG Retrieval
@@ -389,6 +422,7 @@ class GeneratorState(TypedDict):
 **Key Features**:
 - **Annotated Lists**: Fields like `constraints` and `docs_context` use `operator.add` to append values across nodes
 - **Advisory Intake Feedback**: `requirements_feedback` captures fallback, conflict, and missing-input guidance without replacing `constraints` as the downstream planning contract
+- **Advisory Graph Feedback**: `graph_design_feedback` captures validation and fallback details while `graph_exports` stores Mermaid/schema bundles for manifests and notebook overview cells
 - **Last-write-wins cells**: `generated_cells` intentionally has no reducer, so each repair pass replaces prior cells
 - **Immutability**: State updates create new state versions (LangGraph managed)
 - **Type Safety**: TypedDict provides IDE autocomplete and validation
@@ -580,25 +614,25 @@ Every generation produces a `manifest.json`:
 {
   "prompt": "Create a customer support chatbot with routing",
   "mode": "stub",
-  "architecture": "router",
-  "patterns": ["router"],
-  "timestamp": "YYYY-MM-DDTHH:MM:SSZ",
-  "artifacts": {
-    "notebook": "./notebook.ipynb",
-    "html": "./notebook.html",
-    "docx": "./notebook.docx",
-    "zip": "./notebook_bundle.zip"
+  "architecture_type": "router",
+  "graph_design_feedback": {
+    "fallback_used": false,
+    "validation_errors": [],
+    "warnings": []
   },
-  "qa_status": {
-    "passed": true,
-    "checks": 5,
-    "failures": 0
+  "graph_exports": {
+    "mermaid": "flowchart TD ...",
+    "schema": {
+      "entry_point": "router",
+      "terminal_nodes": ["finish"],
+      "validation_summary": {"errors": [], "warnings": []}
+    }
   },
-  "metadata": {
-    "cells_generated": 12,
-    "repair_attempts": 0,
-    "generation_time_ms": 850
-  }
+  "warnings": [],
+  "export_results": {
+    "ipynb": {"status": "completed", "path": "./notebook.ipynb"}
+  },
+  "phase_summary": [{"phase": "compose", "status": "completed"}]
 }
 ```
 
@@ -618,9 +652,10 @@ class Settings(BaseSettings):
     vector_store_path: str = "./data/vector_store"
     
     # Generation
-    default_model: str = "gpt-4-turbo-preview"
+    default_model: str = "gpt-5-mini"
     max_repair_attempts: int = 3
     default_budget_tokens: int = 100000
+    graph_designer_plugin_modules: list[str] = []
     
     # LangSmith
     langsmith_project: Optional[str] = None

--- a/docs/wiki/CLI-and-API-Reference.md
+++ b/docs/wiki/CLI-and-API-Reference.md
@@ -39,15 +39,8 @@ lnf generate PROMPT [OPTIONS]
 |--------|------|---------|-------------|
 | `--output DIR` | path | `./output` | Output directory for artifacts |
 | `--mode MODE` | choice | `stub` | Generation mode: `stub` or `live` |
-| `--formats FORMAT [FORMAT ...]` | list | all | Output formats: `ipynb`, `html`, `docx`, `pdf`, `zip` |
-| `--model MODEL` | string | from config | LLM model (e.g., `gpt-4`, `gpt-3.5-turbo`) |
-| `--temperature FLOAT` | float | 0.7 | LLM temperature (0.0-2.0) |
-| `--max-tokens INT` | int | 4096 | Maximum tokens for LLM response |
-| `--agent-type TYPE` | string | auto | Agent architecture: `router`, `subagents`, `hybrid`, `autoagent` |
-| `--memory-config CONFIG` | string | `none` | Memory configuration: `none`, `short`, `long`, `full` |
-| `--graph-style STYLE` | string | auto | Graph style: `sequential`, `parallel`, `conditional`, `cyclic` |
-| `--retriever-type TYPE` | string | `vector` | Retriever type: `vector`, `keyword`, `hybrid`, `mmr` |
-| `--document-loader LOADER` | string | `text` | Loader type: `text`, `pdf`, `web`, `markdown`, `json`, `csv` |
+| `--formats FORMAT [FORMAT ...]` | list | `ipynb html markdown docx zip` | Output formats: `ipynb`, `html`, `markdown`, `pdf`, `docx`, `zip` |
+| `--agent-type TYPE` | string | auto | Architecture override: `router`, `subagents`, `hybrid`, `autoagent` |
 
 **Examples:**
 
@@ -56,12 +49,12 @@ Basic generation (stub mode):
 lnf generate "Create a customer support chatbot" --output ./my_chatbot
 ```
 
-Full generation with live mode:
+Live generation:
 ```bash
 lnf generate "Build a research assistant with multiple agents" \
   --output ./research_assistant \
   --mode live \
-  --model gpt-4
+  --agent-type subagents
 ```
 
 Specific formats only:
@@ -71,18 +64,9 @@ lnf generate "Create a data analyzer" \
   --formats ipynb html
 ```
 
-Advanced options:
-```bash
-lnf generate "Complex multi-agent system" \
-  --output ./complex_system \
-  --mode live \
-  --model gpt-4 \
-  --temperature 0.8 \
-  --max-tokens 8192 \
-  --agent-type subagents \
-  --memory-config long \
-  --graph-style conditional
-```
+The CLI intentionally keeps advanced model/provider overrides out of the flag
+surface. For request-scoped `model`, `temperature`, `max_tokens`, or
+`custom_endpoint`, use the API instead of the CLI.
 
 #### `lnf build-index`
 
@@ -99,19 +83,21 @@ lnf build-index [OPTIONS]
 |--------|------|---------|-------------|
 | `--cache DIR` | path | `./data/cached_docs` | Cached documentation directory |
 | `--store DIR` | path | `./data/vector_store` | Vector store output directory |
-| `--fake-embeddings` | flag | False | Use fake embeddings (no API key needed) |
+| `--use-openai` | flag | False | Use OpenAI embeddings instead of local fake embeddings |
+| `--chunk-size INT` | int | `500` | Chunk size for document splitting |
+| `--chunk-overlap INT` | int | `50` | Chunk overlap for document splitting |
 
 **Examples:**
 
 Build with OpenAI embeddings:
 ```bash
 export OPENAI_API_KEY='sk-...'
-lnf build-index
+lnf build-index --use-openai
 ```
 
-Build with fake embeddings (testing):
+Build with local fake embeddings (testing/default):
 ```bash
-lnf build-index --fake-embeddings
+lnf build-index
 ```
 
 Custom paths:
@@ -133,10 +119,11 @@ The CLI respects these environment variables:
 | `LANGSMITH_PROJECT` | LangSmith project name | `langgraph-notebook-foundry` |
 | `VECTOR_STORE_TYPE` | Vector store backend | `faiss` |
 | `VECTOR_STORE_PATH` | Vector store location | `./data/vector_store` |
-| `DEFAULT_MODEL` | Default LLM model | `gpt-4-turbo-preview` |
+| `DEFAULT_MODEL` | Default LLM model | `gpt-5-mini` |
 | `MAX_REPAIR_ATTEMPTS` | QA repair attempts | `3` |
 | `DEFAULT_BUDGET_TOKENS` | Token budget | `100000` |
 | `LNF_OUTPUT_BASE` | Base output directory | `.` |
+| `GRAPH_DESIGNER_PLUGIN_MODULES` | Extra graph designer registry modules | None |
 
 ### Exit Codes
 
@@ -195,8 +182,7 @@ Health check endpoint.
 **Response:**
 ```json
 {
-  "status": "healthy",
-  "version": "<current_version>"
+  "status": "ok"
 }
 ```
 
@@ -235,13 +221,26 @@ Generate a multi-agent system from a prompt.
   "output_dir": "./output/api",
   "manifest_path": "./output/api/manifest.json",
   "manifest": {
-    "notebook_path": "./output/api/notebook.ipynb",
-    "html_path": "./output/api/notebook.html",
-    "docx_path": "./output/api/notebook.docx",
-    "pdf_path": "./output/api/notebook.pdf",
-    "zip_path": "./output/api/notebook_bundle.zip",
-    "plan_path": "./output/api/notebook_plan.json",
-    "cells_path": "./output/api/generated_cells.json"
+    "architecture_type": "router",
+    "requirements_feedback": {"fallback_used": false},
+    "architecture_feedback": {"fallback_used": false},
+    "graph_design_feedback": {
+      "fallback_used": false,
+      "validation_errors": [],
+      "warnings": []
+    },
+    "graph_exports": {
+      "mermaid": "flowchart TD ...",
+      "schema": {
+        "entry_point": "router",
+        "terminal_nodes": ["finish"],
+        "validation_summary": {"errors": [], "warnings": []}
+      }
+    },
+    "warnings": [],
+    "export_results": {
+      "ipynb": {"status": "completed", "path": "./output/api/notebook.ipynb"}
+    }
   }
 }
 ```
@@ -354,6 +353,8 @@ All requests are validated using Pydantic models:
 - `temperature`: Must be 0.0-2.0
 - `max_tokens`: Must be 1-32768
 - `formats`: Must be valid format names
+- `agent_type`: Must be one of `router`, `subagents`, `hybrid`, `autoagent`
+- `custom_endpoint`: Must be a valid `http` or `https` URL when provided, and requires an explicit model
 
 **Validation Error Response:**
 ```json
@@ -418,18 +419,22 @@ async def generate_endpoint(request: GenerationRequest):
 For programmatic access from Python, use the CLI functions directly:
 
 ```python
+import asyncio
+
 from langgraph_system_generator.cli import generate_artifacts
 
 # Generate in stub mode
-result = generate_artifacts(
-    prompt="Create a customer support chatbot",
-    mode="stub",
-    output_dir="./output/my_system",
-    formats=["ipynb", "html", "docx"]
+artifacts = asyncio.run(
+    generate_artifacts(
+        prompt="Create a customer support chatbot",
+        mode="stub",
+        output_dir="./output/my_system",
+        formats=["ipynb", "html", "docx"],
+    )
 )
 
-print(f"Success: {result['success']}")
-print(f"Notebook: {result['manifest']['notebook_path']}")
+print(f"Mode: {artifacts['mode']}")
+print(f"Notebook: {artifacts['manifest']['notebook_path']}")
 ```
 
 Or use the generator graph directly:
@@ -437,15 +442,18 @@ Or use the generator graph directly:
 ```python
 from langgraph_system_generator.generator.graph import create_generator_graph
 
-# Create the graph
-graph = create_generator_graph()
-app = graph.compile()
+# Create the compiled app
+app = create_generator_graph()
 
 # Run generation
 initial_state = {
     "user_prompt": "Create a research assistant",
     "uploaded_files": None,
     "constraints": [],
+    "requirements_feedback": {"fallback_used": False},
+    "architecture_feedback": {"fallback_used": False},
+    "graph_design_feedback": {"fallback_used": False},
+    "graph_exports": {"mermaid": "", "schema": {}},
     # ... other state fields ...
 }
 
@@ -473,7 +481,7 @@ Every successful generation produces:
 ### Manifest Structure
 
 The `manifest.json` contains complete generation metadata, including structured
-phase timing, per-format export status, and non-fatal warnings:
+phase timing, per-format export status, graph-design exports, and non-fatal warnings:
 
 ```json
 {
@@ -481,6 +489,24 @@ phase timing, per-format export status, and non-fatal warnings:
   "mode": "stub | live",
   "architecture_type": "router | subagents | hybrid | autoagent",
   "plan_title": "LangGraph Workflow: Example",
+  "requirements_feedback": {"fallback_used": false},
+  "architecture_feedback": {"fallback_used": false},
+  "graph_design_feedback": {
+    "fallback_used": false,
+    "validation_errors": [],
+    "warnings": []
+  },
+  "graph_exports": {
+    "mermaid": "flowchart TD ...",
+    "schema": {
+      "entry_point": "router",
+      "terminal_nodes": ["finish"],
+      "validation_summary": {
+        "errors": [],
+        "warnings": []
+      }
+    }
+  },
   "notebook_path": "./output/api/notebook.ipynb",
   "html_path": "./output/api/notebook.html",
   "zip_path": "./output/api/notebook_bundle.zip",

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -21,11 +21,18 @@ from langgraph_system_generator.generator.state import (
     build_constraint_type_registry,
     CellSpec,
     Constraint,
+    GraphDesignFeedback,
+    GraphExportBundle,
     NotebookPlan,
     RequirementsFeedback,
 )
 from langgraph_system_generator.generator.architecture_registry import (
     get_default_architecture_registry,
+)
+from langgraph_system_generator.generator.graph_design_registry import (
+    build_graph_exports,
+    get_graph_design_registry,
+    normalize_graph_design,
 )
 from langgraph_system_generator.utils.error_handling import GenerationError
 from langgraph_system_generator.utils.config import GenerationConfig, settings
@@ -78,6 +85,8 @@ def _default_state(
             available_constraint_types=_available_constraint_types(),
         ),
         "architecture_feedback": ArchitectureFeedback(fallback_used=False),
+        "graph_design_feedback": GraphDesignFeedback(fallback_used=False),
+        "graph_exports": GraphExportBundle(),
         "selected_patterns": {},
         "docs_context": [],
         "notebook_plan": None,
@@ -101,7 +110,7 @@ def _serialize(obj: Any) -> Any:
     """Recursively convert Pydantic models and objects into plain dicts/lists."""
 
     if hasattr(obj, "model_dump"):
-        return obj.model_dump()
+        return obj.model_dump(by_alias=True)
     if isinstance(obj, list):
         return [_serialize(item) for item in obj]
     if isinstance(obj, dict):
@@ -240,6 +249,44 @@ def _architecture_warning_entries(
                 "validation_errors": validation_errors,
                 "tradeoffs": tradeoffs,
                 "docs_considered": docs_considered,
+            }
+        )
+
+    return warnings
+
+
+def _graph_design_warning_entries(
+    feedback: Dict[str, Any] | None,
+) -> List[Dict[str, Any]]:
+    """Convert structured graph-design feedback into manifest warnings."""
+
+    if not isinstance(feedback, dict):
+        return []
+
+    warnings: List[Dict[str, Any]] = []
+    validation_errors = list(feedback.get("validation_errors") or [])
+    advisory_warnings = list(feedback.get("warnings") or [])
+
+    if feedback.get("fallback_used"):
+        warnings.append(
+            {
+                "code": "graph_design_fallback",
+                "phase": "graph_design",
+                "message": feedback.get("fallback_reason")
+                or "Graph design used a deterministic fallback workflow.",
+                "validation_errors": validation_errors,
+                "warnings": advisory_warnings,
+            }
+        )
+
+    if validation_errors:
+        warnings.append(
+            {
+                "code": "graph_design_validation",
+                "phase": "graph_design",
+                "message": "Graph design reported validation issues.",
+                "validation_errors": validation_errors,
+                "warnings": advisory_warnings,
             }
         )
 
@@ -438,6 +485,7 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
     """Create a deterministic, offline-friendly generation result."""
     RouterPattern, SubagentsPattern, HybridPattern, AutoAgentPattern = _load_patterns()
     architecture_registry = get_default_architecture_registry()
+    graph_design_registry = get_graph_design_registry()
 
     normalized_agent_type = normalize_agent_type(agent_type)
     if normalized_agent_type in SUPPORTED_AGENT_TYPES:
@@ -488,6 +536,32 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
         patterns_used=[architecture_type],
         architecture_type=architecture_type,
     )
+
+    graph_registration = graph_design_registry.get(architecture_type)
+    graph_design = normalize_graph_design(
+        graph_registration.fallback_builder(
+            architecture={
+                "architecture_type": architecture_type,
+                "selected_patterns": {
+                    "primary": architecture_type,
+                    "secondary": secondary_patterns,
+                },
+            },
+            constraints=constraints,
+        ),
+        architecture_type,
+        graph_registration,
+    )
+    graph_exports = build_graph_exports(graph_design, graph_registration)
+    graph_design_feedback = GraphDesignFeedback(
+        fallback_used=False,
+        composition_strategy=graph_registration.composition_strategy,
+    )
+    workflow_design = graph_design.to_workflow_design_payload()
+    workflow_design["selected_patterns"] = {
+        "primary": architecture_type,
+        "secondary": secondary_patterns,
+    }
 
     cells: List[CellSpec] = [
         CellSpec(
@@ -724,6 +798,8 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
             available_constraint_types=_available_constraint_types(),
         ),
         "architecture_feedback": architecture_feedback,
+        "graph_design_feedback": graph_design_feedback,
+        "graph_exports": graph_exports,
         "selected_patterns": {
             "primary": architecture_type,
             "secondary": secondary_patterns,
@@ -734,23 +810,7 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
         "architecture_justification": justification,
         "generation_config": None,
         "generation_mode": "stub",
-        "workflow_design": {
-            "entry_point": architecture_type,
-            "nodes": [
-                {
-                    "name": architecture_type,
-                    "purpose": (
-                        "Dispatch to specialists"
-                        if architecture_type == "router"
-                        else (
-                            "Coordinate AutoAgent workers"
-                            if architecture_type == "autoagent"
-                            else "Coordinate sub-agents"
-                        )
-                    ),
-                }
-            ],
-        },
+        "workflow_design": workflow_design,
         "tools_plan": [],
         "generated_cells": cells,
         "qa_reports": [],
@@ -865,6 +925,8 @@ async def generate_artifacts(
     )
     requirements_feedback = serialized.get("requirements_feedback") or {}
     architecture_feedback = serialized.get("architecture_feedback") or {}
+    graph_design_feedback = serialized.get("graph_design_feedback") or {}
+    graph_exports = serialized.get("graph_exports") or {}
 
     manifest: Dict[str, Any] = {
         "prompt": prompt,
@@ -874,9 +936,12 @@ async def generate_artifacts(
         "plan_title": plan_title,
         "requirements_feedback": requirements_feedback,
         "architecture_feedback": architecture_feedback,
+        "graph_design_feedback": graph_design_feedback,
+        "graph_exports": graph_exports,
         "warnings": [
             *_requirements_warning_entries(requirements_feedback),
             *_architecture_warning_entries(architecture_feedback),
+            *_graph_design_warning_entries(graph_design_feedback),
         ],
         "export_results": {},
     }

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -31,14 +31,17 @@ from langgraph_system_generator.generator.architecture_registry import (
 )
 from langgraph_system_generator.generator.graph_design_registry import (
     build_graph_exports,
+    graph_design_issue_messages,
     get_graph_design_registry,
     normalize_graph_design,
+    validate_graph_design,
 )
 from langgraph_system_generator.utils.error_handling import GenerationError
 from langgraph_system_generator.utils.config import GenerationConfig, settings
 from langgraph_system_generator.utils.generation_options import (
     SUPPORTED_AGENT_TYPES,
     normalize_agent_type,
+    resolve_architecture_type,
 )
 from langgraph_system_generator.utils.optional_deps import (
     OptionalDependencyError,
@@ -552,9 +555,36 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
         architecture_type,
         graph_registration,
     )
-    graph_exports = build_graph_exports(graph_design, graph_registration)
+    graph_design_issues = validate_graph_design(graph_design, graph_registration)
+    graph_design_errors = graph_design_issue_messages(
+        graph_design_issues, severity="error"
+    )
+    graph_design_warnings = graph_design_issue_messages(
+        graph_design_issues, severity="warning"
+    )
+    if graph_design_errors:
+        raise GenerationError(
+            "Stub graph design produced an invalid workflow and could not be exported safely.",
+            code="stub_graph_design_invalid",
+            phase="graph_design",
+            hint="Inspect the graph design fallback builder or registration for this architecture.",
+            details={
+                "architecture_type": architecture_type,
+                "validation_errors": graph_design_errors,
+            },
+            status_code=500,
+        )
+    graph_exports = build_graph_exports(
+        graph_design,
+        graph_registration,
+        graph_design_issues,
+        graph_design_warnings,
+    )
     graph_design_feedback = GraphDesignFeedback(
         fallback_used=False,
+        validation_errors=graph_design_errors,
+        warnings=graph_design_warnings,
+        validation_issues=graph_design_issues,
         composition_strategy=graph_registration.composition_strategy,
     )
     workflow_design = graph_design.to_workflow_design_payload()
@@ -914,11 +944,10 @@ async def generate_artifacts(
     tracker.start("serialize", "Serializing generation results...", percentage=62)
     serialized = _serialize(result)
     tracker.finish("serialize", "Serialized generation results.", percentage=64)
-    if "architecture_type" in serialized and serialized.get("architecture_type"):
-        architecture_type = serialized.get("architecture_type")
-    else:
-        selected_patterns = serialized.get("selected_patterns") or {}
-        architecture_type = selected_patterns.get("primary") or "router"
+    architecture_type = resolve_architecture_type(
+        serialized.get("architecture_type"),
+        serialized.get("selected_patterns") or {},
+    )
 
     plan_title = (
         serialized.get("notebook_plan", {}).get("title") or "Generated Notebook"

--- a/src/langgraph_system_generator/generator/agents/graph_designer.py
+++ b/src/langgraph_system_generator/generator/agents/graph_designer.py
@@ -2,243 +2,291 @@
 
 from __future__ import annotations
 
+import importlib
+import logging
 from typing import Any, Dict, List
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
+from pydantic import ValidationError
 
 from langgraph_system_generator.generator.agents._llm import build_chat_llm
-from langgraph_system_generator.generator.state import Constraint
+from langgraph_system_generator.generator.graph_design_registry import (
+    GraphDesignRegistration,
+    GraphDesignRegistry,
+    build_graph_exports,
+    get_graph_design_registry,
+    graph_design_issue_messages,
+    normalize_graph_design,
+    validate_graph_design,
+)
+from langgraph_system_generator.generator.state import (
+    Constraint,
+    GraphDesignFeedback,
+    GraphDesignResult,
+)
 from langgraph_system_generator.generator.utils import extract_json_from_llm_response
-from langgraph_system_generator.utils.config import ModelConfig
+from langgraph_system_generator.utils.config import ModelConfig, settings
+from langgraph_system_generator.utils.error_handling import GenerationError
+
+logger = logging.getLogger(__name__)
 
 
 class GraphDesigner:
-    """Designs the inner workflow state, nodes, and edges."""
+    """Design the workflow graph for the selected architecture."""
 
     def __init__(
         self,
         model: str | None = None,
         model_config: ModelConfig | None = None,
+        registry: GraphDesignRegistry | None = None,
     ):
         self.llm = build_chat_llm(
             model=model,
             model_config=model_config,
             chat_openai_class=ChatOpenAI,
         )
+        if registry is None:
+            plugin_modules = tuple(settings.graph_designer_plugin_modules)
+            if plugin_modules:
+                importlib.invalidate_caches()
+            self.registry = get_graph_design_registry(plugin_modules=plugin_modules)
+        else:
+            self.registry = registry
 
     async def design_workflow(
         self, architecture: Dict[str, Any], constraints: List[Constraint]
-    ) -> Dict[str, Any]:
-        """Create complete graph specification.
+    ) -> GraphDesignResult:
+        """Create a complete, validated graph specification."""
 
-        Args:
-            architecture: Selected architecture from ArchitectureSelector
-            constraints: Project constraints
-
-        Returns:
-            Dictionary with state_schema, nodes, edges, conditional_logic, etc.
-        """
-        architecture_type = architecture.get("architecture_type", "router")
-        justification = architecture.get("justification", "")
+        architecture_type = str(
+            architecture.get("architecture_type")
+            or architecture.get("selected_patterns", {}).get("primary")
+            or "router"
+        ).strip().lower()
+        registration = self._registration_for(architecture_type)
         selected_patterns = architecture.get("selected_patterns", {}) or {}
-        secondary_patterns = selected_patterns.get("secondary", [])
+        secondary_patterns = list(selected_patterns.get("secondary") or [])
+        justification = architecture.get("justification", "")
 
         constraints_text = "\n".join(
-            [f"- [{c.type}] {c.value} (priority: {c.priority})" for c in constraints]
+            [
+                f"- [{constraint.type}] {constraint.value} (priority: {constraint.priority})"
+                for constraint in constraints
+            ]
         )
 
-        design_prompt = SystemMessage(content="""You are a LangGraph workflow designer.
-Design a complete graph specification for the given architecture type.
+        design_prompt = SystemMessage(
+            content=(
+                "You are a LangGraph workflow designer.\n"
+                "Design a complete graph specification for the requested architecture.\n\n"
+                f"Architecture id: {registration.architecture_id}\n"
+                f"Supported entry shapes: {registration.supported_entry_shapes}\n"
+                f"Supported exit shapes: {registration.supported_exit_shapes}\n"
+                f"Composition strategy: {registration.composition_strategy}\n"
+                f"Cycles allowed: {registration.cycles_allowed}\n\n"
+                "For the workflow, specify:\n"
+                "1. state_schema: TypedDict fields needed for the workflow\n"
+                "2. nodes: List of node names and their purposes\n"
+                "3. edges: Direct edges between nodes\n"
+                "4. conditional_edges: Conditional routing logic with conditions\n"
+                "5. entry_point: Starting node\n"
+                "6. checkpointing: Whether to enable checkpointing\n\n"
+                "Return a JSON object with this structure:\n"
+                "{\n"
+                '  "state_schema": {"field_name": "description"},\n'
+                '  "nodes": [{"name": "node_name", "purpose": "description"}],\n'
+                '  "edges": [{"from": "node_a", "to": "node_b"}],\n'
+                '  "conditional_edges": [\n'
+                "    {\n"
+                '      "from": "node_name",\n'
+                '      "condition": "condition_description",\n'
+                '      "branches": {"branch_name": "target_node", "FINISH": "END"}\n'
+                "    }\n"
+                "  ],\n"
+                '  "entry_point": "start_node",\n'
+                '  "checkpointing": true\n'
+                "}\n"
+            )
+        )
 
-Supported architecture types include router, subagents, hybrid, and autoagent.
-For autoagent, use a coordinator + worker-team shape with explicit planning,
-execution, and critique/review responsibilities.
+        user_message = HumanMessage(
+            content=(
+                f"Architecture Type: {architecture_type}\n"
+                f"Architecture Justification: {justification}\n"
+                f"Selected Patterns: primary={selected_patterns.get('primary', architecture_type)}, "
+                f"secondary={secondary_patterns}\n\n"
+                f"Requirements:\n{constraints_text}\n\n"
+                "Design the workflow graph."
+            )
+        )
 
-For the workflow, specify:
-1. **state_schema**: TypedDict fields needed for the workflow
-2. **nodes**: List of node names and their purposes
-3. **edges**: Direct edges between nodes
-4. **conditional_edges**: Conditional routing logic with conditions
-5. **entry_point**: Starting node
-6. **checkpointing**: Whether to enable checkpointing
-
-Return a JSON object with this structure:
-{
-  "state_schema": {
-    "field_name": "description",
-    ...
-  },
-  "nodes": [
-    {"name": "node_name", "purpose": "description"},
-    ...
-  ],
-  "edges": [
-    {"from": "node_a", "to": "node_b"},
-    ...
-  ],
-  "conditional_edges": [
-    {
-      "from": "node_name",
-      "condition": "condition_description",
-      "branches": {"branch_name": "target_node", ...}
-    },
-    ...
-  ],
-  "entry_point": "start_node",
-  "checkpointing": true
-}""")
-
-        user_message = HumanMessage(content=f"""Architecture Type: {architecture_type}
-Architecture Justification: {justification}
-Selected Patterns: primary={selected_patterns.get("primary", architecture_type)}, secondary={secondary_patterns}
-
-Requirements:
-{constraints_text}
-
-Design the workflow graph.""")
-
-        response = await self.llm.ainvoke([design_prompt, user_message])
+        live_issues = []
+        fallback_reason: str | None = None
 
         try:
-            result = extract_json_from_llm_response(response.content)
-            if selected_patterns.get("primary") == "hybrid":
-                result.setdefault("selected_patterns", selected_patterns)
-            return result
-        except (ValueError, KeyError, TypeError):
-            # Fallback to a basic workflow
-            return self._fallback_design(architecture_type)
-
-    def _fallback_design(self, architecture_type: str) -> Dict[str, Any]:
-        """Provide a fallback design if LLM parsing fails."""
-        if architecture_type == "hybrid":
-            return {
-                "state_schema": {
-                    "messages": "List of messages",
-                    "route": "Selected router branch",
-                    "next_agent": "Next worker to call when the team path is chosen",
-                    "instructions": "Supervisor guidance for the selected worker",
-                    "results": "Direct specialist outputs",
-                    "task_results": "Worker-team outputs",
-                },
-                "nodes": [
-                    {"name": "router", "purpose": "Route to a direct specialist or the team path"},
-                    {
-                        "name": "specialist_1",
-                        "purpose": "Handle direct specialist work without team coordination",
-                    },
-                    {
-                        "name": "supervisor",
-                        "purpose": "Coordinate the worker team when deeper collaboration is needed",
-                    },
-                    {
-                        "name": "researcher",
-                        "purpose": "Gather supporting facts and intermediate context",
-                    },
-                    {
-                        "name": "reviewer",
-                        "purpose": "Review worker output and request refinements before finishing",
-                    },
-                    {
-                        "name": "finish",
-                        "purpose": "Synthesize final results from all branches",
-                    },
-                ],
-                "edges": [
-                    {"from": "specialist_1", "to": "finish"},
-                    {"from": "researcher", "to": "supervisor"},
-                    {"from": "reviewer", "to": "supervisor"},
-                ],
-                "conditional_edges": [
-                    {
-                        "from": "router",
-                        "condition": "Route to a direct specialist or the worker team",
-                        "branches": {
-                            "specialist_1": "specialist_1",
-                            "team_path": "supervisor",
-                        },
-                    },
-                    {
-                        "from": "supervisor",
-                        "condition": "Route to next worker or finish after synthesis",
-                        "branches": {
-                            "researcher": "researcher",
-                            "reviewer": "reviewer",
-                            "FINISH": "finish",
-                        },
-                    },
-                ],
-                "entry_point": "router",
-                "checkpointing": True,
-            }
-        if architecture_type in {"subagents", "autoagent"}:
-            coordinator_name = (
-                "coordinator" if architecture_type == "autoagent" else "supervisor"
+            response = await self.llm.ainvoke([design_prompt, user_message])
+            payload = extract_json_from_llm_response(response.content)
+            live_result = normalize_graph_design(payload, architecture_type, registration)
+            live_issues = validate_graph_design(live_result, registration)
+            if self._has_blocking_issues(live_issues):
+                fallback_reason = "Live graph design validation failed."
+                logger.warning(
+                    "Graph design validation failed for %s: %s",
+                    architecture_type,
+                    graph_design_issue_messages(live_issues),
+                )
+                return self._finalize_fallback(
+                    registration,
+                    architecture,
+                    constraints,
+                    fallback_reason=fallback_reason,
+                    live_issues=live_issues,
+                )
+            return self._finalize_result(
+                live_result,
+                registration,
+                fallback_used=False,
+                fallback_reason=None,
+                validation_issues=live_issues,
             )
-            return {
-                "state_schema": {
-                    "messages": "List of messages",
-                    "next_agent": "Next worker to call",
-                    "instructions": "Coordinator guidance for the selected worker",
-                    "task_results": "Merged worker outputs",
+        except (ValueError, KeyError, TypeError, ValidationError) as exc:
+            fallback_reason = f"Graph design parsing failed: {exc}"
+            logger.warning(
+                "Graph design parsing failed for %s: %s",
+                architecture_type,
+                exc,
+            )
+            return self._finalize_fallback(
+                registration,
+                architecture,
+                constraints,
+                fallback_reason=fallback_reason,
+                live_issues=live_issues,
+            )
+
+    def _registration_for(self, architecture_type: str) -> GraphDesignRegistration:
+        """Return the registry entry for the selected architecture."""
+
+        try:
+            return self.registry.get(architecture_type)
+        except KeyError as exc:
+            raise GenerationError(
+                f"Unsupported graph design architecture '{architecture_type}'.",
+                code="unsupported_graph_architecture",
+                phase="graph_design",
+                hint="Select a registered architecture type before graph design.",
+                details={
+                    "architecture_type": architecture_type,
+                    "supported_architecture_types": self.registry.supported_architecture_types(),
                 },
-                "nodes": [
-                    {
-                        "name": coordinator_name,
-                        "purpose": "Coordinate worker delegation and synthesis",
-                    },
-                    {
-                        "name": "planner",
-                        "purpose": "Break down goals into executable steps",
-                    },
-                    {
-                        "name": "executor",
-                        "purpose": "Execute planned steps and produce outputs",
-                    },
-                    {
-                        "name": "critic",
-                        "purpose": "Review output quality and request refinements",
-                    },
-                ],
-                "edges": [],
-                "conditional_edges": [
-                    {
-                        "from": coordinator_name,
-                        "condition": "Route to next worker",
-                        "branches": {
-                            "planner": "planner",
-                            "executor": "executor",
-                            "critic": "critic",
-                            "FINISH": "END",
-                        },
-                    }
-                ],
-                "entry_point": coordinator_name,
-                "checkpointing": True,
-            }
-        else:
-            # Router fallback
-            return {
-                "state_schema": {
-                    "messages": "List of messages",
-                    "route": "Selected route",
+                status_code=400,
+            ) from exc
+
+    def _finalize_result(
+        self,
+        result: GraphDesignResult,
+        registration: GraphDesignRegistration,
+        *,
+        fallback_used: bool,
+        fallback_reason: str | None,
+        validation_issues: List[Any],
+        warnings: List[str] | None = None,
+    ) -> GraphDesignResult:
+        """Attach feedback and exports to the normalized graph design."""
+
+        warning_messages = list(warnings or [])
+        warning_messages.extend(
+            graph_design_issue_messages(validation_issues, severity="warning")
+        )
+        warning_messages = list(dict.fromkeys(warning_messages))
+        feedback = GraphDesignFeedback(
+            fallback_used=fallback_used,
+            fallback_reason=fallback_reason,
+            validation_errors=graph_design_issue_messages(
+                validation_issues, severity="error"
+            ),
+            warnings=warning_messages,
+            validation_issues=validation_issues,
+            composition_strategy=registration.composition_strategy,
+        )
+        exports = build_graph_exports(
+            result,
+            registration,
+            validation_issues,
+            warning_messages,
+        )
+        return result.model_copy(update={"feedback": feedback, "exports": exports})
+
+    def _finalize_fallback(
+        self,
+        registration: GraphDesignRegistration,
+        architecture: Dict[str, Any],
+        constraints: List[Constraint],
+        *,
+        fallback_reason: str,
+        live_issues: List[Any],
+    ) -> GraphDesignResult:
+        """Build, validate, and return the deterministic fallback graph design."""
+
+        fallback_payload = self._fallback_design(
+            registration.architecture_id,
+            architecture=architecture,
+            constraints=constraints,
+        )
+        fallback_result = normalize_graph_design(
+            fallback_payload,
+            registration.architecture_id,
+            registration,
+        )
+        fallback_issues = validate_graph_design(fallback_result, registration)
+        if self._has_blocking_issues(fallback_issues):
+            blocking_messages = graph_design_issue_messages(
+                fallback_issues, severity="error"
+            )
+            raise GenerationError(
+                (
+                    "Graph designer fallback produced an invalid workflow and could not "
+                    "recover safely."
+                ),
+                code="graph_design_fallback_invalid",
+                phase="graph_design",
+                hint="Inspect the fallback builder or registry registration for this architecture.",
+                details={
+                    "architecture_type": registration.architecture_id,
+                    "fallback_reason": fallback_reason,
+                    "validation_errors": blocking_messages,
                 },
-                "nodes": [
-                    {"name": "router", "purpose": "Route to specialist"},
-                    {"name": "specialist_1", "purpose": "Specialist function 1"},
-                    {"name": "specialist_2", "purpose": "Specialist function 2"},
-                ],
-                "edges": [],
-                "conditional_edges": [
-                    {
-                        "from": "router",
-                        "condition": "Route based on input",
-                        "branches": {
-                            "specialist_1": "specialist_1",
-                            "specialist_2": "specialist_2",
-                        },
-                    }
-                ],
-                "entry_point": "router",
-                "checkpointing": False,
-            }
+                status_code=500,
+            )
+
+        warnings = [f"Recovered using deterministic {registration.architecture_id} fallback."]
+        return self._finalize_result(
+            fallback_result,
+            registration,
+            fallback_used=True,
+            fallback_reason=fallback_reason,
+            validation_issues=[*live_issues, *fallback_issues],
+            warnings=warnings,
+        )
+
+    @staticmethod
+    def _has_blocking_issues(validation_issues: List[Any]) -> bool:
+        """Return True when validation includes blocking errors."""
+
+        return any(issue.severity == "error" for issue in validation_issues)
+
+    def _fallback_design(
+        self,
+        architecture_type: str,
+        *,
+        architecture: Dict[str, Any] | None = None,
+        constraints: List[Constraint] | None = None,
+    ) -> Dict[str, Any]:
+        """Provide a deterministic registry-backed fallback design."""
+
+        registration = self._registration_for(architecture_type)
+        return registration.fallback_builder(
+            architecture=architecture or {},
+            constraints=constraints or [],
+        )

--- a/src/langgraph_system_generator/generator/agents/graph_designer.py
+++ b/src/langgraph_system_generator/generator/agents/graph_designer.py
@@ -28,6 +28,7 @@ from langgraph_system_generator.generator.state import (
 from langgraph_system_generator.generator.utils import extract_json_from_llm_response
 from langgraph_system_generator.utils.config import ModelConfig, settings
 from langgraph_system_generator.utils.error_handling import GenerationError
+from langgraph_system_generator.utils.generation_options import resolve_architecture_type
 
 logger = logging.getLogger(__name__)
 
@@ -59,13 +60,12 @@ class GraphDesigner:
     ) -> GraphDesignResult:
         """Create a complete, validated graph specification."""
 
-        architecture_type = str(
-            architecture.get("architecture_type")
-            or architecture.get("selected_patterns", {}).get("primary")
-            or "router"
-        ).strip().lower()
-        registration = self._registration_for(architecture_type)
         selected_patterns = architecture.get("selected_patterns", {}) or {}
+        architecture_type = resolve_architecture_type(
+            architecture.get("architecture_type"),
+            selected_patterns,
+        )
+        registration = self._registration_for(architecture_type)
         secondary_patterns = list(selected_patterns.get("secondary") or [])
         justification = architecture.get("justification", "")
 

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -112,7 +112,11 @@ class NotebookComposer:
 
         # Title and intro cells
         cells.extend(
-            self._create_intro_cells(notebook_plan, architecture.get("justification"))
+            self._create_intro_cells(
+                notebook_plan,
+                architecture.get("justification"),
+                workflow_design.get("graph_exports"),
+            )
         )
 
         # Installation cells
@@ -140,7 +144,10 @@ class NotebookComposer:
         return cells
 
     def _create_intro_cells(
-        self, plan: NotebookPlan, justification: str | None
+        self,
+        plan: NotebookPlan,
+        justification: str | None,
+        graph_exports: Dict[str, Any] | None = None,
     ) -> List[CellSpec]:
         """Create title and introduction cells."""
         title_cell = CellSpec(
@@ -172,7 +179,41 @@ This notebook implements a LangGraph workflow using the **{plan.architecture_typ
             section="intro",
         )
 
-        return [title_cell, overview_cell]
+        cells = [title_cell, overview_cell]
+
+        if isinstance(graph_exports, dict):
+            mermaid = str(graph_exports.get("mermaid", "")).strip()
+            schema = graph_exports.get("schema", {})
+            if mermaid or schema:
+                graph_overview_lines = ["## Graph Overview", ""]
+                if mermaid:
+                    graph_overview_lines.extend(
+                        [
+                            "```mermaid",
+                            mermaid,
+                            "```",
+                            "",
+                        ]
+                    )
+                if schema:
+                    graph_overview_lines.extend(
+                        [
+                            "### Workflow Schema",
+                            "",
+                            "```json",
+                            json.dumps(schema, indent=2),
+                            "```",
+                        ]
+                    )
+                cells.append(
+                    CellSpec(
+                        cell_type="markdown",
+                        content="\n".join(graph_overview_lines),
+                        section="intro",
+                    )
+                )
+
+        return cells
 
     def _create_install_cells(self, tools: List[Dict[str, Any]]) -> List[CellSpec]:
         """Create installation cells."""

--- a/src/langgraph_system_generator/generator/graph_design_registry.py
+++ b/src/langgraph_system_generator/generator/graph_design_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter, deque
 from dataclasses import dataclass, field
 from functools import lru_cache
 import importlib
@@ -69,6 +70,25 @@ def _mermaid_id(value: str) -> str:
     if slug[0].isdigit():
         slug = f"n_{slug}"
     return slug
+
+
+def _mermaid_label(value: str) -> str:
+    """Return Mermaid-safe label text for node and edge annotations."""
+
+    text = str(value or "").replace("\r\n", "\n").replace("\r", "\n").strip()
+    if not text:
+        return ""
+    return (
+        text.replace("&", "&amp;")
+        .replace('"', "&quot;")
+        .replace("[", "&#91;")
+        .replace("]", "&#93;")
+        .replace("{", "&#123;")
+        .replace("}", "&#125;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\n", "<br/>")
+    )
 
 
 def _issue(
@@ -420,15 +440,15 @@ def _reachable_nodes(result: GraphDesignResult) -> set[str]:
         return set()
 
     seen: set[str] = set()
-    queue = [result.entry_point]
+    queue = deque([result.entry_point])
     while queue:
-        current = queue.pop(0)
+        current = queue.popleft()
         if current in seen:
             continue
         seen.add(current)
-        queue.extend(
-            target for target in adjacency.get(current, set()) if target not in seen
-        )
+        for target in adjacency.get(current, set()):
+            if target not in seen:
+                queue.append(target)
     return seen
 
 
@@ -479,6 +499,7 @@ def validate_graph_design(
 
     issues: list[GraphValidationIssue] = []
     node_names = [node.name for node in result.nodes]
+    duplicate_counts = Counter(node_names)
     node_id_set = set(node_names)
 
     if not result.entry_point:
@@ -498,7 +519,7 @@ def validate_graph_design(
         )
 
     duplicate_node_ids = sorted(
-        {node_name for node_name in node_names if node_names.count(node_name) > 1}
+        node_name for node_name, count in duplicate_counts.items() if count > 1
     )
     for node_id in duplicate_node_ids:
         issues.append(
@@ -627,7 +648,7 @@ def build_graph_exports(
     mermaid_lines = ["flowchart TD", f"    START([START]) --> {_mermaid_id(result.entry_point)}"]
     for node in result.nodes:
         mermaid_lines.append(
-            f'    {_mermaid_id(node.name)}["{node.name}: {node.purpose}"]'
+            f'    {_mermaid_id(node.name)}["{_mermaid_label(f"{node.name}: {node.purpose}")}"]'
         )
     for edge in result.edges:
         mermaid_lines.append(
@@ -637,7 +658,7 @@ def build_graph_exports(
         for branch_label, target in conditional_edge.branches.items():
             target_id = "END" if target in END_TARGETS else _mermaid_id(target)
             mermaid_lines.append(
-                f'    {_mermaid_id(conditional_edge.source)} -- "{branch_label}" --> {target_id}'
+                f'    {_mermaid_id(conditional_edge.source)} -- "{_mermaid_label(branch_label)}" --> {target_id}'
             )
     mermaid_lines.append("    END([END])")
 
@@ -689,7 +710,7 @@ def _default_registrations() -> list[GraphDesignRegistration]:
             architecture_id="hybrid",
             supported_entry_shapes=["router"],
             supported_exit_shapes=["finish"],
-            cycles_allowed=False,
+            cycles_allowed=True,
             fallback_builder=_build_hybrid_fallback,
             export_label_defaults={"title": "Hybrid Workflow"},
             composition_strategy="router_plus_team",
@@ -724,14 +745,26 @@ def _load_plugin_modules(
     """Load plugin registrations into a cloned registry."""
 
     for module_name in plugin_modules:
-        module = importlib.import_module(module_name)
+        try:
+            module = importlib.import_module(module_name)
+        except Exception as exc:
+            raise ValueError(
+                f"Failed to import graph design plugin module '{module_name}': "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
         register = getattr(module, "register_graph_designers", None)
         if not callable(register):
             raise ValueError(
                 f"Graph design plugin module '{module_name}' must define register_graph_designers(registry)."
             )
         hook: PluginHook = register
-        hook(registry)
+        try:
+            hook(registry)
+        except Exception as exc:
+            raise ValueError(
+                f"Graph design plugin module '{module_name}' failed while running "
+                f"register_graph_designers(registry): {type(exc).__name__}: {exc}"
+            ) from exc
     return registry
 
 

--- a/src/langgraph_system_generator/generator/graph_design_registry.py
+++ b/src/langgraph_system_generator/generator/graph_design_registry.py
@@ -1,0 +1,769 @@
+"""Registry, normalization, validation, and exports for graph design."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+import importlib
+import re
+from typing import Any, Callable, Iterable, Mapping
+
+from langgraph_system_generator.generator.state import (
+    GraphConditionalEdgeSpec,
+    GraphDesignResult,
+    GraphEdgeSpec,
+    GraphExportBundle,
+    GraphNodeSpec,
+    GraphValidationIssue,
+)
+from langgraph_system_generator.utils.config import settings
+
+END_TARGETS = {"END", "__end__"}
+PluginHook = Callable[["GraphDesignRegistry"], None]
+FallbackBuilder = Callable[..., dict[str, Any]]
+NormalizationHook = Callable[[GraphDesignResult], GraphDesignResult]
+ValidationHook = Callable[[GraphDesignResult], list[GraphValidationIssue]]
+
+
+def _normalize_architecture_id(value: str) -> str:
+    """Return a normalized architecture identifier."""
+
+    normalized = str(value or "").strip().lower()
+    if not normalized:
+        raise ValueError(
+            "Graph design registrations must include a non-empty architecture_id."
+        )
+    return normalized
+
+
+def _normalize_string_list(values: Iterable[str] | None) -> list[str]:
+    """Return an ordered, de-duplicated list of non-empty strings."""
+
+    normalized_values: list[str] = []
+    for raw_value in values or []:
+        normalized = str(raw_value or "").strip()
+        if normalized and normalized not in normalized_values:
+            normalized_values.append(normalized)
+    return normalized_values
+
+
+def _normalize_mapping(values: Mapping[str, Any] | None) -> dict[str, str]:
+    """Return a stringified mapping with trimmed keys and values."""
+
+    normalized: dict[str, str] = {}
+    for raw_key, raw_value in (values or {}).items():
+        key = str(raw_key or "").strip()
+        value = str(raw_value or "").strip()
+        if key:
+            normalized[key] = value
+    return normalized
+
+
+def _mermaid_id(value: str) -> str:
+    """Return a Mermaid-safe identifier derived from a node id."""
+
+    slug = re.sub(r"[^a-zA-Z0-9_]", "_", str(value or "").strip())
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    if not slug:
+        slug = "node"
+    if slug[0].isdigit():
+        slug = f"n_{slug}"
+    return slug
+
+
+def _issue(
+    code: str,
+    message: str,
+    *,
+    severity: str = "error",
+    nodes: Iterable[str] | None = None,
+) -> GraphValidationIssue:
+    """Create a normalized validation issue."""
+
+    return GraphValidationIssue(
+        code=code,
+        message=message,
+        severity="warning" if severity == "warning" else "error",
+        nodes=[str(node) for node in nodes or [] if str(node or "").strip()],
+    )
+
+
+def _build_router_fallback(*_args, **_kwargs) -> dict[str, Any]:
+    """Return the deterministic fallback router design."""
+
+    return {
+        "state_schema": {
+            "messages": "List of messages",
+            "route": "Selected route",
+            "results": "Outputs grouped by direct specialist",
+            "final_output": "Final synthesized answer",
+        },
+        "nodes": [
+            {"name": "router", "purpose": "Route the request to the best specialist"},
+            {
+                "name": "specialist_1",
+                "purpose": "Handle the first specialist pathway directly",
+            },
+            {
+                "name": "specialist_2",
+                "purpose": "Handle the second specialist pathway directly",
+            },
+        ],
+        "edges": [],
+        "conditional_edges": [
+            {
+                "from": "router",
+                "condition": "Dispatch by selected route",
+                "branches": {
+                    "specialist_1": "specialist_1",
+                    "specialist_2": "specialist_2",
+                },
+            }
+        ],
+        "entry_point": "router",
+        "checkpointing": False,
+    }
+
+
+def _build_supervisor_fallback(
+    *,
+    coordinator_name: str,
+    worker_names: list[str],
+    state_schema: Mapping[str, str],
+) -> dict[str, Any]:
+    """Return a deterministic coordinator-plus-workers design."""
+
+    return {
+        "state_schema": dict(state_schema),
+        "nodes": [
+            {
+                "name": coordinator_name,
+                "purpose": "Coordinate worker delegation and synthesis",
+            },
+            *[
+                {
+                    "name": worker_name,
+                    "purpose": f"{worker_name.title()} specialist worker",
+                }
+                for worker_name in worker_names
+            ],
+        ],
+        "edges": [],
+        "conditional_edges": [
+            {
+                "from": coordinator_name,
+                "condition": "Route to the next worker or finish once synthesis is complete",
+                "branches": {
+                    **{worker_name: worker_name for worker_name in worker_names},
+                    "FINISH": "END",
+                },
+            }
+        ],
+        "entry_point": coordinator_name,
+        "checkpointing": True,
+    }
+
+
+def _build_subagents_fallback(*_args, **_kwargs) -> dict[str, Any]:
+    """Return the deterministic fallback subagents design."""
+
+    return _build_supervisor_fallback(
+        coordinator_name="supervisor",
+        worker_names=["planner", "executor", "critic"],
+        state_schema={
+            "messages": "List of messages",
+            "next_agent": "Next worker to call",
+            "instructions": "Supervisor guidance for the selected worker",
+            "task_results": "Merged worker outputs",
+            "dispatch_log": "History of dispatched workers",
+            "iterations": "Current supervisor iteration count",
+        },
+    )
+
+
+def _build_autoagent_fallback(*_args, **_kwargs) -> dict[str, Any]:
+    """Return the deterministic fallback autoagent design."""
+
+    return _build_supervisor_fallback(
+        coordinator_name="coordinator",
+        worker_names=["planner", "executor", "critic"],
+        state_schema={
+            "messages": "List of messages",
+            "next_agent": "Next worker to call",
+            "instructions": "Coordinator guidance for the selected worker",
+            "task_results": "Merged worker outputs",
+            "dispatch_log": "History of dispatched workers",
+            "iterations": "Current coordinator iteration count",
+        },
+    )
+
+
+def _build_hybrid_fallback(*_args, **_kwargs) -> dict[str, Any]:
+    """Return the deterministic fallback hybrid design."""
+
+    return {
+        "state_schema": {
+            "messages": "List of messages",
+            "route": "Selected router branch",
+            "results": "Outputs grouped by direct specialist",
+            "next_agent": "Next worker to call when the team path is chosen",
+            "instructions": "Supervisor guidance for the selected worker",
+            "task_results": "Worker-team outputs",
+            "dispatch_log": "History of direct and team path routing",
+            "iterations": "Current supervisor iteration count",
+            "final_output": "Final synthesized answer",
+        },
+        "nodes": [
+            {
+                "name": "router",
+                "purpose": "Route to a direct specialist or the supervisor-led team path",
+            },
+            {
+                "name": "specialist_1",
+                "purpose": "Handle direct specialist work without team coordination",
+            },
+            {
+                "name": "supervisor",
+                "purpose": "Coordinate the worker team when deeper collaboration is needed",
+            },
+            {
+                "name": "researcher",
+                "purpose": "Gather supporting facts and intermediate context",
+            },
+            {
+                "name": "reviewer",
+                "purpose": "Review worker output before the final synthesis",
+            },
+            {
+                "name": "finish",
+                "purpose": "Synthesize final results from both direct and team branches",
+            },
+        ],
+        "edges": [
+            {"from": "specialist_1", "to": "finish"},
+            {"from": "researcher", "to": "supervisor"},
+            {"from": "reviewer", "to": "supervisor"},
+        ],
+        "conditional_edges": [
+            {
+                "from": "router",
+                "condition": "Route to a direct specialist or the worker team",
+                "branches": {
+                    "specialist_1": "specialist_1",
+                    "team_path": "supervisor",
+                },
+            },
+            {
+                "from": "supervisor",
+                "condition": "Route to the next worker or finish after synthesis",
+                "branches": {
+                    "researcher": "researcher",
+                    "reviewer": "reviewer",
+                    "FINISH": "finish",
+                },
+            },
+        ],
+        "entry_point": "router",
+        "checkpointing": True,
+    }
+
+
+@dataclass(frozen=True)
+class GraphDesignRegistration:
+    """Metadata describing a supported graph design architecture."""
+
+    architecture_id: str
+    supported_entry_shapes: list[str] = field(default_factory=list)
+    supported_exit_shapes: list[str] = field(default_factory=list)
+    cycles_allowed: bool = False
+    fallback_builder: FallbackBuilder = _build_router_fallback
+    normalization_hook: NormalizationHook | None = None
+    validation_hook: ValidationHook | None = None
+    export_label_defaults: dict[str, str] = field(default_factory=dict)
+    composition_strategy: str = "deterministic"
+
+    def normalized(self) -> "GraphDesignRegistration":
+        """Return a normalized copy suitable for registry storage."""
+
+        architecture_id = _normalize_architecture_id(self.architecture_id)
+        if not callable(self.fallback_builder):
+            raise ValueError(
+                f"Graph design registration '{architecture_id}' must include a callable fallback_builder."
+            )
+        composition_strategy = str(self.composition_strategy or "").strip()
+        if not composition_strategy:
+            raise ValueError(
+                f"Graph design registration '{architecture_id}' must include a composition_strategy."
+            )
+        return GraphDesignRegistration(
+            architecture_id=architecture_id,
+            supported_entry_shapes=_normalize_string_list(self.supported_entry_shapes),
+            supported_exit_shapes=_normalize_string_list(self.supported_exit_shapes),
+            cycles_allowed=bool(self.cycles_allowed),
+            fallback_builder=self.fallback_builder,
+            normalization_hook=self.normalization_hook,
+            validation_hook=self.validation_hook,
+            export_label_defaults={
+                str(key).strip(): str(value).strip()
+                for key, value in (self.export_label_defaults or {}).items()
+                if str(key).strip()
+            },
+            composition_strategy=composition_strategy,
+        )
+
+
+class GraphDesignRegistry:
+    """Mutable in-memory registry for graph design architectures."""
+
+    def __init__(self, registrations: Iterable[GraphDesignRegistration] | None = None):
+        self._registrations: dict[str, GraphDesignRegistration] = {}
+        for registration in registrations or []:
+            self.register(registration)
+
+    def clone(self) -> "GraphDesignRegistry":
+        """Return a shallow copy of the registry."""
+
+        return GraphDesignRegistry(self._registrations.values())
+
+    def register(self, registration: GraphDesignRegistration) -> GraphDesignRegistration:
+        """Register or replace a graph design entry."""
+
+        normalized = registration.normalized()
+        self._registrations[normalized.architecture_id] = normalized
+        return normalized
+
+    def get(self, architecture_id: str) -> GraphDesignRegistration:
+        """Return a registered graph design entry."""
+
+        return self._registrations[_normalize_architecture_id(architecture_id)]
+
+    def supported_architecture_types(self) -> list[str]:
+        """Return registered architecture identifiers in insertion order."""
+
+        return list(self._registrations.keys())
+
+
+def normalize_graph_design(
+    payload: Mapping[str, Any] | GraphDesignResult,
+    architecture_type: str,
+    registration: GraphDesignRegistration,
+) -> GraphDesignResult:
+    """Normalize arbitrary graph-design payloads into typed output."""
+
+    if isinstance(payload, GraphDesignResult):
+        result = payload.model_copy(
+            update={"architecture_type": _normalize_architecture_id(architecture_type)}
+        )
+    else:
+        state_schema = _normalize_mapping(payload.get("state_schema"))
+        nodes = [
+            GraphNodeSpec(
+                name=str(node.get("name", "")).strip(),
+                purpose=str(
+                    node.get("purpose", "")
+                    or f"Handle {str(node.get('name', '')).strip()} work."
+                ).strip(),
+            )
+            for node in list(payload.get("nodes") or [])
+            if str(node.get("name", "")).strip()
+        ]
+        edges = [
+            GraphEdgeSpec.model_validate(edge)
+            for edge in list(payload.get("edges") or [])
+        ]
+        conditional_edges = [
+            GraphConditionalEdgeSpec.model_validate(edge)
+            for edge in list(payload.get("conditional_edges") or [])
+        ]
+        result = GraphDesignResult(
+            architecture_type=_normalize_architecture_id(architecture_type),
+            state_schema=state_schema,
+            nodes=nodes,
+            edges=edges,
+            conditional_edges=conditional_edges,
+            entry_point=str(payload.get("entry_point", "")).strip(),
+            checkpointing=bool(payload.get("checkpointing", False)),
+        )
+
+    if registration.normalization_hook:
+        result = registration.normalization_hook(result)
+
+    return result.model_copy(
+        update={"architecture_type": _normalize_architecture_id(result.architecture_type)}
+    )
+
+
+def _adjacency_map(result: GraphDesignResult) -> dict[str, set[str]]:
+    """Return adjacency among real node ids, excluding END targets."""
+
+    adjacency: dict[str, set[str]] = {node.name: set() for node in result.nodes}
+    for edge in result.edges:
+        if edge.source in adjacency and edge.target in adjacency:
+            adjacency[edge.source].add(edge.target)
+    for conditional_edge in result.conditional_edges:
+        if conditional_edge.source not in adjacency:
+            continue
+        for target in conditional_edge.branches.values():
+            if target not in END_TARGETS and target in adjacency:
+                adjacency[conditional_edge.source].add(target)
+    return adjacency
+
+
+def _reachable_nodes(result: GraphDesignResult) -> set[str]:
+    """Return node ids reachable from the entry point."""
+
+    if not result.entry_point:
+        return set()
+
+    adjacency = _adjacency_map(result)
+    if result.entry_point not in adjacency:
+        return set()
+
+    seen: set[str] = set()
+    queue = [result.entry_point]
+    while queue:
+        current = queue.pop(0)
+        if current in seen:
+            continue
+        seen.add(current)
+        queue.extend(
+            target for target in adjacency.get(current, set()) if target not in seen
+        )
+    return seen
+
+
+def terminal_nodes_for(result: GraphDesignResult) -> list[str]:
+    """Return normalized terminal node ids for the workflow."""
+
+    adjacency = _adjacency_map(result)
+    conditional_end_sources = {
+        conditional_edge.source
+        for conditional_edge in result.conditional_edges
+        if any(target in END_TARGETS for target in conditional_edge.branches.values())
+    }
+    terminal_nodes: list[str] = []
+    for node in result.nodes:
+        if not adjacency.get(node.name) or node.name in conditional_end_sources:
+            if node.name not in terminal_nodes:
+                terminal_nodes.append(node.name)
+    return terminal_nodes
+
+
+def _detect_cycle(adjacency: Mapping[str, set[str]]) -> bool:
+    """Return True when the graph contains a cycle."""
+
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def _visit(node_id: str) -> bool:
+        if node_id in visiting:
+            return True
+        if node_id in visited:
+            return False
+        visiting.add(node_id)
+        for target in adjacency.get(node_id, set()):
+            if _visit(target):
+                return True
+        visiting.remove(node_id)
+        visited.add(node_id)
+        return False
+
+    return any(_visit(node_id) for node_id in adjacency)
+
+
+def validate_graph_design(
+    result: GraphDesignResult,
+    registration: GraphDesignRegistration,
+) -> list[GraphValidationIssue]:
+    """Validate a normalized graph design and return structured issues."""
+
+    issues: list[GraphValidationIssue] = []
+    node_names = [node.name for node in result.nodes]
+    node_id_set = set(node_names)
+
+    if not result.entry_point:
+        issues.append(
+            _issue(
+                "missing_entry_point",
+                "Graph design must include a non-empty entry_point.",
+            )
+        )
+    elif result.entry_point not in node_id_set:
+        issues.append(
+            _issue(
+                "missing_entry_point",
+                f"Entry point '{result.entry_point}' does not match any declared node.",
+                nodes=[result.entry_point],
+            )
+        )
+
+    duplicate_node_ids = sorted(
+        {node_name for node_name in node_names if node_names.count(node_name) > 1}
+    )
+    for node_id in duplicate_node_ids:
+        issues.append(
+            _issue(
+                "duplicate_node_id",
+                f"Duplicate node id '{node_id}'.",
+                nodes=[node_id],
+            )
+        )
+
+    incoming_counts = {node_id: 0 for node_id in node_id_set}
+    for edge in result.edges:
+        if edge.source not in node_id_set:
+            issues.append(
+                _issue(
+                    "unknown_edge_source",
+                    f"Unknown edge source '{edge.source}'.",
+                    nodes=[edge.source],
+                )
+            )
+        if edge.target not in node_id_set:
+            issues.append(
+                _issue(
+                    "unknown_edge_target",
+                    f"Unknown edge target '{edge.target}'.",
+                    nodes=[edge.target],
+                )
+            )
+        if edge.target in incoming_counts:
+            incoming_counts[edge.target] += 1
+
+    for conditional_edge in result.conditional_edges:
+        if conditional_edge.source not in node_id_set:
+            issues.append(
+                _issue(
+                    "unknown_branch_source",
+                    f"Unknown conditional edge source '{conditional_edge.source}'.",
+                    nodes=[conditional_edge.source],
+                )
+            )
+        for branch_label, target in conditional_edge.branches.items():
+            if target in END_TARGETS:
+                continue
+            if target not in node_id_set:
+                issues.append(
+                    _issue(
+                        "unknown_branch_target",
+                        f"Unknown edge target '{target}' for branch '{branch_label}'.",
+                        nodes=[target],
+                    )
+                )
+            elif target in incoming_counts:
+                incoming_counts[target] += 1
+
+    adjacency = _adjacency_map(result)
+    reachable = _reachable_nodes(result)
+    for node in result.nodes:
+        if node.name == result.entry_point:
+            continue
+        if incoming_counts.get(node.name, 0) == 0:
+            issues.append(
+                _issue(
+                    "orphan_node",
+                    f"Node '{node.name}' has no inbound edges or branches.",
+                    severity="warning",
+                    nodes=[node.name],
+                )
+            )
+        if node.name not in reachable:
+            issues.append(
+                _issue(
+                    "unreachable_node",
+                    f"Node '{node.name}' is unreachable from entry point '{result.entry_point}'.",
+                    severity="warning",
+                    nodes=[node.name],
+                )
+            )
+
+    reachable_terminals = [
+        node_id for node_id in terminal_nodes_for(result) if node_id in reachable
+    ]
+    if not reachable_terminals:
+        issues.append(
+            _issue(
+                "missing_terminal_path",
+                "Graph design does not contain a reachable terminal path.",
+            )
+        )
+
+    if not registration.cycles_allowed and _detect_cycle(adjacency):
+        issues.append(
+            _issue(
+                "cycle_detected",
+                (
+                    f"Graph design for architecture '{registration.architecture_id}' "
+                    "contains a cycle, but this architecture does not allow cycles."
+                ),
+            )
+        )
+
+    if registration.validation_hook:
+        issues.extend(registration.validation_hook(result))
+
+    return issues
+
+
+def build_graph_exports(
+    result: GraphDesignResult,
+    registration: GraphDesignRegistration,
+    issues: Iterable[GraphValidationIssue] | None = None,
+    warnings: Iterable[str] | None = None,
+) -> GraphExportBundle:
+    """Build Mermaid and JSON-schema exports for a graph design."""
+
+    issue_list = list(issues or [])
+    warning_messages = list(warnings or [])
+    error_messages = [
+        issue.message for issue in issue_list if issue.severity == "error"
+    ]
+    warning_messages.extend(
+        issue.message
+        for issue in issue_list
+        if issue.severity == "warning" and issue.message not in warning_messages
+    )
+
+    mermaid_lines = ["flowchart TD", f"    START([START]) --> {_mermaid_id(result.entry_point)}"]
+    for node in result.nodes:
+        mermaid_lines.append(
+            f'    {_mermaid_id(node.name)}["{node.name}: {node.purpose}"]'
+        )
+    for edge in result.edges:
+        mermaid_lines.append(
+            f"    {_mermaid_id(edge.source)} --> {_mermaid_id(edge.target)}"
+        )
+    for conditional_edge in result.conditional_edges:
+        for branch_label, target in conditional_edge.branches.items():
+            target_id = "END" if target in END_TARGETS else _mermaid_id(target)
+            mermaid_lines.append(
+                f'    {_mermaid_id(conditional_edge.source)} -- "{branch_label}" --> {target_id}'
+            )
+    mermaid_lines.append("    END([END])")
+
+    schema = {
+        "architecture_type": result.architecture_type,
+        "composition_strategy": registration.composition_strategy,
+        "labels": dict(registration.export_label_defaults),
+        "state_schema": dict(result.state_schema),
+        "nodes": [node.model_dump() for node in result.nodes],
+        "edges": [edge.model_dump(by_alias=True) for edge in result.edges],
+        "conditional_edges": [
+            edge.model_dump(by_alias=True) for edge in result.conditional_edges
+        ],
+        "entry_point": result.entry_point,
+        "checkpointing": result.checkpointing,
+        "terminal_nodes": terminal_nodes_for(result),
+        "validation_summary": {
+            "errors": error_messages,
+            "warnings": warning_messages,
+        },
+    }
+
+    return GraphExportBundle(mermaid="\n".join(mermaid_lines), schema=schema)
+
+
+def _default_registrations() -> list[GraphDesignRegistration]:
+    """Return the built-in graph design catalog."""
+
+    return [
+        GraphDesignRegistration(
+            architecture_id="router",
+            supported_entry_shapes=["router"],
+            supported_exit_shapes=["terminal"],
+            cycles_allowed=False,
+            fallback_builder=_build_router_fallback,
+            export_label_defaults={"title": "Router Workflow"},
+            composition_strategy="router_direct",
+        ),
+        GraphDesignRegistration(
+            architecture_id="subagents",
+            supported_entry_shapes=["supervisor"],
+            supported_exit_shapes=["supervisor_end"],
+            cycles_allowed=False,
+            fallback_builder=_build_subagents_fallback,
+            export_label_defaults={"title": "Supervisor Team Workflow"},
+            composition_strategy="supervisor_team",
+        ),
+        GraphDesignRegistration(
+            architecture_id="hybrid",
+            supported_entry_shapes=["router"],
+            supported_exit_shapes=["finish"],
+            cycles_allowed=False,
+            fallback_builder=_build_hybrid_fallback,
+            export_label_defaults={"title": "Hybrid Workflow"},
+            composition_strategy="router_plus_team",
+        ),
+        GraphDesignRegistration(
+            architecture_id="autoagent",
+            supported_entry_shapes=["coordinator"],
+            supported_exit_shapes=["coordinator_end"],
+            cycles_allowed=False,
+            fallback_builder=_build_autoagent_fallback,
+            export_label_defaults={"title": "AutoAgent Workflow"},
+            composition_strategy="coordinator_team",
+        ),
+    ]
+
+
+def _normalize_plugin_modules(plugin_modules: Iterable[str] | None) -> tuple[str, ...]:
+    """Return normalized plugin module paths for cache keys and loading."""
+
+    normalized: list[str] = []
+    for raw_value in plugin_modules or []:
+        module_name = str(raw_value or "").strip()
+        if module_name and module_name not in normalized:
+            normalized.append(module_name)
+    return tuple(normalized)
+
+
+def _load_plugin_modules(
+    registry: GraphDesignRegistry,
+    plugin_modules: tuple[str, ...],
+) -> GraphDesignRegistry:
+    """Load plugin registrations into a cloned registry."""
+
+    for module_name in plugin_modules:
+        module = importlib.import_module(module_name)
+        register = getattr(module, "register_graph_designers", None)
+        if not callable(register):
+            raise ValueError(
+                f"Graph design plugin module '{module_name}' must define register_graph_designers(registry)."
+            )
+        hook: PluginHook = register
+        hook(registry)
+    return registry
+
+
+@lru_cache(maxsize=16)
+def get_graph_design_registry(
+    plugin_modules: tuple[str, ...] | None = None,
+) -> GraphDesignRegistry:
+    """Return the built-in graph design registry with optional plugin extensions."""
+
+    normalized_modules = _normalize_plugin_modules(
+        settings.graph_designer_plugin_modules
+        if plugin_modules is None
+        else plugin_modules
+    )
+    registry = GraphDesignRegistry(_default_registrations())
+    if normalized_modules:
+        registry = _load_plugin_modules(registry, normalized_modules)
+    return registry
+
+
+def graph_design_issue_messages(
+    issues: Iterable[GraphValidationIssue],
+    *,
+    severity: str | None = None,
+) -> list[str]:
+    """Return validation issue messages filtered by severity when requested."""
+
+    normalized_severity = severity if severity in {"error", "warning"} else None
+    messages: list[str] = []
+    for issue in issues:
+        if normalized_severity and issue.severity != normalized_severity:
+            continue
+        if issue.message not in messages:
+            messages.append(issue.message)
+    return messages

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -43,6 +43,7 @@ from langgraph_system_generator.rag.retriever import DocsRetriever
 from langgraph_system_generator.utils.generation_options import (
     SUPPORTED_AGENT_TYPES,
     normalize_agent_type,
+    resolve_architecture_type,
 )
 from langgraph_system_generator.utils.config import settings
 
@@ -276,9 +277,10 @@ async def graph_design_node(state: GeneratorState) -> Dict[str, Any]:
     designer = GraphDesigner(model_config=_resolve_model_config(state))
 
     selected_patterns = state.get("selected_patterns", {}) or {}
-    architecture_type = state.get("architecture_type")
-    if not architecture_type:
-        architecture_type = selected_patterns.get("primary", "router")
+    architecture_type = resolve_architecture_type(
+        state.get("architecture_type"),
+        selected_patterns,
+    )
     architecture = {
         "architecture_type": architecture_type,
         "justification": state["architecture_justification"],
@@ -302,7 +304,7 @@ async def graph_design_node(state: GeneratorState) -> Dict[str, Any]:
             "Execution",
         ],
         cell_count_estimate=len(design_result.nodes) * 3 + 10,
-        patterns_used=[state.get("selected_patterns", {}).get("primary", "router")],
+        patterns_used=[architecture_type],
         architecture_type=architecture["architecture_type"],
     )
 
@@ -354,8 +356,10 @@ async def notebook_assembly_node(state: GeneratorState) -> Dict[str, Any]:
     tools_plan = state.get("tools_plan", [])
 
     architecture = {
-        "architecture_type": state.get("architecture_type")
-        or state.get("selected_patterns", {}).get("primary", "router"),
+        "architecture_type": resolve_architecture_type(
+            state.get("architecture_type"),
+            state.get("selected_patterns", {}) or {},
+        ),
         "justification": state["architecture_justification"],
     }
 
@@ -640,8 +644,10 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
     manifest = {
         "notebook_plan": str(state.get("notebook_plan")),
         "cell_count": str(len(state.get("generated_cells", []))),
-        "architecture_type": state.get("architecture_type")
-        or state.get("selected_patterns", {}).get("primary", "router"),
+        "architecture_type": resolve_architecture_type(
+            state.get("architecture_type"),
+            state.get("selected_patterns", {}) or {},
+        ),
         "constraints_count": str(len(state.get("constraints", []))),
         "requirements_feedback": (
             requirements_feedback.model_dump()

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -25,6 +25,8 @@ from langgraph_system_generator.generator.state import (
     CellSpec,
     DocSnippet,
     GeneratorState,
+    GraphDesignFeedback,
+    GraphExportBundle,
     NotebookPlan,
     QAReport,
 )
@@ -283,7 +285,8 @@ async def graph_design_node(state: GeneratorState) -> Dict[str, Any]:
         "selected_patterns": selected_patterns,
     }
 
-    workflow_design = await designer.design_workflow(architecture, state["constraints"])
+    design_result = await designer.design_workflow(architecture, state["constraints"])
+    workflow_design = design_result.to_workflow_design_payload()
     if selected_patterns.get("primary") == "hybrid":
         workflow_design.setdefault("selected_patterns", selected_patterns)
 
@@ -298,13 +301,15 @@ async def graph_design_node(state: GeneratorState) -> Dict[str, Any]:
             "Graph Construction",
             "Execution",
         ],
-        cell_count_estimate=len(workflow_design.get("nodes", [])) * 3 + 10,
+        cell_count_estimate=len(design_result.nodes) * 3 + 10,
         patterns_used=[state.get("selected_patterns", {}).get("primary", "router")],
         architecture_type=architecture["architecture_type"],
     )
 
     return {
         "workflow_design": workflow_design,
+        "graph_design_feedback": design_result.feedback,
+        "graph_exports": design_result.exports,
         "notebook_plan": notebook_plan,
     }
 
@@ -338,7 +343,14 @@ async def notebook_assembly_node(state: GeneratorState) -> Dict[str, Any]:
     composer = NotebookComposer(model_config=_resolve_model_config(state))
 
     notebook_plan = state.get("notebook_plan")
-    workflow_design = state.get("workflow_design", {})
+    workflow_design = dict(state.get("workflow_design", {}) or {})
+    graph_exports = state.get("graph_exports")
+    if graph_exports and "graph_exports" not in workflow_design:
+        workflow_design["graph_exports"] = (
+            graph_exports.model_dump(by_alias=True)
+            if hasattr(graph_exports, "model_dump")
+            else graph_exports
+        )
     tools_plan = state.get("tools_plan", [])
 
     architecture = {
@@ -623,6 +635,8 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
     # Create artifacts manifest
     requirements_feedback = state.get("requirements_feedback")
     architecture_feedback = state.get("architecture_feedback")
+    graph_design_feedback = state.get("graph_design_feedback")
+    graph_exports = state.get("graph_exports")
     manifest = {
         "notebook_plan": str(state.get("notebook_plan")),
         "cell_count": str(len(state.get("generated_cells", []))),
@@ -638,6 +652,19 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
             architecture_feedback.model_dump()
             if hasattr(architecture_feedback, "model_dump")
             else (architecture_feedback or {})
+        ),
+        "graph_design_feedback": (
+            graph_design_feedback.model_dump()
+            if hasattr(graph_design_feedback, "model_dump")
+            else (
+                graph_design_feedback
+                or GraphDesignFeedback(fallback_used=False).model_dump()
+            )
+        ),
+        "graph_exports": (
+            graph_exports.model_dump(by_alias=True)
+            if hasattr(graph_exports, "model_dump")
+            else (graph_exports or GraphExportBundle().model_dump(by_alias=True))
         ),
     }
 

--- a/src/langgraph_system_generator/generator/state.py
+++ b/src/langgraph_system_generator/generator/state.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import operator
 from typing import Annotated, Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypedDict
 
 from langgraph_system_generator.utils.config import GenerationConfig
@@ -194,6 +194,155 @@ class ArchitectureSelectionResult(BaseModel):
     )
 
 
+class GraphNodeSpec(BaseModel):
+    """Normalized graph node specification."""
+
+    name: str = Field(description="Stable node identifier used in graph wiring.")
+    purpose: str = Field(description="Human-readable purpose for the node.")
+
+
+class GraphEdgeSpec(BaseModel):
+    """Normalized directed edge between two workflow nodes."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    source: str = Field(alias="from", description="Source node identifier.")
+    target: str = Field(alias="to", description="Target node identifier.")
+
+
+class GraphConditionalEdgeSpec(BaseModel):
+    """Normalized conditional edge specification."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    source: str = Field(
+        alias="from",
+        description="Node identifier that owns the conditional routing logic.",
+    )
+    condition: str = Field(description="Human-readable routing condition description.")
+    branches: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Mapping from branch labels to target node identifiers or END.",
+    )
+
+
+class GraphValidationIssue(BaseModel):
+    """Structured graph validation issue surfaced during design."""
+
+    code: str = Field(description="Stable validation issue code.")
+    message: str = Field(description="Human-readable validation issue description.")
+    severity: Literal["error", "warning"] = Field(
+        default="error",
+        description="Whether the issue is blocking or advisory.",
+    )
+    nodes: List[str] = Field(
+        default_factory=list,
+        description="Node identifiers associated with the issue, when applicable.",
+    )
+
+
+class GraphExportBundle(BaseModel):
+    """Serializable graph-design export surfaces."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    mermaid: str = Field(
+        default="",
+        description="Mermaid flowchart representation of the normalized graph.",
+    )
+    schema_payload: Dict[str, Any] = Field(
+        default_factory=dict,
+        alias="schema",
+        description="JSON-serializable workflow schema and validation summary.",
+    )
+
+    @property
+    def schema(self) -> Dict[str, Any]:
+        """Return the serialized graph schema payload."""
+
+        return self.schema_payload
+
+
+class GraphDesignFeedback(BaseModel):
+    """Advisory feedback captured during graph design."""
+
+    fallback_used: bool = Field(
+        default=False,
+        description="Whether the designer had to use a deterministic fallback graph.",
+    )
+    fallback_reason: Optional[str] = Field(
+        default=None,
+        description="Reason fallback mode was used, when applicable.",
+    )
+    validation_errors: List[str] = Field(
+        default_factory=list,
+        description="Blocking validation errors encountered during live graph design.",
+    )
+    warnings: List[str] = Field(
+        default_factory=list,
+        description="Advisory warnings captured during graph design.",
+    )
+    validation_issues: List[GraphValidationIssue] = Field(
+        default_factory=list,
+        description="Structured validation issues captured during graph design.",
+    )
+    composition_strategy: Optional[str] = Field(
+        default=None,
+        description="Composition strategy used to normalize or build the graph.",
+    )
+
+
+class GraphDesignResult(BaseModel):
+    """Structured graph-design output consumed by downstream stages."""
+
+    architecture_type: str = Field(description="Normalized architecture identifier.")
+    state_schema: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Normalized workflow state schema mapping.",
+    )
+    nodes: List[GraphNodeSpec] = Field(
+        default_factory=list,
+        description="Normalized workflow node specifications.",
+    )
+    edges: List[GraphEdgeSpec] = Field(
+        default_factory=list,
+        description="Normalized direct graph edges.",
+    )
+    conditional_edges: List[GraphConditionalEdgeSpec] = Field(
+        default_factory=list,
+        description="Normalized conditional graph edges.",
+    )
+    entry_point: str = Field(description="Entry point node identifier.")
+    checkpointing: bool = Field(
+        default=False,
+        description="Whether the generated workflow should enable checkpointing.",
+    )
+    feedback: GraphDesignFeedback = Field(
+        default_factory=GraphDesignFeedback,
+        description="Advisory graph-design feedback.",
+    )
+    exports: GraphExportBundle = Field(
+        default_factory=GraphExportBundle,
+        description="Serializable graph exports for manifests and notebooks.",
+    )
+
+    def to_workflow_design_payload(self) -> Dict[str, Any]:
+        """Return the backward-compatible workflow_design payload."""
+
+        return {
+            "architecture_type": self.architecture_type,
+            "state_schema": dict(self.state_schema),
+            "nodes": [node.model_dump() for node in self.nodes],
+            "edges": [edge.model_dump(by_alias=True) for edge in self.edges],
+            "conditional_edges": [
+                edge.model_dump(by_alias=True) for edge in self.conditional_edges
+            ],
+            "entry_point": self.entry_point,
+            "checkpointing": self.checkpointing,
+            "graph_exports": self.exports.model_dump(by_alias=True),
+        }
+
+
 class DocSnippet(BaseModel):
     """Retrieved documentation snippet."""
 
@@ -265,6 +414,8 @@ class GeneratorState(TypedDict):
     constraints: Annotated[List[Constraint], operator.add]
     requirements_feedback: RequirementsFeedback
     architecture_feedback: ArchitectureFeedback
+    graph_design_feedback: GraphDesignFeedback
+    graph_exports: GraphExportBundle
     selected_patterns: Dict[str, Any]
 
     # RAG context

--- a/src/langgraph_system_generator/utils/config.py
+++ b/src/langgraph_system_generator/utils/config.py
@@ -154,6 +154,12 @@ class Settings(BaseSettings):
         ge=1,
         description="Maximum number of weighted docs snippets included in the architecture selector prompt.",
     )
+    graph_designer_plugin_modules: Annotated[list[str], NoDecode] = Field(
+        default_factory=list,
+        description=(
+            "Optional graph designer plugin modules loaded to extend the graph design registry."
+        ),
+    )
 
     @field_validator("requirements_constraint_types", mode="before")
     @classmethod
@@ -257,6 +263,42 @@ class Settings(BaseSettings):
                 ) from exc
         return normalized
 
+    @field_validator("graph_designer_plugin_modules", mode="before")
+    @classmethod
+    def _parse_graph_designer_plugin_modules(cls, value):
+        """Accept JSON arrays or comma-separated plugin module strings."""
+        if value in (None, ""):
+            return []
+        if isinstance(value, list):
+            raw_items = value
+        elif isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return []
+            if stripped.startswith("["):
+                try:
+                    parsed = json.loads(stripped)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"Invalid JSON in graph_designer_plugin_modules: {exc}"
+                    ) from exc
+                if not isinstance(parsed, list):
+                    raise ValueError(
+                        "graph_designer_plugin_modules must decode to a list"
+                    )
+                raw_items = parsed
+            else:
+                raw_items = stripped.split(",")
+        else:
+            return value
+
+        normalized: list[str] = []
+        for raw_item in raw_items:
+            module_name = str(raw_item or "").strip()
+            if module_name and module_name not in normalized:
+                normalized.append(module_name)
+        return normalized
+
 
 _DEFAULT_ENV_FILE = object()
 _TEST_SETTINGS_ENV_KEYS = (
@@ -273,6 +315,7 @@ _TEST_SETTINGS_ENV_KEYS = (
     "ARCHITECTURE_PATTERN_DOC_QUERIES",
     "ARCHITECTURE_PATTERN_DOC_WEIGHTS",
     "ARCHITECTURE_PROMPT_DOC_LIMIT",
+    "GRAPH_DESIGNER_PLUGIN_MODULES",
 )
 
 

--- a/src/langgraph_system_generator/utils/generation_options.py
+++ b/src/langgraph_system_generator/utils/generation_options.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, Mapping
+
 from langgraph_system_generator.generator.architecture_registry import (
     get_default_architecture_registry,
 )
@@ -31,3 +33,27 @@ def normalize_agent_type(agent_type: str | None) -> str | None:
     if normalized is None:
         return None
     return normalized.lower()
+
+
+def resolve_architecture_type(
+    architecture_type: str | None,
+    selected_patterns: Mapping[str, Any] | None = None,
+    *,
+    default: str = "router",
+) -> str:
+    """Resolve a normalized architecture id from explicit or pattern-selected state."""
+
+    if isinstance(architecture_type, str):
+        normalized_explicit = normalize_agent_type(architecture_type)
+        if normalized_explicit:
+            return normalized_explicit
+
+    if isinstance(selected_patterns, Mapping):
+        primary = selected_patterns.get("primary")
+        if isinstance(primary, str):
+            normalized_primary = normalize_agent_type(primary)
+            if normalized_primary:
+                return normalized_primary
+
+    normalized_default = normalize_agent_type(default)
+    return normalized_default or "router"

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -53,9 +53,13 @@ async def test_generate_artifacts_stub(tmp_path: Path, monkeypatch: pytest.Monke
     assert artifacts["manifest"]["requirements_feedback"]["fallback_used"] is False
     assert artifacts["manifest"]["architecture_feedback"]["fallback_used"] is False
     assert artifacts["manifest"]["architecture_feedback"]["docs_considered"] == []
+    assert artifacts["manifest"]["graph_design_feedback"]["fallback_used"] is False
+    assert "flowchart TD" in artifacts["manifest"]["graph_exports"]["mermaid"]
     assert artifacts["result"]["requirements_feedback"]["fallback_used"] is False
     assert artifacts["result"]["architecture_feedback"]["fallback_used"] is False
     assert artifacts["result"]["architecture_feedback"]["docs_considered"] == []
+    assert artifacts["result"]["graph_design_feedback"]["fallback_used"] is False
+    assert "flowchart TD" in artifacts["result"]["graph_exports"]["mermaid"]
     assert Path(artifacts["manifest_path"]).exists()
     assert artifacts["result"]["generation_complete"] is True
 
@@ -73,6 +77,8 @@ def test_default_state_includes_generation_mode_and_qa_history():
     assert state["qa_history"] == []
     assert state["requirements_feedback"].fallback_used is False
     assert state["architecture_feedback"].fallback_used is False
+    assert state["graph_design_feedback"].fallback_used is False
+    assert state["graph_exports"].schema == {}
     assert "goal" in state["requirements_feedback"].available_constraint_types
 
 
@@ -326,6 +332,74 @@ async def test_generate_artifacts_surfaces_architecture_feedback_as_warnings(
     assert "architecture_fallback" in warning_codes
     assert "architecture_validation" in warning_codes
     assert artifacts["manifest"]["architecture_feedback"]["fallback_used"] is True
+
+
+@pytest.mark.asyncio
+async def test_generate_artifacts_surfaces_graph_design_feedback_as_warnings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_graph_design_feedback_warning")
+
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.cli as cli_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(cli_module)
+
+    original_build_stub_result = cli_module._build_stub_result
+
+    def build_stub_result_with_graph_feedback(prompt: str, agent_type: str | None = None):
+        result = original_build_stub_result(prompt, agent_type=agent_type)
+        result["graph_design_feedback"] = {
+            "fallback_used": True,
+            "fallback_reason": "Live graph design validation failed.",
+            "validation_errors": [
+                "Duplicate node id 'router'.",
+                "Unknown edge target 'missing_target'.",
+            ],
+            "warnings": ["Recovered using deterministic fallback."],
+            "validation_issues": [
+                {
+                    "code": "duplicate_node_id",
+                    "message": "Duplicate node id 'router'.",
+                    "severity": "error",
+                    "nodes": ["router"],
+                    "details": {},
+                }
+            ],
+        }
+        result["graph_exports"] = {
+            "mermaid": "flowchart TD\n    router --> finish",
+            "schema": {
+                "entry_point": "router",
+                "terminal_nodes": ["finish"],
+                "validation_summary": {
+                    "errors": [
+                        "Duplicate node id 'router'.",
+                        "Unknown edge target 'missing_target'.",
+                    ],
+                    "warnings": ["Recovered using deterministic fallback."],
+                },
+            },
+        }
+        return result
+
+    monkeypatch.setattr(cli_module, "_build_stub_result", build_stub_result_with_graph_feedback)
+
+    output_dir = constants_module._BASE_OUTPUT / "graph_feedback_stub"
+    artifacts = await cli_module.generate_artifacts(
+        "Graph feedback prompt",
+        output_dir=str(output_dir),
+        mode="stub",
+    )
+
+    warning_codes = {warning["code"] for warning in artifacts["manifest"]["warnings"]}
+    assert "graph_design_fallback" in warning_codes
+    assert "graph_design_validation" in warning_codes
+    assert artifacts["manifest"]["graph_design_feedback"]["fallback_used"] is True
+    assert "flowchart TD" in artifacts["manifest"]["graph_exports"]["mermaid"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -13,7 +13,12 @@ from fastapi.testclient import TestClient
 
 from langgraph_system_generator.api.server import app
 from langgraph_system_generator.cli import GenerationArtifacts, generate_artifacts
+from langgraph_system_generator.generator.graph_design_registry import (
+    GraphDesignRegistration,
+    get_graph_design_registry,
+)
 from langgraph_system_generator.utils.config import GenerationConfig
+from langgraph_system_generator.utils.error_handling import GenerationError
 from langgraph_system_generator.utils.optional_deps import OptionalDependencyError
 
 
@@ -400,6 +405,37 @@ async def test_generate_artifacts_surfaces_graph_design_feedback_as_warnings(
     assert "graph_design_validation" in warning_codes
     assert artifacts["manifest"]["graph_design_feedback"]["fallback_used"] is True
     assert "flowchart TD" in artifacts["manifest"]["graph_exports"]["mermaid"]
+
+
+def test_build_stub_result_raises_for_invalid_stub_graph_design(monkeypatch):
+    import langgraph_system_generator.cli as cli_module
+
+    registry = get_graph_design_registry().clone()
+    router_registration = get_graph_design_registry().get("router")
+    registry.register(
+        GraphDesignRegistration(
+            architecture_id="router",
+            supported_entry_shapes=router_registration.supported_entry_shapes,
+            supported_exit_shapes=router_registration.supported_exit_shapes,
+            cycles_allowed=router_registration.cycles_allowed,
+            fallback_builder=lambda *_args, **_kwargs: {
+                "state_schema": {},
+                "nodes": [{"name": "router", "purpose": "Route requests"}],
+                "edges": [{"from": "router", "to": "missing_target"}],
+                "conditional_edges": [],
+                "entry_point": "router",
+                "checkpointing": False,
+            },
+            normalization_hook=router_registration.normalization_hook,
+            validation_hook=router_registration.validation_hook,
+            export_label_defaults=router_registration.export_label_defaults,
+            composition_strategy=router_registration.composition_strategy,
+        )
+    )
+    monkeypatch.setattr(cli_module, "get_graph_design_registry", lambda: registry)
+
+    with pytest.raises(GenerationError, match="invalid workflow"):
+        cli_module._build_stub_result("Build a test workflow")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -163,6 +163,46 @@ def test_settings_reject_invalid_requirements_constraint_types_json(tmp_path):
         FileSettings()
 
 
+def test_settings_parse_graph_designer_plugin_modules_from_json(tmp_path):
+    env_path = Path(tmp_path) / ".env"
+    env_path.write_text(
+        'GRAPH_DESIGNER_PLUGIN_MODULES=["pkg.plugins.alpha","pkg.plugins.beta"]\n',
+        encoding="utf-8",
+    )
+
+    class FileSettings(Settings):
+        model_config = SettingsConfigDict(
+            env_file=env_path, env_file_encoding="utf-8", extra="ignore"
+        )
+
+    loaded = FileSettings()
+
+    assert loaded.graph_designer_plugin_modules == [
+        "pkg.plugins.alpha",
+        "pkg.plugins.beta",
+    ]
+
+
+def test_settings_parse_graph_designer_plugin_modules_from_csv(tmp_path):
+    env_path = Path(tmp_path) / ".env"
+    env_path.write_text(
+        "GRAPH_DESIGNER_PLUGIN_MODULES=pkg.plugins.alpha, pkg.plugins.beta , pkg.plugins.alpha\n",
+        encoding="utf-8",
+    )
+
+    class FileSettings(Settings):
+        model_config = SettingsConfigDict(
+            env_file=env_path, env_file_encoding="utf-8", extra="ignore"
+        )
+
+    loaded = FileSettings()
+
+    assert loaded.graph_designer_plugin_modules == [
+        "pkg.plugins.alpha",
+        "pkg.plugins.beta",
+    ]
+
+
 def test_model_config_defaults():
     """Test ModelConfig uses correct defaults."""
     config = ModelConfig()

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -19,9 +19,11 @@ from langgraph_system_generator.generator.architecture_registry import (
     get_default_architecture_registry,
 )
 from langgraph_system_generator.generator.graph_design_registry import (
+    build_graph_exports,
     GraphDesignRegistration,
     GraphDesignRegistry,
     get_graph_design_registry,
+    normalize_graph_design,
     validate_graph_design,
 )
 from langgraph_system_generator.generator.state import (
@@ -962,6 +964,23 @@ def test_graph_design_registry_loads_plugin_modules(monkeypatch):
     assert registry.get("plugin_router").composition_strategy == "plugin"
 
 
+def test_graph_design_registry_surfaces_plugin_import_failures(monkeypatch):
+    """Plugin import failures should name the module and the original import error."""
+
+    def broken_import(name: str):
+        if name == "broken_graph_plugin":
+            raise ModuleNotFoundError("No module named 'missing_graph_extension'")
+        raise AssertionError(f"Unexpected import request: {name}")
+
+    monkeypatch.setattr(graph_designer.importlib, "import_module", broken_import)
+
+    with pytest.raises(
+        ValueError,
+        match="Failed to import graph design plugin module 'broken_graph_plugin'",
+    ):
+        get_graph_design_registry(plugin_modules=("broken_graph_plugin",))
+
+
 def test_graph_designer_hybrid_fallback_contains_router_supervisor_and_team(monkeypatch):
     """Hybrid fallback should produce a real mixed routing/team workflow shape."""
     monkeypatch.setattr(
@@ -995,6 +1014,50 @@ def test_graph_designer_hybrid_fallback_contains_router_supervisor_and_team(monk
     assert router_edges[0]["branches"]["team_path"] == "supervisor"
     assert supervisor_edges
     assert "FINISH" in supervisor_edges[0]["branches"]
+
+    registration = get_graph_design_registry().get("hybrid")
+    normalized = normalize_graph_design(result, "hybrid", registration)
+    issues = validate_graph_design(normalized, registration)
+    assert not [issue for issue in issues if issue.severity == "error"]
+
+
+def test_graph_design_exports_escape_mermaid_labels():
+    """Mermaid exports should escape labels that contain quotes, brackets, or newlines."""
+
+    result = GraphDesignResult(
+        architecture_type="router",
+        state_schema={"messages": "Conversation state"},
+        nodes=[
+            GraphNodeSpec(
+                name='router "alpha"',
+                purpose="Route [requests]\ncarefully",
+            ),
+            GraphNodeSpec(name="finish", purpose="Finish the workflow"),
+        ],
+        edges=[],
+        conditional_edges=[
+            GraphConditionalEdgeSpec.model_validate(
+                {
+                    "from": 'router "alpha"',
+                    "condition": "Dispatch by route",
+                    "branches": {
+                        'team "path"\n[1]': "finish",
+                        "END": "END",
+                    },
+                }
+            )
+        ],
+        entry_point='router "alpha"',
+        checkpointing=False,
+    )
+
+    exports = build_graph_exports(result, get_graph_design_registry().get("router"))
+
+    assert "&quot;" in exports.mermaid
+    assert "&#91;" in exports.mermaid
+    assert "&#93;" in exports.mermaid
+    assert "<br/>" in exports.mermaid
+
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -18,11 +18,22 @@ from langgraph_system_generator.generator.architecture_registry import (
     ArchitectureRegistration,
     get_default_architecture_registry,
 )
+from langgraph_system_generator.generator.graph_design_registry import (
+    GraphDesignRegistration,
+    GraphDesignRegistry,
+    get_graph_design_registry,
+    validate_graph_design,
+)
 from langgraph_system_generator.generator.state import (
     ArchitectureSelectionResult,
     Constraint,
     DocSnippet,
+    GraphConditionalEdgeSpec,
+    GraphDesignResult,
+    GraphEdgeSpec,
+    GraphNodeSpec,
 )
+from langgraph_system_generator.utils.error_handling import GenerationError
 from langgraph_system_generator.utils.config import ModelConfig
 
 
@@ -729,7 +740,7 @@ async def test_architecture_selector_normalizes_hybrid_secondary_patterns(monkey
 @pytest.mark.asyncio
 @pytest.mark.parametrize("arch_type", ["router", "subagents"])
 async def test_graph_designer_fallback(arch_type, monkeypatch):
-    """GraphDesigner falls back to the correct design when parsing fails."""
+    """GraphDesigner should return typed fallback output when parsing fails."""
     monkeypatch.setattr(
         graph_designer,
         "ChatOpenAI",
@@ -740,7 +751,215 @@ async def test_graph_designer_fallback(arch_type, monkeypatch):
     architecture = {"architecture_type": arch_type, "justification": "x"}
     expected = designer._fallback_design(arch_type)
     result = await designer.design_workflow(architecture, constraints)
-    assert result == expected
+    assert isinstance(result, GraphDesignResult)
+    assert result.feedback.fallback_used is True
+    assert result.to_workflow_design_payload()["entry_point"] == expected["entry_point"]
+    assert result.to_workflow_design_payload()["nodes"] == expected["nodes"]
+
+
+@pytest.mark.asyncio
+async def test_graph_designer_returns_typed_result_with_exports(monkeypatch):
+    """GraphDesigner should normalize a valid design into typed output plus exports."""
+
+    payload = """
+    {
+      "state_schema": {
+        "messages": "Conversation state",
+        "route": "Selected route"
+      },
+      "nodes": [
+        {"name": "router", "purpose": "Route requests"},
+        {"name": "search", "purpose": "Search documents"}
+      ],
+      "edges": [],
+      "conditional_edges": [
+        {
+          "from": "router",
+          "condition": "Dispatch by route",
+          "branches": {"search": "search", "END": "END"}
+        }
+      ],
+      "entry_point": "router",
+      "checkpointing": false
+    }
+    """
+    monkeypatch.setattr(graph_designer, "ChatOpenAI", make_stub_llm(payload))
+
+    designer = graph_designer.GraphDesigner()
+    result = await designer.design_workflow(
+        {
+            "architecture_type": "router",
+            "justification": "Routing is sufficient.",
+            "selected_patterns": {"primary": "router", "secondary": []},
+        },
+        [Constraint(type="goal", value="Build a router workflow", priority=5)],
+    )
+
+    assert isinstance(result, GraphDesignResult)
+    assert result.architecture_type == "router"
+    assert result.nodes[0].name == "router"
+    assert result.feedback.fallback_used is False
+    assert "flowchart TD" in result.exports.mermaid
+    assert result.exports.schema["entry_point"] == "router"
+    assert result.exports.schema["terminal_nodes"]
+
+
+@pytest.mark.asyncio
+async def test_graph_designer_falls_back_for_invalid_live_graph(monkeypatch):
+    """Invalid live graph payloads should trigger validated fallback feedback."""
+
+    payload = """
+    {
+      "state_schema": {"messages": "Conversation state"},
+      "nodes": [
+        {"name": "router", "purpose": "Route requests"},
+        {"name": "router", "purpose": "Duplicate node"},
+        {"name": "orphan", "purpose": "Never reached"}
+      ],
+      "edges": [
+        {"from": "router", "to": "missing_target"}
+      ],
+      "conditional_edges": [],
+      "entry_point": "router",
+      "checkpointing": false
+    }
+    """
+    monkeypatch.setattr(graph_designer, "ChatOpenAI", make_stub_llm(payload))
+
+    designer = graph_designer.GraphDesigner()
+    result = await designer.design_workflow(
+        {
+            "architecture_type": "router",
+            "justification": "Routing is sufficient.",
+            "selected_patterns": {"primary": "router", "secondary": []},
+        },
+        [Constraint(type="goal", value="Build a router workflow", priority=5)],
+    )
+
+    assert isinstance(result, GraphDesignResult)
+    assert result.feedback.fallback_used is True
+    assert result.feedback.fallback_reason
+    assert any("duplicate" in message.lower() for message in result.feedback.validation_errors)
+    assert any("missing_target" in message for message in result.feedback.validation_errors)
+    assert result.entry_point == "router"
+    assert "flowchart TD" in result.exports.mermaid
+
+
+@pytest.mark.asyncio
+async def test_graph_designer_raises_when_fallback_is_invalid(monkeypatch):
+    """If fallback normalization still fails, GraphDesigner should raise a structured error."""
+
+    monkeypatch.setattr(graph_designer, "ChatOpenAI", make_stub_llm("not-json"))
+
+    registry = GraphDesignRegistry()
+    registry.register(
+        GraphDesignRegistration(
+            architecture_id="broken",
+            supported_entry_shapes=["broken"],
+            supported_exit_shapes=["broken"],
+            cycles_allowed=False,
+            fallback_builder=lambda *_args, **_kwargs: {
+                "state_schema": {},
+                "nodes": [],
+                "edges": [],
+                "conditional_edges": [],
+                "entry_point": "",
+                "checkpointing": False,
+            },
+            normalization_hook=None,
+            validation_hook=None,
+            export_label_defaults={"title": "Broken"},
+            composition_strategy="broken",
+        )
+    )
+
+    designer = graph_designer.GraphDesigner(registry=registry)
+    with pytest.raises(GenerationError, match="fallback"):
+        await designer.design_workflow(
+            {
+                "architecture_type": "broken",
+                "justification": "Broken architecture for validation testing.",
+                "selected_patterns": {"primary": "broken", "secondary": []},
+            },
+            [Constraint(type="goal", value="Break the graph designer", priority=5)],
+        )
+
+
+def test_graph_design_validation_detects_cycles_and_unreachable_nodes():
+    """Graph validation should detect structural errors before export or use."""
+
+    result = GraphDesignResult(
+        architecture_type="router",
+        state_schema={"messages": "Conversation state"},
+        nodes=[
+            GraphNodeSpec(name="router", purpose="Route requests"),
+            GraphNodeSpec(name="search", purpose="Search documents"),
+            GraphNodeSpec(name="dead_end", purpose="Never reached"),
+        ],
+        edges=[
+            GraphEdgeSpec.model_validate({"from": "search", "to": "router"}),
+        ],
+        conditional_edges=[
+            GraphConditionalEdgeSpec.model_validate(
+                {
+                    "from": "router",
+                    "condition": "Dispatch by route",
+                    "branches": {"search": "search"},
+                }
+            )
+        ],
+        entry_point="router",
+        checkpointing=False,
+    )
+
+    issues = validate_graph_design(result, get_graph_design_registry().get("router"))
+    issue_codes = {issue.code for issue in issues}
+
+    assert "cycle_detected" in issue_codes
+    assert "unreachable_node" in issue_codes
+    assert "missing_terminal_path" in issue_codes
+
+
+def test_graph_design_registry_loads_plugin_modules(monkeypatch):
+    """Graph design plugin modules should be able to register new architectures."""
+
+    class FakePluginModule:
+        @staticmethod
+        def register_graph_designers(registry):
+            registry.register(
+                GraphDesignRegistration(
+                    architecture_id="plugin_router",
+                    supported_entry_shapes=["router"],
+                    supported_exit_shapes=["terminal"],
+                    cycles_allowed=False,
+                    fallback_builder=lambda *_args, **_kwargs: {
+                        "state_schema": {"messages": "Conversation state"},
+                        "nodes": [
+                            {"name": "router", "purpose": "Route requests"},
+                            {"name": "finish", "purpose": "Finish requests"},
+                        ],
+                        "edges": [{"from": "router", "to": "finish"}],
+                        "conditional_edges": [],
+                        "entry_point": "router",
+                        "checkpointing": False,
+                    },
+                    normalization_hook=None,
+                    validation_hook=None,
+                    export_label_defaults={"title": "Plugin Router"},
+                    composition_strategy="plugin",
+                )
+            )
+
+    monkeypatch.setattr(
+        graph_designer.importlib,
+        "import_module",
+        lambda name: FakePluginModule if name == "fake_graph_plugin" else None,
+    )
+
+    registry = get_graph_design_registry(plugin_modules=("fake_graph_plugin",))
+
+    assert "plugin_router" in registry.supported_architecture_types()
+    assert registry.get("plugin_router").composition_strategy == "plugin"
 
 
 def test_graph_designer_hybrid_fallback_contains_router_supervisor_and_team(monkeypatch):

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -25,6 +25,8 @@ from langgraph_system_generator.generator.state import (
     ArchitectureFeedback,
     CellSpec,
     Constraint,
+    GraphDesignFeedback,
+    GraphExportBundle,
     QAReport,
 )
 from langgraph_system_generator.utils.config import GenerationConfig
@@ -213,7 +215,33 @@ async def test_architecture_selection_node_honors_hybrid_override():
 
 @pytest.mark.asyncio
 async def test_graph_design_node_defaults_architecture_type(monkeypatch):
-    payload = '{"nodes":["a","b"]}'
+    payload = """
+    {
+      "state_schema": {
+        "messages": "Conversation state",
+        "next_agent": "Selected worker"
+      },
+      "nodes": [
+        {"name": "supervisor", "purpose": "Coordinate workers"},
+        {"name": "researcher", "purpose": "Research documents"},
+        {"name": "critic", "purpose": "Critique results"}
+      ],
+      "edges": [],
+      "conditional_edges": [
+        {
+          "from": "supervisor",
+          "condition": "Dispatch to next worker",
+          "branches": {
+            "researcher": "researcher",
+            "critic": "critic",
+            "FINISH": "END"
+          }
+        }
+      ],
+      "entry_point": "supervisor",
+      "checkpointing": true
+    }
+    """
 
     monkeypatch.setattr(
         graph_designer,
@@ -241,7 +269,11 @@ async def test_graph_design_node_defaults_architecture_type(monkeypatch):
     ]
     assert notebook_plan.patterns_used == ["subagents"]
     assert notebook_plan.architecture_type == "subagents"
-    assert result["workflow_design"] == {"nodes": ["a", "b"]}
+    assert result["workflow_design"]["architecture_type"] == "subagents"
+    assert result["workflow_design"]["entry_point"] == "supervisor"
+    assert result["graph_design_feedback"].fallback_used is False
+    assert "flowchart TD" in result["graph_exports"].mermaid
+    assert result["graph_exports"].schema["entry_point"] == "supervisor"
 
 
 @pytest.mark.asyncio
@@ -285,7 +317,16 @@ async def test_notebook_assembly_node_returns_generated_cells(monkeypatch):
 
     state = {
         "notebook_plan": None,
-        "workflow_design": {},
+        "workflow_design": {
+            "graph_exports": {
+                "mermaid": "flowchart TD\n    A-->B",
+                "schema": {"entry_point": "router"},
+            }
+        },
+        "graph_exports": GraphExportBundle(
+            mermaid="flowchart TD\n    A-->B",
+            schema={"entry_point": "router"},
+        ),
         "tools_plan": [],
         "selected_patterns": {"primary": "router"},
         "architecture_justification": "Reason",
@@ -538,6 +579,23 @@ async def test_package_outputs_node_manifest_fields():
             fallback_reason="Validation failed.",
             validation_errors=["Unsupported architecture_type 'swarm'."],
         ),
+        "graph_design_feedback": GraphDesignFeedback(
+            fallback_used=True,
+            fallback_reason="Live graph design validation failed.",
+            validation_errors=["Duplicate node id 'router'."],
+            warnings=["Recovered using deterministic hybrid fallback."],
+        ),
+        "graph_exports": GraphExportBundle(
+            mermaid="flowchart TD\n    router --> finish",
+            schema={
+                "entry_point": "router",
+                "terminal_nodes": ["finish"],
+                "validation_summary": {
+                    "errors": ["Duplicate node id 'router'."],
+                    "warnings": ["Recovered using deterministic hybrid fallback."],
+                },
+            },
+        ),
     }
     result = await package_outputs_node(state)
 
@@ -546,4 +604,6 @@ async def test_package_outputs_node_manifest_fields():
     assert manifest["constraints_count"] == "1"
     assert manifest["architecture_type"] == "hybrid"
     assert manifest["architecture_feedback"]["fallback_used"] is True
+    assert manifest["graph_design_feedback"]["fallback_used"] is True
+    assert "flowchart TD" in manifest["graph_exports"]["mermaid"]
     assert result["generation_complete"] is True

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -316,6 +316,55 @@ async def test_compose_notebook_hybrid_sanitizes_worker_and_specialist_graph_ids
     assert '"fact checker": "fact_checker"' in graph_code
 
 
+@pytest.mark.asyncio
+async def test_compose_notebook_includes_graph_overview_from_exports(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Graph exports should appear in the intro section as notebook-facing context."""
+
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+
+    plan = NotebookPlan(
+        title="Graph Overview Notebook",
+        sections=["Setup", "Workflow", "Execution"],
+        patterns_used=["router"],
+        architecture_type="router",
+    )
+    workflow_design = {
+        "architecture_type": "router",
+        "state_schema": {"messages": "Conversation state"},
+        "nodes": [
+            {"name": "router", "purpose": "Route requests"},
+            {"name": "search", "purpose": "Search documents"},
+        ],
+        "graph_exports": {
+            "mermaid": "flowchart TD\n    START --> router\n    router --> search",
+            "schema": {
+                "entry_point": "router",
+                "terminal_nodes": ["search"],
+                "validation_summary": {"errors": [], "warnings": []},
+            },
+        },
+    }
+
+    cells = await composer.compose_notebook(
+        notebook_plan=plan,
+        workflow_design=workflow_design,
+        tools=[],
+        architecture={"architecture_type": "router", "justification": "Router is sufficient."},
+    )
+
+    intro_markdown = "\n\n".join(
+        cell.content for cell in cells if cell.section == "intro" and cell.cell_type == "markdown"
+    )
+
+    assert "Graph Overview" in intro_markdown
+    assert "```mermaid" in intro_markdown
+    assert "flowchart TD" in intro_markdown
+    assert "terminal_nodes" in intro_markdown
+
+
 def test_generate_node_implementation_falls_back_to_meaningful_state_updates(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
## Summary
- add typed graph-design models, registry/plugin loading, and validated Mermaid/schema exports for GraphDesigner
- refactor graph design to return structured feedback plus deterministic fallback handling, then thread those surfaces through nodes, manifests, and notebook assembly
- add regression coverage for graph validation, plugin loading, graph overview rendering, and CLI/API warning surfacing

## Testing
- pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes.py tests/unit/test_generator_nodes_additional.py tests/unit/test_generator_notebook_composer.py tests/unit/test_cli_api.py -q
- pytest tests/unit -q
- pytest --asyncio-mode=auto -q
- python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

Closes #186
Closes #187
Closes #188
Closes #189
Closes #190
Closes #185
