### PR TITLE
Harden NotebookComposer contract and dependency planning

### DIFF
--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -23,6 +23,8 @@ from langgraph_system_generator.generator.state import (
     Constraint,
     GraphDesignFeedback,
     GraphExportBundle,
+    NotebookCompositionFeedback,
+    NotebookDependencyPlan,
     NotebookPlan,
     RequirementsFeedback,
 )
@@ -90,6 +92,10 @@ def _default_state(
         "architecture_feedback": ArchitectureFeedback(fallback_used=False),
         "graph_design_feedback": GraphDesignFeedback(fallback_used=False),
         "graph_exports": GraphExportBundle(),
+        "notebook_composition_feedback": NotebookCompositionFeedback(
+            fallback_used=False
+        ),
+        "notebook_dependency_plan": NotebookDependencyPlan(),
         "selected_patterns": {},
         "docs_context": [],
         "notebook_plan": None,
@@ -294,6 +300,32 @@ def _graph_design_warning_entries(
         )
 
     return warnings
+
+
+def _notebook_composition_warning_entries(
+    feedback: Dict[str, Any] | None,
+) -> List[Dict[str, Any]]:
+    """Convert notebook-composition feedback into manifest warnings."""
+
+    if not isinstance(feedback, dict):
+        return []
+
+    if not feedback.get("fallback_used"):
+        return []
+
+    advisory_warnings = list(feedback.get("warnings") or [])
+    fallback_events = list(feedback.get("fallback_events") or [])
+    return [
+        {
+            "code": "notebook_composition_fallback",
+            "phase": "notebook_assembly",
+            "message": advisory_warnings[0]
+            if advisory_warnings
+            else "Notebook composition used deterministic fallback content.",
+            "warnings": advisory_warnings,
+            "fallback_events": fallback_events,
+        }
+    ]
 
 
 class _PhaseTracker:
@@ -830,6 +862,21 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
         "architecture_feedback": architecture_feedback,
         "graph_design_feedback": graph_design_feedback,
         "graph_exports": graph_exports,
+        "notebook_composition_feedback": NotebookCompositionFeedback(
+            fallback_used=False,
+            resolved_model=settings.default_model,
+            resolved_api_base=None,
+            resolved_max_iterations=settings.notebook_composer_default_max_iterations,
+            sections_built=["intro", "install", "state", "nodes", "graph"],
+        ),
+        "notebook_dependency_plan": NotebookDependencyPlan(
+            packages=["langgraph", "langchain-openai"],
+            install_commands=["python -m pip install -q langgraph langchain-openai"],
+            runtime_notes=[
+                "Stub mode emits a deterministic dependency plan for the generated notebook."
+            ],
+            provider_env_vars=["OPENAI_API_KEY"],
+        ),
         "selected_patterns": {
             "primary": architecture_type,
             "secondary": secondary_patterns,
@@ -956,6 +1003,10 @@ async def generate_artifacts(
     architecture_feedback = serialized.get("architecture_feedback") or {}
     graph_design_feedback = serialized.get("graph_design_feedback") or {}
     graph_exports = serialized.get("graph_exports") or {}
+    notebook_composition_feedback = (
+        serialized.get("notebook_composition_feedback") or {}
+    )
+    notebook_dependency_plan = serialized.get("notebook_dependency_plan") or {}
 
     manifest: Dict[str, Any] = {
         "prompt": prompt,
@@ -967,10 +1018,13 @@ async def generate_artifacts(
         "architecture_feedback": architecture_feedback,
         "graph_design_feedback": graph_design_feedback,
         "graph_exports": graph_exports,
+        "notebook_composition_feedback": notebook_composition_feedback,
+        "notebook_dependency_plan": notebook_dependency_plan,
         "warnings": [
             *_requirements_warning_entries(requirements_feedback),
             *_architecture_warning_entries(architecture_feedback),
             *_graph_design_warning_entries(graph_design_feedback),
+            *_notebook_composition_warning_entries(notebook_composition_feedback),
         ],
         "export_results": {},
     }

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 import keyword
 import re
@@ -11,7 +12,14 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from langgraph_system_generator.generator.agents._llm import build_chat_llm
-from langgraph_system_generator.generator.state import CellSpec, NotebookPlan
+from langgraph_system_generator.generator.state import (
+    CellSpec,
+    NotebookCompositionFeedback,
+    NotebookCompositionResult,
+    NotebookDependencyPlan,
+    NotebookFallbackEvent,
+    NotebookPlan,
+)
 from langgraph_system_generator.patterns import (
     AutoAgentPattern,
     CritiqueLoopPattern,
@@ -20,6 +28,34 @@ from langgraph_system_generator.patterns import (
     SubagentsPattern,
 )
 from langgraph_system_generator.utils.config import ModelConfig, settings
+
+
+_PACKAGE_IMPORT_PROBES = {
+    "langgraph": "langgraph",
+    "langchain-core": "langchain_core",
+    "langchain-openai": "langchain_openai",
+    "langchain-community": "langchain_community",
+    "pypdf": "pypdf",
+    "requests": "requests",
+}
+
+_PACKAGE_FAMILIES = {
+    "pypdf": "pdf_parser",
+    "pdfminer.six": "pdf_parser",
+    "pymupdf": "pdf_parser",
+}
+
+
+@dataclass
+class _NotebookCompositionContext:
+    """Internal notebook composition context shared across section builders."""
+
+    notebook_plan: NotebookPlan
+    workflow_design: Dict[str, Any]
+    tools: List[Dict[str, Any]]
+    architecture: Dict[str, Any]
+    dependency_plan: NotebookDependencyPlan
+    feedback: NotebookCompositionFeedback
 
 
 class NotebookComposer:
@@ -83,14 +119,221 @@ class NotebookComposer:
         normalized = "\n    ".join(lines).strip()
         return normalized or fallback
 
+    @staticmethod
+    def _package_import_probe(package_name: str) -> str:
+        """Return the import probe used to detect whether a package is installed."""
+
+        return _PACKAGE_IMPORT_PROBES.get(
+            package_name,
+            package_name.replace("-", "_").replace(".", "_"),
+        )
+
+    def _resolve_max_iterations(self, workflow_design: Dict[str, Any]) -> int:
+        """Resolve the iteration limit embedded into notebook cells."""
+
+        for key in ("max_iterations", "max_revisions"):
+            raw_value = workflow_design.get(key)
+            if isinstance(raw_value, int) and raw_value > 0:
+                return raw_value
+        return settings.notebook_composer_default_max_iterations
+
+    @staticmethod
+    def _record_fallback(
+        feedback: NotebookCompositionFeedback | None,
+        *,
+        kind: str,
+        item_name: str | None,
+        reason: str,
+        warning: str,
+    ) -> None:
+        """Record a structured fallback event when feedback tracking is enabled."""
+
+        if feedback is None:
+            return
+        feedback.fallback_used = True
+        if warning not in feedback.warnings:
+            feedback.warnings.append(warning)
+        feedback.fallback_events.append(
+            NotebookFallbackEvent(
+                kind=kind,
+                item_name=item_name,
+                reason=reason,
+                warning=warning,
+            )
+        )
+
+    def _fallback_banner(self, label: str, reason: str) -> str:
+        """Return a visible notebook-facing warning comment for fallback code."""
+
+        safe_label = self._normalize_inline_text(label, "generated component")
+        safe_reason = self._normalize_inline_text(
+            reason,
+            "Primary generation was unavailable or returned placeholder code.",
+        )
+        return (
+            f"# WARNING: Deterministic fallback generated for {safe_label}.\n"
+            f"# Reason: {safe_reason}\n\n"
+        )
+
+    def _add_dependency_candidate(
+        self,
+        plan: NotebookDependencyPlan,
+        selected_packages: List[str],
+        selected_families: Dict[str, str],
+        package_name: str,
+        *,
+        family: str | None = None,
+        requested_by: str | None = None,
+    ) -> None:
+        """Add a dependency candidate while deduplicating and resolving conflicts."""
+
+        normalized_package = str(package_name or "").strip()
+        if not normalized_package:
+            return
+
+        dependency_family = family or _PACKAGE_FAMILIES.get(normalized_package)
+        if dependency_family:
+            chosen = selected_families.get(dependency_family)
+            if chosen and chosen != normalized_package:
+                detail = (
+                    f"Kept '{chosen}' instead of '{normalized_package}' "
+                    f"for dependency family '{dependency_family}'."
+                )
+                if requested_by:
+                    detail += f" Requested by {requested_by}."
+                if detail not in plan.conflicts_resolved:
+                    plan.conflicts_resolved.append(detail)
+                return
+            selected_families[dependency_family] = normalized_package
+
+        if normalized_package not in selected_packages:
+            selected_packages.append(normalized_package)
+
+    def _plan_dependencies(
+        self,
+        tools: List[Dict[str, Any]],
+        workflow_design: Dict[str, Any],
+    ) -> NotebookDependencyPlan:
+        """Build a normalized dependency plan for the generated notebook."""
+
+        plan = NotebookDependencyPlan(
+            runtime_notes=[
+                "The install cell checks for missing packages before invoking pip.",
+                "Generated notebooks assume a Jupyter or Colab-style environment with pip available.",
+            ]
+        )
+        selected_packages: List[str] = []
+        selected_families: Dict[str, str] = {}
+
+        for package_name in ["langgraph", "langchain-core", "langchain-openai"]:
+            self._add_dependency_candidate(
+                plan,
+                selected_packages,
+                selected_families,
+                package_name,
+            )
+
+        for tool in tools:
+            category = self._normalize_inline_text(tool.get("category", ""), "").lower()
+            requested_packages = tool.get("configuration", {}).get("packages", [])
+            if isinstance(requested_packages, str):
+                requested_packages = [requested_packages]
+            for package_name in requested_packages if isinstance(requested_packages, list) else []:
+                self._add_dependency_candidate(
+                    plan,
+                    selected_packages,
+                    selected_families,
+                    str(package_name),
+                    requested_by=self._normalize_inline_text(tool.get("name", ""), "tool"),
+                )
+
+            inferred_packages: List[tuple[str, str | None]] = []
+            if "search" in category:
+                inferred_packages.append(("langchain-community", None))
+            if any(token in category for token in {"file", "document", "pdf"}):
+                inferred_packages.append(("pypdf", "pdf_parser"))
+            if "api" in category:
+                inferred_packages.append(("requests", None))
+
+            for package_name, family in inferred_packages:
+                self._add_dependency_candidate(
+                    plan,
+                    selected_packages,
+                    selected_families,
+                    package_name,
+                    family=family,
+                    requested_by=self._normalize_inline_text(tool.get("name", ""), "tool"),
+                )
+
+        if "langchain-openai" in selected_packages and "OPENAI_API_KEY" not in plan.provider_env_vars:
+            plan.provider_env_vars.append("OPENAI_API_KEY")
+
+        plan.packages = selected_packages
+        if selected_packages:
+            plan.install_commands = [
+                "python -m pip install -q " + " ".join(selected_packages)
+            ]
+        return plan
+
+    def _section_builders(
+        self,
+        context: _NotebookCompositionContext,
+    ) -> List[tuple[str, Any]]:
+        """Return the ordered internal section builders for notebook composition."""
+
+        resolved_max_iterations = context.feedback.resolved_max_iterations or 1
+        return [
+            (
+                "intro",
+                lambda: self._create_intro_cells(
+                    context.notebook_plan,
+                    context.architecture.get("justification"),
+                    context.workflow_design.get("graph_exports"),
+                ),
+            ),
+            ("install", lambda: self._create_install_cells(context.dependency_plan)),
+            (
+                "config",
+                lambda: self._create_config_cells(
+                    context.dependency_plan,
+                    context.feedback,
+                ),
+            ),
+            ("state", lambda: self._create_state_cells(context.workflow_design)),
+            (
+                "tools",
+                lambda: self._create_tool_cells(context.tools, context.feedback)
+                if context.tools
+                else [],
+            ),
+            (
+                "nodes",
+                lambda: self._create_node_cells(
+                    context.workflow_design,
+                    context.feedback,
+                ),
+            ),
+            (
+                "graph",
+                lambda: self._create_graph_cells(
+                    context.workflow_design,
+                    resolved_max_iterations,
+                ),
+            ),
+            (
+                "execution",
+                lambda: self._create_execution_cells(context.workflow_design),
+            ),
+        ]
+
     async def compose_notebook(
         self,
         notebook_plan: NotebookPlan,
         workflow_design: Dict[str, Any],
         tools: List[Dict[str, Any]],
         architecture: Dict[str, Any],
-    ) -> List[CellSpec]:
-        """Generate complete list of notebook cells.
+    ) -> NotebookCompositionResult:
+        """Generate complete notebook cells plus composition metadata.
 
         Args:
             notebook_plan: Notebook structure plan
@@ -99,7 +342,7 @@ class NotebookComposer:
             architecture: Architecture selection
 
         Returns:
-            List of CellSpec objects defining all notebook cells
+            Structured notebook composition output
         """
         # Ensure architecture_type is in workflow_design for pattern selection
         if (
@@ -108,40 +351,33 @@ class NotebookComposer:
         ):
             workflow_design["architecture_type"] = architecture["architecture_type"]
 
-        cells = []
-
-        # Title and intro cells
-        cells.extend(
-            self._create_intro_cells(
-                notebook_plan,
-                architecture.get("justification"),
-                workflow_design.get("graph_exports"),
-            )
+        feedback = NotebookCompositionFeedback(
+            resolved_model=self.model_config.model,
+            resolved_api_base=self.model_config.api_base,
+            resolved_max_iterations=self._resolve_max_iterations(workflow_design),
+        )
+        dependency_plan = self._plan_dependencies(tools, workflow_design)
+        context = _NotebookCompositionContext(
+            notebook_plan=notebook_plan,
+            workflow_design=workflow_design,
+            tools=tools,
+            architecture=architecture,
+            dependency_plan=dependency_plan,
+            feedback=feedback,
         )
 
-        # Installation cells
-        cells.extend(self._create_install_cells(tools))
+        cells: List[CellSpec] = []
+        for section_name, builder in self._section_builders(context):
+            section_cells = builder()
+            if section_cells:
+                feedback.sections_built.append(section_name)
+                cells.extend(section_cells)
 
-        # Configuration cells
-        cells.extend(self._create_config_cells())
-
-        # State definition
-        cells.extend(self._create_state_cells(workflow_design))
-
-        # Tool implementations
-        if tools:
-            cells.extend(self._create_tool_cells(tools))
-
-        # Node implementations
-        cells.extend(self._create_node_cells(workflow_design))
-
-        # Graph construction
-        cells.extend(self._create_graph_cells(workflow_design))
-
-        # Execution cells
-        cells.extend(self._create_execution_cells(workflow_design))
-
-        return cells
+        return NotebookCompositionResult(
+            cells=cells,
+            dependency_plan=dependency_plan,
+            feedback=feedback,
+        )
 
     def _create_intro_cells(
         self,
@@ -215,45 +451,69 @@ This notebook implements a LangGraph workflow using the **{plan.architecture_typ
 
         return cells
 
-    def _create_install_cells(self, tools: List[Dict[str, Any]]) -> List[CellSpec]:
-        """Create installation cells."""
-        packages = [
-            "langgraph",
-            "langchain-core",
-            "langchain-community",
-            "langchain-openai",
-        ]
+    def _create_install_cells(
+        self,
+        dependency_plan: NotebookDependencyPlan,
+    ) -> List[CellSpec]:
+        """Create normalized installation cells from the dependency plan."""
 
-        # Add tool-specific packages
-        for tool in tools:
-            category = tool.get("category", "")
-            if "search" in category.lower():
-                packages.append("langchain-community")
-            elif "file" in category.lower() or "document" in category.lower():
-                packages.append("pypdf")
+        package_imports = {
+            package: self._package_import_probe(package)
+            for package in dependency_plan.packages
+        }
+        install_content = f"""# Install missing notebook dependencies
+from importlib.util import find_spec
+import subprocess
+import sys
 
-        install_content = f"""# Install required packages
-!pip install -q {' '.join(packages)}"""
+PACKAGE_IMPORTS = {json.dumps(package_imports, indent=4)}
+REQUIRED_PACKAGES = {json.dumps(dependency_plan.packages, indent=4)}
+
+missing_packages = [
+    package
+    for package in REQUIRED_PACKAGES
+    if find_spec(PACKAGE_IMPORTS[package]) is None
+]
+
+if missing_packages:
+    print("Installing missing packages:", ", ".join(missing_packages))
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-q", *missing_packages])
+else:
+    print("All required packages are already available.")"""
+
+        markdown_lines = ["## Installation", "", "Install any missing packages needed by this notebook."]
+        if dependency_plan.runtime_notes:
+            markdown_lines.extend(["", "### Environment Notes", ""])
+            markdown_lines.extend(f"- {note}" for note in dependency_plan.runtime_notes)
+        if dependency_plan.conflicts_resolved:
+            markdown_lines.extend(["", "### Dependency Conflict Resolution", ""])
+            markdown_lines.extend(
+                f"- {detail}" for detail in dependency_plan.conflicts_resolved
+            )
 
         return [
             CellSpec(
                 cell_type="markdown",
-                content="## Installation\n\nInstall the required packages:",
+                content="\n".join(markdown_lines),
                 section="setup",
             ),
             CellSpec(cell_type="code", content=install_content, section="setup"),
         ]
 
-    def _create_config_cells(self) -> List[CellSpec]:
-        """Create configuration cells."""
+    def _create_config_cells(
+        self,
+        dependency_plan: NotebookDependencyPlan,
+        feedback: NotebookCompositionFeedback,
+    ) -> List[CellSpec]:
+        """Create configuration cells using resolved request-scoped settings."""
+
         config_lines = [
             "import os",
-            "from getpass import getpass",
             "",
             "# Configuration",
             f"MODEL = {json.dumps(self.model_config.model)}",
             f"TEMPERATURE = {self.model_config.temperature}",
-            "MAX_ITERATIONS = 10",
+            f"MAX_ITERATIONS = {feedback.resolved_max_iterations}",
             (
                 f"MAX_TOKENS = {self.model_config.max_tokens}"
                 if self.model_config.max_tokens is not None
@@ -265,13 +525,25 @@ This notebook implements a LangGraph workflow using the **{plan.architecture_typ
                 else "API_BASE = None"
             ),
             "",
-            "# API Keys",
-            'if not os.environ.get("OPENAI_API_KEY"):',
-            '    os.environ["OPENAI_API_KEY"] = getpass("Enter OpenAI API Key: ")',
-            "",
-            'if not os.environ.get("ANTHROPIC_API_KEY"):',
-            '    os.environ["ANTHROPIC_API_KEY"] = getpass("Enter Anthropic API Key (optional): ")',
+            "# Credentials",
+            "# Prefer environment variables over hardcoded secrets in notebooks.",
         ]
+        for env_var in dependency_plan.provider_env_vars:
+            config_lines.extend(
+                [
+                    f'{env_var} = os.environ.get("{env_var}", "")',
+                    f'if not {env_var}:',
+                    f'    print("{env_var} is not set. Configure it in your environment before running live model cells.")',
+                    "    # Optional interactive fallback for local notebook sessions:",
+                    "    # from getpass import getpass",
+                    f'    # os.environ["{env_var}"] = getpass("Enter {env_var}: ")',
+                    "",
+                ]
+            )
+        if not dependency_plan.provider_env_vars:
+            config_lines.append(
+                "# No provider-specific credential environment variables were required for this notebook."
+            )
         config_content = "\n".join(config_lines)
 
         return [
@@ -323,8 +595,12 @@ class WorkflowState(MessagesState):
             CellSpec(cell_type="code", content=state_content, section="state"),
         ]
 
-    def _create_tool_cells(self, tools: List[Dict[str, Any]]) -> List[CellSpec]:
-        """Create tool implementation cells with LLM-generated code."""
+    def _create_tool_cells(
+        self,
+        tools: List[Dict[str, Any]],
+        feedback: NotebookCompositionFeedback,
+    ) -> List[CellSpec]:
+        """Create tool implementation cells with tracked fallback behavior."""
         cells = [
             CellSpec(
                 cell_type="markdown",
@@ -335,13 +611,18 @@ class WorkflowState(MessagesState):
 
         for tool in tools:
             # Try to generate real implementation with LLM
-            tool_code = self._generate_tool_implementation(tool)
+            tool_code = self._generate_tool_implementation(tool, feedback=feedback)
 
             cells.append(CellSpec(cell_type="code", content=tool_code, section="tools"))
 
         return cells
 
-    def _generate_tool_implementation(self, tool: Dict[str, Any]) -> str:
+    def _generate_tool_implementation(
+        self,
+        tool: Dict[str, Any],
+        *,
+        feedback: NotebookCompositionFeedback | None = None,
+    ) -> str:
         """Generate tool implementation using LLM.
 
         Args:
@@ -391,7 +672,13 @@ Generate the complete Python function implementation.""")
             response = self.llm.invoke([system_prompt, user_prompt])
             generated_code = self._strip_code_fences(response.content)
             if not self._is_meaningful_tool_code(generated_code):
-                return self._generate_tool_fallback(tool)
+                return self._generate_tool_fallback(
+                    tool,
+                    reason=(
+                        "LLM tool generation returned placeholder or incomplete code."
+                    ),
+                    feedback=feedback,
+                )
 
             # Add header comment
             header = f"""# Tool: {tool_name}
@@ -401,14 +688,28 @@ Generate the complete Python function implementation.""")
 """
             return header + generated_code
 
-        except (ValueError, KeyError, AttributeError):
+        except (ValueError, KeyError, AttributeError) as exc:
             # Fallback to template with better implementation hints
-            return self._generate_tool_fallback(tool)
-        except Exception:
+            return self._generate_tool_fallback(
+                tool,
+                reason=f"Tool generation could not parse the tool specification: {exc}",
+                feedback=feedback,
+            )
+        except Exception as exc:
             # Unexpected error - still fallback but this is unusual
-            return self._generate_tool_fallback(tool)
+            return self._generate_tool_fallback(
+                tool,
+                reason=f"Tool generation failed unexpectedly: {type(exc).__name__}: {exc}",
+                feedback=feedback,
+            )
 
-    def _generate_tool_fallback(self, tool: Dict[str, Any]) -> str:
+    def _generate_tool_fallback(
+        self,
+        tool: Dict[str, Any],
+        *,
+        reason: str | None = None,
+        feedback: NotebookCompositionFeedback | None = None,
+    ) -> str:
         """Generate a deterministic fallback tool implementation.
 
         Args:
@@ -429,8 +730,19 @@ Generate the complete Python function implementation.""")
         )
         safe_tool_category = self._normalize_inline_text(tool_category, "general")
         func_name = self._safe_identifier(tool_name, "unknown_tool")
+        warning = (
+            f'Deterministic fallback used for tool "{safe_tool_name}".'
+        )
+        self._record_fallback(
+            feedback,
+            kind="tool",
+            item_name=safe_tool_name,
+            reason=reason or "Primary tool generation was unavailable.",
+            warning=warning,
+        )
 
-        header = f"""# Tool: {safe_tool_name}
+        header = f"""{self._fallback_banner(f'tool "{safe_tool_name}"', reason or "Primary tool generation was unavailable.")}
+# Tool: {safe_tool_name}
 # Purpose: {safe_tool_purpose_comment}
 # Category: {safe_tool_category}
 
@@ -516,8 +828,12 @@ Generate the complete Python function implementation.""")
 
         return header + implementation
 
-    def _create_node_cells(self, workflow_design: Dict[str, Any]) -> List[CellSpec]:
-        """Create node implementation cells with LLM-generated or pattern-based code."""
+    def _create_node_cells(
+        self,
+        workflow_design: Dict[str, Any],
+        feedback: NotebookCompositionFeedback,
+    ) -> List[CellSpec]:
+        """Create node implementation cells with tracked fallback behavior."""
         cells = [
             CellSpec(
                 cell_type="markdown",
@@ -545,7 +861,11 @@ Generate the complete Python function implementation.""")
         else:
             # Use LLM for custom node generation
             for node in nodes:
-                node_code = self._generate_node_implementation(node, workflow_design)
+                node_code = self._generate_node_implementation(
+                    node,
+                    workflow_design,
+                    feedback=feedback,
+                )
                 cells.append(
                     CellSpec(cell_type="code", content=node_code, section="nodes")
                 )
@@ -553,7 +873,11 @@ Generate the complete Python function implementation.""")
         return cells
 
     def _generate_node_implementation(
-        self, node: Dict[str, Any], workflow_design: Dict[str, Any]
+        self,
+        node: Dict[str, Any],
+        workflow_design: Dict[str, Any],
+        *,
+        feedback: NotebookCompositionFeedback | None = None,
     ) -> str:
         """Generate node implementation using LLM.
 
@@ -608,19 +932,41 @@ Generate the complete Python function implementation.""")
             response = self.llm.invoke([system_prompt, user_prompt])
             generated_code = self._strip_code_fences(response.content)
             if not self._is_meaningful_node_code(generated_code):
-                return self._generate_node_fallback(node, workflow_design)
+                return self._generate_node_fallback(
+                    node,
+                    workflow_design,
+                    reason=(
+                        "LLM node generation returned placeholder or incomplete code."
+                    ),
+                    feedback=feedback,
+                )
 
             return generated_code
 
-        except (ValueError, KeyError, AttributeError):
+        except (ValueError, KeyError, AttributeError) as exc:
             # Fallback to improved template
-            return self._generate_node_fallback(node, workflow_design)
-        except Exception:
+            return self._generate_node_fallback(
+                node,
+                workflow_design,
+                reason=f"Node generation could not parse the node specification: {exc}",
+                feedback=feedback,
+            )
+        except Exception as exc:
             # Unexpected error - still fallback
-            return self._generate_node_fallback(node, workflow_design)
+            return self._generate_node_fallback(
+                node,
+                workflow_design,
+                reason=f"Node generation failed unexpectedly: {type(exc).__name__}: {exc}",
+                feedback=feedback,
+            )
 
     def _generate_node_fallback(
-        self, node: Dict[str, Any], workflow_design: Dict[str, Any]
+        self,
+        node: Dict[str, Any],
+        workflow_design: Dict[str, Any],
+        *,
+        reason: str | None = None,
+        feedback: NotebookCompositionFeedback | None = None,
     ) -> str:
         """Generate deterministic fallback node implementation.
 
@@ -639,6 +985,14 @@ Generate the complete Python function implementation.""")
         safe_node_purpose = self._normalize_docstring_text(
             node_purpose,
             f"Process workflow state in the {safe_node_name} node.",
+        )
+        warning = f'Deterministic fallback used for node "{safe_node_name}".'
+        self._record_fallback(
+            feedback,
+            kind="node",
+            item_name=safe_node_name,
+            reason=reason or "Primary node generation was unavailable.",
+            warning=warning,
         )
         routes = [
             candidate.get("name")
@@ -727,7 +1081,8 @@ Generate the complete Python function implementation.""")
 
         update_lines.append("    return updates")
 
-        return f"""def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
+        return f"""{self._fallback_banner(f'node "{safe_node_name}"', reason or "Primary node generation was unavailable.")}
+def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
     \"\"\"
     {safe_node_purpose}
     \"\"\"
@@ -980,7 +1335,11 @@ Generate the complete Python function implementation.""")
 
         return cells
 
-    def _create_graph_cells(self, workflow_design: Dict[str, Any]) -> List[CellSpec]:
+    def _create_graph_cells(
+        self,
+        workflow_design: Dict[str, Any],
+        max_iterations: int,
+    ) -> List[CellSpec]:
         """Create graph construction cells using pattern library or custom generation."""
         architecture_type = workflow_design.get("architecture_type", "router")
         nodes = workflow_design.get("nodes", [])
@@ -995,12 +1354,16 @@ Generate the complete Python function implementation.""")
             subagents = [
                 node.get("name") for node in nodes if node.get("name") != "supervisor"
             ]
-            graph_code = SubagentsPattern.generate_graph_code(subagents)
+            graph_code = SubagentsPattern.generate_graph_code(
+                subagents,
+                max_iterations=max_iterations,
+            )
         elif architecture_type == "hybrid":
             direct_specialists, _, team_workers, _ = self._split_hybrid_nodes(nodes)
             graph_code = HybridPattern.generate_graph_code(
                 direct_specialists,
                 team_workers,
+                max_iterations=max_iterations,
             )
         elif architecture_type == "autoagent":
             workers = [
@@ -1008,10 +1371,14 @@ Generate the complete Python function implementation.""")
                 for node in nodes
                 if node.get("name") not in {"coordinator", "supervisor"}
             ]
-            graph_code = AutoAgentPattern.generate_graph_code(workers)
+            graph_code = AutoAgentPattern.generate_graph_code(
+                workers,
+                max_iterations=max_iterations,
+            )
         elif architecture_type == "critique_loop":
             graph_code = CritiqueLoopPattern.generate_graph_code(
-                max_revisions=3, min_quality_score=0.8
+                max_revisions=max_iterations,
+                min_quality_score=0.8,
             )
         else:
             # Fallback to enhanced template-based generation

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -235,10 +235,15 @@ class NotebookComposer:
 
         for tool in tools:
             category = self._normalize_inline_text(tool.get("category", ""), "").lower()
-            requested_packages = tool.get("configuration", {}).get("packages", [])
+            tool_configuration = tool.get("configuration")
+            if not isinstance(tool_configuration, dict):
+                tool_configuration = {}
+            requested_packages = tool_configuration.get("packages", [])
             if isinstance(requested_packages, str):
                 requested_packages = [requested_packages]
-            for package_name in requested_packages if isinstance(requested_packages, list) else []:
+            if not isinstance(requested_packages, list):
+                requested_packages = []
+            for package_name in requested_packages:
                 self._add_dependency_candidate(
                     plan,
                     selected_packages,

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -25,6 +25,8 @@ from langgraph_system_generator.generator.state import (
     CellSpec,
     DocSnippet,
     GeneratorState,
+    NotebookCompositionFeedback,
+    NotebookDependencyPlan,
     GraphDesignFeedback,
     GraphExportBundle,
     NotebookPlan,
@@ -363,11 +365,15 @@ async def notebook_assembly_node(state: GeneratorState) -> Dict[str, Any]:
         "justification": state["architecture_justification"],
     }
 
-    cells = await composer.compose_notebook(
+    composition = await composer.compose_notebook(
         notebook_plan, workflow_design, tools_plan, architecture
     )
 
-    return {"generated_cells": cells}
+    return {
+        "generated_cells": composition.cells,
+        "notebook_composition_feedback": composition.feedback,
+        "notebook_dependency_plan": composition.dependency_plan,
+    }
 
 
 def _cells_from_notebook(path: Path) -> List[CellSpec]:
@@ -641,6 +647,8 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
     architecture_feedback = state.get("architecture_feedback")
     graph_design_feedback = state.get("graph_design_feedback")
     graph_exports = state.get("graph_exports")
+    notebook_composition_feedback = state.get("notebook_composition_feedback")
+    notebook_dependency_plan = state.get("notebook_dependency_plan")
     manifest = {
         "notebook_plan": str(state.get("notebook_plan")),
         "cell_count": str(len(state.get("generated_cells", []))),
@@ -671,6 +679,21 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
             graph_exports.model_dump(by_alias=True)
             if hasattr(graph_exports, "model_dump")
             else (graph_exports or GraphExportBundle().model_dump(by_alias=True))
+        ),
+        "notebook_composition_feedback": (
+            notebook_composition_feedback.model_dump()
+            if hasattr(notebook_composition_feedback, "model_dump")
+            else (
+                notebook_composition_feedback
+                or NotebookCompositionFeedback(fallback_used=False).model_dump()
+            )
+        ),
+        "notebook_dependency_plan": (
+            notebook_dependency_plan.model_dump()
+            if hasattr(notebook_dependency_plan, "model_dump")
+            else (
+                notebook_dependency_plan or NotebookDependencyPlan().model_dump()
+            )
         ),
     }
 

--- a/src/langgraph_system_generator/generator/state.py
+++ b/src/langgraph_system_generator/generator/state.py
@@ -371,6 +371,79 @@ class NotebookPlan(BaseModel):
     )
 
 
+class NotebookDependencyPlan(BaseModel):
+    """Normalized dependency and install plan for a generated notebook."""
+
+    packages: List[str] = Field(
+        default_factory=list,
+        description="Ordered, de-duplicated packages required by the notebook.",
+    )
+    install_commands: List[str] = Field(
+        default_factory=list,
+        description="Install commands emitted or recommended for the notebook runtime.",
+    )
+    runtime_notes: List[str] = Field(
+        default_factory=list,
+        description="Environment assumptions or install notes shown to notebook users.",
+    )
+    conflicts_resolved: List[str] = Field(
+        default_factory=list,
+        description="Dependency family conflicts resolved during planning.",
+    )
+    provider_env_vars: List[str] = Field(
+        default_factory=list,
+        description="Credential environment variables referenced by notebook config.",
+    )
+
+
+class NotebookFallbackEvent(BaseModel):
+    """Structured record of a notebook-composition fallback."""
+
+    kind: str = Field(description="Notebook component that used a fallback path.")
+    item_name: Optional[str] = Field(
+        default=None,
+        description="Tool or node name associated with the fallback, when applicable.",
+    )
+    reason: str = Field(description="Reason the fallback path was used.")
+    warning: str = Field(
+        description="Visible notebook-facing warning emitted for this fallback."
+    )
+
+
+class NotebookCompositionFeedback(BaseModel):
+    """Advisory feedback captured during notebook composition."""
+
+    fallback_used: bool = Field(
+        default=False,
+        description="Whether notebook composition used one or more deterministic fallbacks.",
+    )
+    warnings: List[str] = Field(
+        default_factory=list,
+        description="Advisory composition warnings surfaced to manifests and callers.",
+    )
+    fallback_events: List[NotebookFallbackEvent] = Field(
+        default_factory=list,
+        description="Structured fallback events captured during notebook composition.",
+    )
+    resolved_model: Optional[str] = Field(
+        default=None,
+        description="Resolved model identifier embedded in notebook config cells.",
+    )
+    resolved_api_base: Optional[str] = Field(
+        default=None,
+        description="Resolved OpenAI-compatible base URL embedded in config cells.",
+    )
+    resolved_max_iterations: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Resolved iteration limit embedded in notebook cells.",
+    )
+    sections_built: List[str] = Field(
+        default_factory=list,
+        description="Ordered internal section builders used to assemble the notebook.",
+    )
+
+
 class CellSpec(BaseModel):
     """Specification for a notebook cell."""
 
@@ -379,6 +452,23 @@ class CellSpec(BaseModel):
     metadata: Dict[str, Any] = Field(default_factory=dict, description="Cell metadata")
     section: Optional[str] = Field(
         default=None, description="Section this cell belongs to"
+    )
+
+
+class NotebookCompositionResult(BaseModel):
+    """Structured notebook composition output consumed by downstream stages."""
+
+    cells: List[CellSpec] = Field(
+        default_factory=list,
+        description="Generated notebook cells in final execution order.",
+    )
+    dependency_plan: NotebookDependencyPlan = Field(
+        default_factory=NotebookDependencyPlan,
+        description="Resolved dependency and install metadata for the notebook.",
+    )
+    feedback: NotebookCompositionFeedback = Field(
+        default_factory=NotebookCompositionFeedback,
+        description="Advisory notebook-composition metadata.",
     )
 
 
@@ -431,6 +521,8 @@ class GeneratorState(TypedDict):
     # Workflow design (added for graph designer)
     workflow_design: Optional[Dict[str, Any]]
     tools_plan: Optional[List[Dict[str, Any]]]
+    notebook_composition_feedback: NotebookCompositionFeedback
+    notebook_dependency_plan: NotebookDependencyPlan
 
     # Generation
     # NOTE: `generated_cells` is intentionally *not* annotated with `operator.add`.

--- a/src/langgraph_system_generator/utils/config.py
+++ b/src/langgraph_system_generator/utils/config.py
@@ -154,6 +154,26 @@ class Settings(BaseSettings):
         ge=1,
         description="Maximum number of weighted docs snippets included in the architecture selector prompt.",
     )
+    notebook_composer_default_max_iterations: int = Field(
+        default=10,
+        ge=1,
+        description="Default iteration limit embedded in generated notebook cells.",
+    )
+    notebook_composer_parallelism_mode: str = Field(
+        default="parallel",
+        description="Internal notebook-composer parallelism mode: parallel or sequential.",
+    )
+    notebook_composer_max_concurrency: int = Field(
+        default=4,
+        ge=1,
+        description="Maximum concurrent notebook-composer generation tasks when parallel mode is enabled.",
+    )
+    notebook_composer_plugin_modules: Annotated[list[str], NoDecode] = Field(
+        default_factory=list,
+        description=(
+            "Optional notebook composer plugin modules loaded to extend internal section builders."
+        ),
+    )
     graph_designer_plugin_modules: Annotated[list[str], NoDecode] = Field(
         default_factory=list,
         description=(
@@ -299,6 +319,55 @@ class Settings(BaseSettings):
                 normalized.append(module_name)
         return normalized
 
+    @field_validator("notebook_composer_plugin_modules", mode="before")
+    @classmethod
+    def _parse_notebook_composer_plugin_modules(cls, value):
+        """Accept JSON arrays or comma-separated plugin module strings."""
+        if value in (None, ""):
+            return []
+        if isinstance(value, list):
+            raw_items = value
+        elif isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return []
+            if stripped.startswith("["):
+                try:
+                    parsed = json.loads(stripped)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"Invalid JSON in notebook_composer_plugin_modules: {exc}"
+                    ) from exc
+                if not isinstance(parsed, list):
+                    raise ValueError(
+                        "notebook_composer_plugin_modules must decode to a list"
+                    )
+                raw_items = parsed
+            else:
+                raw_items = stripped.split(",")
+        else:
+            return value
+
+        normalized: list[str] = []
+        for raw_item in raw_items:
+            module_name = str(raw_item or "").strip()
+            if module_name and module_name not in normalized:
+                normalized.append(module_name)
+        return normalized
+
+    @field_validator("notebook_composer_parallelism_mode", mode="before")
+    @classmethod
+    def _validate_notebook_composer_parallelism_mode(cls, value):
+        """Normalize and validate notebook composer parallelism mode values."""
+        normalized = str(value or "").strip().lower()
+        if not normalized:
+            return "parallel"
+        if normalized not in {"parallel", "sequential"}:
+            raise ValueError(
+                "notebook_composer_parallelism_mode must be 'parallel' or 'sequential'"
+            )
+        return normalized
+
 
 _DEFAULT_ENV_FILE = object()
 _TEST_SETTINGS_ENV_KEYS = (
@@ -315,6 +384,10 @@ _TEST_SETTINGS_ENV_KEYS = (
     "ARCHITECTURE_PATTERN_DOC_QUERIES",
     "ARCHITECTURE_PATTERN_DOC_WEIGHTS",
     "ARCHITECTURE_PROMPT_DOC_LIMIT",
+    "NOTEBOOK_COMPOSER_DEFAULT_MAX_ITERATIONS",
+    "NOTEBOOK_COMPOSER_PARALLELISM_MODE",
+    "NOTEBOOK_COMPOSER_MAX_CONCURRENCY",
+    "NOTEBOOK_COMPOSER_PLUGIN_MODULES",
     "GRAPH_DESIGNER_PLUGIN_MODULES",
 )
 

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -60,11 +60,15 @@ async def test_generate_artifacts_stub(tmp_path: Path, monkeypatch: pytest.Monke
     assert artifacts["manifest"]["architecture_feedback"]["docs_considered"] == []
     assert artifacts["manifest"]["graph_design_feedback"]["fallback_used"] is False
     assert "flowchart TD" in artifacts["manifest"]["graph_exports"]["mermaid"]
+    assert artifacts["manifest"]["notebook_composition_feedback"]["fallback_used"] is False
+    assert "langgraph" in artifacts["manifest"]["notebook_dependency_plan"]["packages"]
     assert artifacts["result"]["requirements_feedback"]["fallback_used"] is False
     assert artifacts["result"]["architecture_feedback"]["fallback_used"] is False
     assert artifacts["result"]["architecture_feedback"]["docs_considered"] == []
     assert artifacts["result"]["graph_design_feedback"]["fallback_used"] is False
     assert "flowchart TD" in artifacts["result"]["graph_exports"]["mermaid"]
+    assert artifacts["result"]["notebook_composition_feedback"]["fallback_used"] is False
+    assert "OPENAI_API_KEY" in artifacts["result"]["notebook_dependency_plan"]["provider_env_vars"]
     assert Path(artifacts["manifest_path"]).exists()
     assert artifacts["result"]["generation_complete"] is True
 
@@ -84,6 +88,8 @@ def test_default_state_includes_generation_mode_and_qa_history():
     assert state["architecture_feedback"].fallback_used is False
     assert state["graph_design_feedback"].fallback_used is False
     assert state["graph_exports"].schema == {}
+    assert state["notebook_composition_feedback"].fallback_used is False
+    assert state["notebook_dependency_plan"].packages == []
     assert "goal" in state["requirements_feedback"].available_constraint_types
 
 
@@ -119,6 +125,11 @@ def test_default_and_stub_results_normalize_constraint_type_registry(monkeypatch
 
     assert state["requirements_feedback"].available_constraint_types == expected_registry
     assert stub_result["requirements_feedback"].available_constraint_types == expected_registry
+    assert (
+        stub_result["notebook_composition_feedback"].resolved_model
+        == cli_module.settings.default_model
+    )
+    assert "langgraph" in stub_result["notebook_dependency_plan"].packages
 
 
 @pytest.mark.asyncio
@@ -249,6 +260,8 @@ async def test_api_generate_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert payload["output_dir"] == str(output_dir)
     assert payload["manifest"]["requirements_feedback"]["fallback_used"] is False
     assert payload["manifest"]["architecture_feedback"]["fallback_used"] is False
+    assert payload["manifest"]["notebook_composition_feedback"]["fallback_used"] is False
+    assert "langgraph" in payload["manifest"]["notebook_dependency_plan"]["packages"]
 
 
 @pytest.mark.asyncio
@@ -405,6 +418,84 @@ async def test_generate_artifacts_surfaces_graph_design_feedback_as_warnings(
     assert "graph_design_validation" in warning_codes
     assert artifacts["manifest"]["graph_design_feedback"]["fallback_used"] is True
     assert "flowchart TD" in artifacts["manifest"]["graph_exports"]["mermaid"]
+
+
+@pytest.mark.asyncio
+async def test_generate_artifacts_surfaces_notebook_composition_feedback_as_warnings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_notebook_feedback_warning")
+
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.cli as cli_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(cli_module)
+
+    original_build_stub_result = cli_module._build_stub_result
+
+    def build_stub_result_with_notebook_feedback(
+        prompt: str,
+        agent_type: str | None = None,
+    ):
+        result = original_build_stub_result(prompt, agent_type=agent_type)
+        result["notebook_composition_feedback"] = {
+            "fallback_used": True,
+            "warnings": ['Deterministic fallback used for tool "search".'],
+            "fallback_events": [
+                {
+                    "kind": "tool",
+                    "item_name": "search",
+                    "reason": "LLM tool generation returned placeholder or incomplete code.",
+                    "warning": 'Deterministic fallback used for tool "search".',
+                }
+            ],
+            "resolved_model": "gpt-5.2",
+            "resolved_api_base": None,
+            "resolved_max_iterations": 10,
+            "sections_built": [
+                "intro",
+                "install",
+                "config",
+                "state",
+                "tools",
+                "nodes",
+                "graph",
+                "execution",
+            ],
+        }
+        result["notebook_dependency_plan"] = {
+            "packages": ["langgraph", "langchain-openai", "requests"],
+            "install_commands": [
+                "python -m pip install -q langgraph langchain-openai requests"
+            ],
+            "runtime_notes": [
+                "The install cell checks for missing packages before invoking pip."
+            ],
+            "conflicts_resolved": [],
+            "provider_env_vars": ["OPENAI_API_KEY"],
+        }
+        return result
+
+    monkeypatch.setattr(
+        cli_module,
+        "_build_stub_result",
+        build_stub_result_with_notebook_feedback,
+    )
+
+    output_dir = constants_module._BASE_OUTPUT / "notebook_feedback_stub"
+    artifacts = await cli_module.generate_artifacts(
+        "Notebook feedback prompt",
+        output_dir=str(output_dir),
+        mode="stub",
+    )
+
+    warning_codes = {warning["code"] for warning in artifacts["manifest"]["warnings"]}
+    assert "notebook_composition_fallback" in warning_codes
+    assert artifacts["manifest"]["notebook_composition_feedback"]["fallback_used"] is True
+    assert "requests" in artifacts["manifest"]["notebook_dependency_plan"]["packages"]
 
 
 def test_build_stub_result_raises_for_invalid_stub_graph_design(monkeypatch):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -203,6 +203,62 @@ def test_settings_parse_graph_designer_plugin_modules_from_csv(tmp_path):
     ]
 
 
+def test_settings_parse_notebook_composer_plugin_modules_from_json(tmp_path):
+    env_path = Path(tmp_path) / ".env"
+    env_path.write_text(
+        'NOTEBOOK_COMPOSER_PLUGIN_MODULES=["pkg.plugins.alpha","pkg.plugins.beta"]\n',
+        encoding="utf-8",
+    )
+
+    class FileSettings(Settings):
+        model_config = SettingsConfigDict(
+            env_file=env_path, env_file_encoding="utf-8", extra="ignore"
+        )
+
+    loaded = FileSettings()
+
+    assert loaded.notebook_composer_plugin_modules == [
+        "pkg.plugins.alpha",
+        "pkg.plugins.beta",
+    ]
+
+
+def test_settings_parse_notebook_composer_plugin_modules_from_csv(tmp_path):
+    env_path = Path(tmp_path) / ".env"
+    env_path.write_text(
+        "NOTEBOOK_COMPOSER_PLUGIN_MODULES=pkg.plugins.alpha, pkg.plugins.beta , pkg.plugins.alpha\n",
+        encoding="utf-8",
+    )
+
+    class FileSettings(Settings):
+        model_config = SettingsConfigDict(
+            env_file=env_path, env_file_encoding="utf-8", extra="ignore"
+        )
+
+    loaded = FileSettings()
+
+    assert loaded.notebook_composer_plugin_modules == [
+        "pkg.plugins.alpha",
+        "pkg.plugins.beta",
+    ]
+
+
+def test_settings_validates_notebook_composer_parallelism_mode(tmp_path):
+    env_path = Path(tmp_path) / ".env"
+    env_path.write_text(
+        "NOTEBOOK_COMPOSER_PARALLELISM_MODE=sequential\n",
+        encoding="utf-8",
+    )
+
+    class FileSettings(Settings):
+        model_config = SettingsConfigDict(
+            env_file=env_path, env_file_encoding="utf-8", extra="ignore"
+        )
+
+    loaded = FileSettings()
+    assert loaded.notebook_composer_parallelism_mode == "sequential"
+
+
 def test_model_config_defaults():
     """Test ModelConfig uses correct defaults."""
     config = ModelConfig()

--- a/tests/unit/test_generator_nodes.py
+++ b/tests/unit/test_generator_nodes.py
@@ -17,6 +17,9 @@ from langgraph_system_generator.generator.state import (
     CellSpec,
     Constraint,
     DocSnippet,
+    NotebookCompositionFeedback,
+    NotebookCompositionResult,
+    NotebookDependencyPlan,
     NotebookPlan,
     RequirementsAnalysis,
     RequirementsFeedback,
@@ -94,13 +97,24 @@ async def test_notebook_assembly_node_passes_architecture_and_plans():
     expected_cells = [
         CellSpec(cell_type="markdown", content="# Intro", metadata={}, section="Setup")
     ]
+    expected_feedback = NotebookCompositionFeedback(
+        fallback_used=True,
+        warnings=["Notebook composition used deterministic fallback content."],
+    )
+    expected_dependency_plan = NotebookDependencyPlan(
+        packages=["langgraph", "langchain-openai"]
+    )
 
     async def capture_compose(plan, design, tools, architecture):
         captured_args["plan"] = plan
         captured_args["design"] = design
         captured_args["tools"] = tools
         captured_args["architecture"] = architecture
-        return expected_cells
+        return NotebookCompositionResult(
+            cells=expected_cells,
+            feedback=expected_feedback,
+            dependency_plan=expected_dependency_plan,
+        )
 
     with patch(
         "langgraph_system_generator.generator.agents.notebook_composer.ChatOpenAI",
@@ -121,7 +135,11 @@ async def test_notebook_assembly_node_passes_architecture_and_plans():
                 }
             )
 
-    assert result == {"generated_cells": expected_cells}
+    assert result == {
+        "generated_cells": expected_cells,
+        "notebook_composition_feedback": expected_feedback,
+        "notebook_dependency_plan": expected_dependency_plan,
+    }
     assert captured_args["plan"] is notebook_plan
     assert captured_args["design"] == workflow_design
     assert captured_args["tools"] == tools_plan
@@ -148,10 +166,16 @@ async def test_notebook_assembly_node_fallback_when_primary_missing():
     expected_cells = [
         CellSpec(cell_type="markdown", content="# Intro", metadata={}, section="Setup")
     ]
+    expected_feedback = NotebookCompositionFeedback(fallback_used=False)
+    expected_dependency_plan = NotebookDependencyPlan()
 
     async def capture_compose(plan, design, tools, architecture):
         captured_args["architecture"] = architecture
-        return expected_cells
+        return NotebookCompositionResult(
+            cells=expected_cells,
+            feedback=expected_feedback,
+            dependency_plan=expected_dependency_plan,
+        )
 
     with patch(
         "langgraph_system_generator.generator.agents.notebook_composer.ChatOpenAI",
@@ -172,7 +196,11 @@ async def test_notebook_assembly_node_fallback_when_primary_missing():
                 }
             )
 
-    assert result == {"generated_cells": expected_cells}
+    assert result == {
+        "generated_cells": expected_cells,
+        "notebook_composition_feedback": expected_feedback,
+        "notebook_dependency_plan": expected_dependency_plan,
+    }
     assert captured_args["architecture"] == {
         "architecture_type": "router",  # Should default to "router"
         "justification": "Fits the request.",
@@ -196,10 +224,16 @@ async def test_notebook_assembly_node_fallback_when_selected_patterns_missing():
     expected_cells = [
         CellSpec(cell_type="markdown", content="# Intro", metadata={}, section="Setup")
     ]
+    expected_feedback = NotebookCompositionFeedback(fallback_used=False)
+    expected_dependency_plan = NotebookDependencyPlan()
 
     async def capture_compose(plan, design, tools, architecture):
         captured_args["architecture"] = architecture
-        return expected_cells
+        return NotebookCompositionResult(
+            cells=expected_cells,
+            feedback=expected_feedback,
+            dependency_plan=expected_dependency_plan,
+        )
 
     with patch(
         "langgraph_system_generator.generator.agents.notebook_composer.ChatOpenAI",
@@ -220,7 +254,11 @@ async def test_notebook_assembly_node_fallback_when_selected_patterns_missing():
                 }
             )
 
-    assert result == {"generated_cells": expected_cells}
+    assert result == {
+        "generated_cells": expected_cells,
+        "notebook_composition_feedback": expected_feedback,
+        "notebook_dependency_plan": expected_dependency_plan,
+    }
     assert captured_args["architecture"] == {
         "architecture_type": "router",  # Should default to "router"
         "justification": "Fits the request.",

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -27,6 +27,9 @@ from langgraph_system_generator.generator.state import (
     Constraint,
     GraphDesignFeedback,
     GraphExportBundle,
+    NotebookCompositionFeedback,
+    NotebookCompositionResult,
+    NotebookDependencyPlan,
     QAReport,
 )
 from langgraph_system_generator.utils.config import GenerationConfig
@@ -298,6 +301,13 @@ async def test_tooling_plan_node_returns_tools_plan(monkeypatch):
 @pytest.mark.asyncio
 async def test_notebook_assembly_node_returns_generated_cells(monkeypatch):
     cells = [CellSpec(cell_type="markdown", content="Hi", metadata={})]
+    feedback = NotebookCompositionFeedback(
+        fallback_used=True,
+        warnings=["Notebook composition used deterministic fallback content."],
+    )
+    dependency_plan = NotebookDependencyPlan(
+        packages=["langgraph", "langchain-openai"]
+    )
     # Mock NotebookComposer to return cells without needing LLM
     payload = "[]"  # Dummy payload since we'll mock the compose method
 
@@ -308,7 +318,11 @@ async def test_notebook_assembly_node_returns_generated_cells(monkeypatch):
     )
 
     async def fake_compose_notebook(*_args, **_kwargs):
-        return cells
+        return NotebookCompositionResult(
+            cells=cells,
+            feedback=feedback,
+            dependency_plan=dependency_plan,
+        )
 
     monkeypatch.setattr(
         "langgraph_system_generator.generator.nodes.NotebookComposer.compose_notebook",
@@ -334,6 +348,8 @@ async def test_notebook_assembly_node_returns_generated_cells(monkeypatch):
     result = await notebook_assembly_node(state)
 
     assert result["generated_cells"] == cells
+    assert result["notebook_composition_feedback"] == feedback
+    assert result["notebook_dependency_plan"] == dependency_plan
 
 
 @pytest.mark.asyncio
@@ -596,6 +612,15 @@ async def test_package_outputs_node_manifest_fields():
                 },
             },
         ),
+        "notebook_composition_feedback": NotebookCompositionFeedback(
+            fallback_used=True,
+            warnings=["Deterministic fallback used for node \"enrich\"."],
+            sections_built=["intro", "install", "config", "state", "nodes", "graph"],
+        ),
+        "notebook_dependency_plan": NotebookDependencyPlan(
+            packages=["langgraph", "langchain-openai", "requests"],
+            provider_env_vars=["OPENAI_API_KEY"],
+        ),
     }
     result = await package_outputs_node(state)
 
@@ -606,4 +631,6 @@ async def test_package_outputs_node_manifest_fields():
     assert manifest["architecture_feedback"]["fallback_used"] is True
     assert manifest["graph_design_feedback"]["fallback_used"] is True
     assert "flowchart TD" in manifest["graph_exports"]["mermaid"]
+    assert manifest["notebook_composition_feedback"]["fallback_used"] is True
+    assert "requests" in manifest["notebook_dependency_plan"]["packages"]
     assert result["generation_complete"] is True

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -122,12 +122,13 @@ async def test_compose_notebook_sections_and_packages(
         "justification": "Matches the workflow requirements.",
     }
 
-    cells = await composer.compose_notebook(
+    composition = await composer.compose_notebook(
         notebook_plan=plan,
         workflow_design=workflow_design,
         tools=tools,
         architecture=architecture,
     )
+    cells = composition.cells
 
     intro_cells = [cell for cell in cells if cell.section == "intro"]
     assert len(intro_cells) >= 2
@@ -147,10 +148,21 @@ async def test_compose_notebook_sections_and_packages(
         for cell in cells
         if cell.section == "setup"
         and cell.cell_type == "code"
-        and "pip install" in cell.content
+        and "missing_packages" in cell.content
     ]
     assert install_cells
     assert "pypdf" in install_cells[0].content
+    assert "subprocess.check_call" in install_cells[0].content
+
+    config_cells = [
+        cell
+        for cell in cells
+        if cell.section == "setup" and cell.cell_type == "code" and "MODEL =" in cell.content
+    ]
+    assert config_cells
+    assert 'OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")' in config_cells[0].content
+    assert "ANTHROPIC_API_KEY" not in config_cells[0].content
+    assert "MAX_ITERATIONS = 10" in config_cells[0].content
 
     state_cells = [
         cell for cell in cells if cell.section == "state" and cell.cell_type == "code"
@@ -162,6 +174,7 @@ async def test_compose_notebook_sections_and_packages(
         cell for cell in cells if cell.section == "tools" and cell.cell_type == "code"
     ]
     assert tool_cells
+    assert tool_cells[0].content.startswith("# WARNING: Deterministic fallback generated")
     assert "def File_Reader" in tool_cells[0].content
     assert "Path(" in tool_cells[0].content
     assert "pass" not in tool_cells[0].content
@@ -195,6 +208,24 @@ async def test_compose_notebook_sections_and_packages(
         assert "def router_node" in node_source
         assert "def supervisor_node" in node_source
         assert "def reviewer_node" in node_source
+
+    assert composition.feedback.fallback_used is True
+    assert composition.feedback.resolved_model
+    assert composition.feedback.fallback_events[0].kind == "tool"
+    assert composition.feedback.fallback_events[0].item_name == "File Reader"
+    assert composition.feedback.sections_built == [
+        "intro",
+        "install",
+        "config",
+        "state",
+        "tools",
+        "nodes",
+        "graph",
+        "execution",
+    ]
+    assert "langgraph" in composition.dependency_plan.packages
+    assert "langchain-openai" in composition.dependency_plan.packages
+    assert "OPENAI_API_KEY" in composition.dependency_plan.provider_env_vars
 
     sections = {cell.section for cell in cells}
     assert {"intro", "setup", "state", "tools", "graph", "execution"}.issubset(
@@ -243,12 +274,13 @@ async def test_compose_notebook_hybrid_sparse_nodes_keep_defaults_aligned(
         ],
     }
 
-    cells = await composer.compose_notebook(
+    composition = await composer.compose_notebook(
         notebook_plan=plan,
         workflow_design=workflow_design,
         tools=[],
         architecture={"architecture_type": "hybrid", "justification": "Fallback hybrid."},
     )
+    cells = composition.cells
 
     node_source = "\n\n".join(cell.content for cell in cells if cell.section == "nodes")
     graph_code = next(
@@ -293,12 +325,13 @@ async def test_compose_notebook_hybrid_sanitizes_worker_and_specialist_graph_ids
         ],
     }
 
-    cells = await composer.compose_notebook(
+    composition = await composer.compose_notebook(
         notebook_plan=plan,
         workflow_design=workflow_design,
         tools=[],
         architecture={"architecture_type": "hybrid", "justification": "Hybrid sanitization."},
     )
+    cells = composition.cells
 
     node_source = "\n\n".join(cell.content for cell in cells if cell.section == "nodes")
     graph_code = next(
@@ -348,12 +381,13 @@ async def test_compose_notebook_includes_graph_overview_from_exports(
         },
     }
 
-    cells = await composer.compose_notebook(
+    composition = await composer.compose_notebook(
         notebook_plan=plan,
         workflow_design=workflow_design,
         tools=[],
         architecture={"architecture_type": "router", "justification": "Router is sufficient."},
     )
+    cells = composition.cells
 
     intro_markdown = "\n\n".join(
         cell.content for cell in cells if cell.section == "intro" and cell.cell_type == "markdown"
@@ -392,6 +426,45 @@ def test_generate_node_implementation_falls_back_to_meaningful_state_updates(
     assert "TODO" not in node_code
 
 
+def test_generate_tool_implementation_records_visible_fallback_warning(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+    feedback = composer_module.NotebookCompositionFeedback()
+
+    fallback_code = composer._generate_tool_implementation(
+        {"name": "Example Tool", "purpose": "Fallback to a deterministic helper", "category": "misc"},
+        feedback=feedback,
+    )
+
+    assert fallback_code.startswith("# WARNING: Deterministic fallback generated")
+    assert feedback.fallback_used is True
+    assert feedback.fallback_events[0].kind == "tool"
+
+
+def test_generate_node_implementation_records_visible_fallback_warning(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+    feedback = composer_module.NotebookCompositionFeedback()
+
+    fallback_code = composer._generate_node_implementation(
+        {"name": "enrich", "purpose": "Enrich the current workflow results"},
+        {
+            "architecture_type": "custom",
+            "state_schema": {"results": "Collected outputs"},
+            "nodes": [{"name": "enrich", "purpose": "Enrich the current workflow results"}],
+        },
+        feedback=feedback,
+    )
+
+    assert fallback_code.startswith("# WARNING: Deterministic fallback generated")
+    assert feedback.fallback_used is True
+    assert feedback.fallback_events[0].kind == "node"
+
+
 def test_tool_fallback_sanitizes_identifier_and_compiles(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -410,7 +483,9 @@ def test_tool_fallback_sanitizes_identifier_and_compiles(
     assert '# Tool: 9 bad tool"; print("oops")' in fallback_code
     assert '9 bad tool";\nprint("oops")' not in fallback_code
     assert '"category": "api\\" # injected"' in fallback_code
-    assert fallback_code.splitlines()[0] == '# Tool: 9 bad tool"; print("oops")'
+    assert fallback_code.splitlines()[0].startswith(
+        "# WARNING: Deterministic fallback generated"
+    )
     compile(fallback_code, "<tool_fallback>", "exec")
     parsed = ast.parse(fallback_code)
     assert len(parsed.body) == 1
@@ -515,7 +590,7 @@ async def test_pattern_nodes_use_request_scoped_model_config(
             {"name": "revise", "purpose": "Revise the draft using feedback"},
         ]
 
-    cells = await composer.compose_notebook(
+    composition = await composer.compose_notebook(
         notebook_plan=plan,
         workflow_design={
             "architecture_type": architecture_type,
@@ -528,6 +603,7 @@ async def test_pattern_nodes_use_request_scoped_model_config(
             "justification": "Matches the workflow requirements.",
         },
     )
+    cells = composition.cells
 
     node_cells = [cell for cell in cells if cell.section == "nodes"]
     assert node_cells
@@ -546,3 +622,5 @@ async def test_pattern_nodes_use_request_scoped_model_config(
     assert any("TEMPERATURE = 0.3" in cell.content for cell in setup_code_cells)
     assert any('API_BASE = "https://example.test/v1"' in cell.content for cell in setup_code_cells)
     assert any("MAX_TOKENS = 2048" in cell.content for cell in setup_code_cells)
+    assert composition.feedback.resolved_model == "gpt-5.2"
+    assert composition.feedback.resolved_api_base == "https://example.test/v1"


### PR DESCRIPTION
## Summary
- return a typed `NotebookCompositionResult` with structured composition feedback and dependency planning
- thread notebook composition metadata through generator nodes plus CLI/API manifest warning surfaces
- replace ad hoc install/config/fallback notebook assembly with normalized tranche-1 section builders

## Testing
- pytest tests/unit/test_generator_notebook_composer.py tests/unit/test_generator_nodes.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py tests/unit/test_notebook.py -q
- pytest tests/unit -q
- pytest --asyncio-mode=auto -q
- python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

Closes #181
Closes #182
Closes #183
Part of #179