### PR TITLE
Complete NotebookComposer tranche 2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ These node functions are the clearest map of the runtime lifecycle:
 | Architecture selection | `architecture_selection_node` | `ArchitectureSelector` | `selected_patterns`, `architecture_type`, `architecture_justification`, `architecture_feedback` |
 | Workflow design | `graph_design_node` | `GraphDesigner` | `workflow_design`, `graph_design_feedback`, `graph_exports`, `notebook_plan` |
 | Tool planning | `tooling_plan_node` | `ToolchainEngineer` | `tools_plan` |
-| Notebook assembly | `notebook_assembly_node` | `NotebookComposer` | `generated_cells` |
+| Notebook assembly | `notebook_assembly_node` | `NotebookComposer` | `generated_cells`, `notebook_composition_feedback`, `notebook_dependency_plan` |
 | Static QA | `static_qa_node` | validators under `src/langgraph_system_generator/qa/` | `qa_reports`, `qa_history` |
 | Runtime QA | `runtime_qa_node` | notebook runtime helpers | `qa_reports`, `qa_history` |
 | Repair | `repair_node` | `NotebookRepairAgent` from `langgraph_system_generator.qa.repair` and notebook repair helpers | `generated_cells`, `repair_attempts`, `qa_reports`, `qa_history` |
@@ -118,6 +118,10 @@ Important patterns:
 - `workflow_design` remains the backward-compatible downstream graph payload,
   while `graph_design_feedback` and `graph_exports` carry validation/fallback
   metadata plus Mermaid/schema exports for manifests and notebooks.
+- `generated_cells` remains the authoritative notebook payload, while
+  `notebook_composition_feedback` and `notebook_dependency_plan` carry
+  advisory fallback/config/dependency metadata for manifests and API/CLI
+  callers.
 
 When adding a new runtime agent or stage:
 
@@ -194,6 +198,25 @@ raw dict. Keep these conventions aligned when changing graph design behavior:
   `src/langgraph_system_generator/generator/graph_design_registry.py`
   and `GRAPH_DESIGNER_PLUGIN_MODULES` rather than hardcoding more branches into
   the agent
+
+### NotebookComposer-specific expectations
+
+`NotebookComposer.compose_notebook()` returns a typed
+`NotebookCompositionResult`, not just a list of cells. Keep these conventions
+aligned when changing notebook assembly behavior:
+
+- keep `generated_cells` backward-compatible even when you add new advisory
+  metadata
+- keep deterministic pattern builders ordered and synchronous; only the
+  LLM-backed tool and custom-node generation paths should use the internal
+  parallel async flow
+- register architecture-specific notebook assembly behavior through
+  `src/langgraph_system_generator/generator/notebook_composer_registry.py`
+  and `NOTEBOOK_COMPOSER_PLUGIN_MODULES` rather than adding more hardcoded
+  branches directly to the agent
+- preserve stable final cell ordering even when async generation is enabled
+- surface deterministic fallbacks through visible notebook comments plus
+  `notebook_composition_feedback` instead of silently dropping into placeholders
 
 ### Minimal runtime-agent skeleton
 

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -162,6 +162,22 @@ class NotebookComposer:
             )
         )
 
+    @staticmethod
+    def _merge_feedback(
+        target: NotebookCompositionFeedback,
+        source: NotebookCompositionFeedback | None,
+    ) -> None:
+        """Merge per-task feedback into the main composition feedback in order."""
+
+        if source is None:
+            return
+        if source.fallback_used:
+            target.fallback_used = True
+        for warning in source.warnings:
+            if warning not in target.warnings:
+                target.warnings.append(warning)
+        target.fallback_events.extend(source.fallback_events)
+
     def _fallback_banner(self, label: str, reason: str) -> str:
         """Return a visible notebook-facing warning comment for fallback code."""
 
@@ -293,7 +309,7 @@ class NotebookComposer:
         self,
         items: List[Any],
         worker: Any,
-    ) -> List[str]:
+    ) -> List[Any]:
         """Execute async LLM-backed generation while preserving input order."""
 
         if not items:
@@ -307,13 +323,13 @@ class NotebookComposer:
                 results.append(await worker(item))
             return results
 
-        semaphore = asyncio.Semaphore(settings.notebook_composer_max_concurrency)
+        semaphore = asyncio.Semaphore(max(1, settings.notebook_composer_max_concurrency))
 
         async def run(item: Any) -> str:
             async with semaphore:
                 return await worker(item)
 
-        return list(await asyncio.gather(*(run(item) for item in items)))
+        return await asyncio.gather(*(run(item) for item in items))
 
     async def _invoke_llm(self, messages: List[Any]) -> Any:
         """Invoke the configured LLM using the async path when available."""
@@ -371,6 +387,7 @@ class NotebookComposer:
             or notebook_plan.architecture_type
             or "router"
         ).strip().lower()
+        workflow_design["architecture_type"] = architecture_type
         registration = self.registry.resolve(architecture_type)
         cells: List[CellSpec] = []
         for section_name in registration.section_order:
@@ -638,14 +655,22 @@ class WorkflowState(MessagesState):
             )
         ]
 
-        tool_codes = await self._execute_llm_tasks_in_order(
-            tools,
-            lambda tool: self._generate_tool_implementation(
+        async def build_tool_code(
+            tool: Dict[str, Any],
+        ) -> tuple[str, NotebookCompositionFeedback]:
+            tool_feedback = NotebookCompositionFeedback()
+            tool_code = await self._generate_tool_implementation(
                 tool,
-                feedback=feedback,
-            ),
+                feedback=tool_feedback,
+            )
+            return tool_code, tool_feedback
+
+        tool_results = await self._execute_llm_tasks_in_order(
+            tools,
+            build_tool_code,
         )
-        for tool_code in tool_codes:
+        for tool_code, tool_feedback in tool_results:
+            self._merge_feedback(feedback, tool_feedback)
             cells.append(CellSpec(cell_type="code", content=tool_code, section="tools"))
 
         return cells
@@ -893,15 +918,23 @@ Generate the complete Python function implementation.""")
             cells.extend(pattern_cells)
         else:
             # Use LLM for custom node generation
-            node_codes = await self._execute_llm_tasks_in_order(
-                nodes,
-                lambda node: self._generate_node_implementation(
+            async def build_node_code(
+                node: Dict[str, Any],
+            ) -> tuple[str, NotebookCompositionFeedback]:
+                node_feedback = NotebookCompositionFeedback()
+                node_code = await self._generate_node_implementation(
                     node,
                     workflow_design,
-                    feedback=feedback,
-                ),
+                    feedback=node_feedback,
+                )
+                return node_code, node_feedback
+
+            node_results = await self._execute_llm_tasks_in_order(
+                nodes,
+                build_node_code,
             )
-            for node_code in node_codes:
+            for node_code, node_feedback in node_results:
+                self._merge_feedback(feedback, node_feedback)
                 cells.append(
                     CellSpec(cell_type="code", content=node_code, section="nodes")
                 )

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -6,8 +6,9 @@ import asyncio
 import inspect
 import json
 import keyword
+import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Awaitable, Callable, Dict, List, TypeVar
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
@@ -50,6 +51,9 @@ _PACKAGE_FAMILIES = {
     "pdfminer.six": "pdf_parser",
     "pymupdf": "pdf_parser",
 }
+
+_T = TypeVar("_T")
+logger = logging.getLogger(__name__)
 
 
 class NotebookComposer:
@@ -308,8 +312,8 @@ class NotebookComposer:
     async def _execute_llm_tasks_in_order(
         self,
         items: List[Any],
-        worker: Any,
-    ) -> List[Any]:
+        worker: Callable[[Any], Awaitable[_T]],
+    ) -> List[_T]:
         """Execute async LLM-backed generation while preserving input order."""
 
         if not items:
@@ -323,9 +327,15 @@ class NotebookComposer:
                 results.append(await worker(item))
             return results
 
-        semaphore = asyncio.Semaphore(max(1, settings.notebook_composer_max_concurrency))
+        max_concurrency = settings.notebook_composer_max_concurrency
+        if max_concurrency <= 0:
+            logger.warning(
+                "Invalid notebook_composer_max_concurrency=%s; using 1 instead.",
+                max_concurrency,
+            )
+        semaphore = asyncio.Semaphore(max(1, max_concurrency))
 
-        async def run(item: Any) -> str:
+        async def run(item: Any) -> _T:
             async with semaphore:
                 return await worker(item)
 

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import asyncio
+import inspect
 import json
 import keyword
 import re
@@ -12,6 +13,11 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from langgraph_system_generator.generator.agents._llm import build_chat_llm
+from langgraph_system_generator.generator.notebook_composer_registry import (
+    NotebookComposerContext,
+    NotebookComposerRegistry,
+    get_notebook_composer_registry,
+)
 from langgraph_system_generator.generator.state import (
     CellSpec,
     NotebookCompositionFeedback,
@@ -46,18 +52,6 @@ _PACKAGE_FAMILIES = {
 }
 
 
-@dataclass
-class _NotebookCompositionContext:
-    """Internal notebook composition context shared across section builders."""
-
-    notebook_plan: NotebookPlan
-    workflow_design: Dict[str, Any]
-    tools: List[Dict[str, Any]]
-    architecture: Dict[str, Any]
-    dependency_plan: NotebookDependencyPlan
-    feedback: NotebookCompositionFeedback
-
-
 class NotebookComposer:
     """Generate notebook cell specifications with pattern-first code synthesis.
 
@@ -72,6 +66,7 @@ class NotebookComposer:
         self,
         model: str | None = None,
         model_config: ModelConfig | None = None,
+        registry: NotebookComposerRegistry | None = None,
     ):
         self.model_config = model_config or ModelConfig(
             model=model or settings.default_model,
@@ -81,6 +76,11 @@ class NotebookComposer:
             model=model,
             model_config=self.model_config,
             chat_openai_class=ChatOpenAI,
+        )
+        self.registry = (
+            registry.clone()
+            if registry is not None
+            else get_notebook_composer_registry().clone()
         )
 
     @staticmethod
@@ -280,56 +280,50 @@ class NotebookComposer:
             ]
         return plan
 
-    def _section_builders(
-        self,
-        context: _NotebookCompositionContext,
-    ) -> List[tuple[str, Any]]:
-        """Return the ordered internal section builders for notebook composition."""
+    async def _resolve_builder_output(self, builder_output: Any) -> List[CellSpec]:
+        """Normalize sync or async section-builder output into a cell list."""
 
-        resolved_max_iterations = context.feedback.resolved_max_iterations or 1
-        return [
-            (
-                "intro",
-                lambda: self._create_intro_cells(
-                    context.notebook_plan,
-                    context.architecture.get("justification"),
-                    context.workflow_design.get("graph_exports"),
-                ),
-            ),
-            ("install", lambda: self._create_install_cells(context.dependency_plan)),
-            (
-                "config",
-                lambda: self._create_config_cells(
-                    context.dependency_plan,
-                    context.feedback,
-                ),
-            ),
-            ("state", lambda: self._create_state_cells(context.workflow_design)),
-            (
-                "tools",
-                lambda: self._create_tool_cells(context.tools, context.feedback)
-                if context.tools
-                else [],
-            ),
-            (
-                "nodes",
-                lambda: self._create_node_cells(
-                    context.workflow_design,
-                    context.feedback,
-                ),
-            ),
-            (
-                "graph",
-                lambda: self._create_graph_cells(
-                    context.workflow_design,
-                    resolved_max_iterations,
-                ),
-            ),
-            (
-                "execution",
-                lambda: self._create_execution_cells(context.workflow_design),
-            ),
-        ]
+        if inspect.isawaitable(builder_output):
+            builder_output = await builder_output
+        if builder_output is None:
+            return []
+        return list(builder_output)
+
+    async def _execute_llm_tasks_in_order(
+        self,
+        items: List[Any],
+        worker: Any,
+    ) -> List[str]:
+        """Execute async LLM-backed generation while preserving input order."""
+
+        if not items:
+            return []
+        if (
+            settings.notebook_composer_parallelism_mode == "sequential"
+            or len(items) == 1
+        ):
+            results: List[str] = []
+            for item in items:
+                results.append(await worker(item))
+            return results
+
+        semaphore = asyncio.Semaphore(settings.notebook_composer_max_concurrency)
+
+        async def run(item: Any) -> str:
+            async with semaphore:
+                return await worker(item)
+
+        return list(await asyncio.gather(*(run(item) for item in items)))
+
+    async def _invoke_llm(self, messages: List[Any]) -> Any:
+        """Invoke the configured LLM using the async path when available."""
+
+        if hasattr(self.llm, "ainvoke"):
+            result = self.llm.ainvoke(messages)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+        return await asyncio.to_thread(self.llm.invoke, messages)
 
     async def compose_notebook(
         self,
@@ -362,7 +356,7 @@ class NotebookComposer:
             resolved_max_iterations=self._resolve_max_iterations(workflow_design),
         )
         dependency_plan = self._plan_dependencies(tools, workflow_design)
-        context = _NotebookCompositionContext(
+        context = NotebookComposerContext(
             notebook_plan=notebook_plan,
             workflow_design=workflow_design,
             tools=tools,
@@ -371,9 +365,39 @@ class NotebookComposer:
             feedback=feedback,
         )
 
+        architecture_type = str(
+            workflow_design.get("architecture_type")
+            or architecture.get("architecture_type")
+            or notebook_plan.architecture_type
+            or "router"
+        ).strip().lower()
+        registration = self.registry.resolve(architecture_type)
         cells: List[CellSpec] = []
-        for section_name, builder in self._section_builders(context):
-            section_cells = builder()
+        for section_name in registration.section_order:
+            section_cells: List[CellSpec] = []
+            for hook in self.registry.resolve_hooks(
+                architecture_type,
+                section_name,
+                when="pre",
+            ):
+                section_cells.extend(
+                    await self._resolve_builder_output(hook(self, context))
+                )
+
+            builder = self.registry.resolve_builder(architecture_type, section_name)
+            section_cells.extend(
+                await self._resolve_builder_output(builder(self, context))
+            )
+
+            for hook in self.registry.resolve_hooks(
+                architecture_type,
+                section_name,
+                when="post",
+            ):
+                section_cells.extend(
+                    await self._resolve_builder_output(hook(self, context))
+                )
+
             if section_cells:
                 feedback.sections_built.append(section_name)
                 cells.extend(section_cells)
@@ -600,7 +624,7 @@ class WorkflowState(MessagesState):
             CellSpec(cell_type="code", content=state_content, section="state"),
         ]
 
-    def _create_tool_cells(
+    async def _create_tool_cells(
         self,
         tools: List[Dict[str, Any]],
         feedback: NotebookCompositionFeedback,
@@ -614,15 +638,19 @@ class WorkflowState(MessagesState):
             )
         ]
 
-        for tool in tools:
-            # Try to generate real implementation with LLM
-            tool_code = self._generate_tool_implementation(tool, feedback=feedback)
-
+        tool_codes = await self._execute_llm_tasks_in_order(
+            tools,
+            lambda tool: self._generate_tool_implementation(
+                tool,
+                feedback=feedback,
+            ),
+        )
+        for tool_code in tool_codes:
             cells.append(CellSpec(cell_type="code", content=tool_code, section="tools"))
 
         return cells
 
-    def _generate_tool_implementation(
+    async def _generate_tool_implementation(
         self,
         tool: Dict[str, Any],
         *,
@@ -673,8 +701,8 @@ Configuration: {tool_config}
 
 Generate the complete Python function implementation.""")
 
-            # Get LLM response (synchronous)
-            response = self.llm.invoke([system_prompt, user_prompt])
+            # Use the async LLM path so multiple tool implementations can run concurrently.
+            response = await self._invoke_llm([system_prompt, user_prompt])
             generated_code = self._strip_code_fences(response.content)
             if not self._is_meaningful_tool_code(generated_code):
                 return self._generate_tool_fallback(
@@ -833,7 +861,7 @@ Generate the complete Python function implementation.""")
 
         return header + implementation
 
-    def _create_node_cells(
+    async def _create_node_cells(
         self,
         workflow_design: Dict[str, Any],
         feedback: NotebookCompositionFeedback,
@@ -859,25 +887,28 @@ Generate the complete Python function implementation.""")
             "critique_loop",
         ]:
             # Use pattern library for architecture-specific nodes
-            pattern_cells = self._generate_nodes_from_pattern(
+            pattern_cells = self._create_pattern_node_cells(
                 nodes, architecture_type, workflow_design
             )
             cells.extend(pattern_cells)
         else:
             # Use LLM for custom node generation
-            for node in nodes:
-                node_code = self._generate_node_implementation(
+            node_codes = await self._execute_llm_tasks_in_order(
+                nodes,
+                lambda node: self._generate_node_implementation(
                     node,
                     workflow_design,
                     feedback=feedback,
-                )
+                ),
+            )
+            for node_code in node_codes:
                 cells.append(
                     CellSpec(cell_type="code", content=node_code, section="nodes")
                 )
 
         return cells
 
-    def _generate_node_implementation(
+    async def _generate_node_implementation(
         self,
         node: Dict[str, Any],
         workflow_design: Dict[str, Any],
@@ -933,8 +964,8 @@ State Schema:
 
 Generate the complete Python function implementation.""")
 
-            # Get LLM response
-            response = self.llm.invoke([system_prompt, user_prompt])
+            # Use the async LLM path so custom nodes can run concurrently.
+            response = await self._invoke_llm([system_prompt, user_prompt])
             generated_code = self._strip_code_fences(response.content)
             if not self._is_meaningful_node_code(generated_code):
                 return self._generate_node_fallback(
@@ -1157,7 +1188,7 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
             worker_descriptions,
         )
 
-    def _generate_nodes_from_pattern(
+    def _create_pattern_node_cells(
         self,
         nodes: List[Dict[str, Any]],
         architecture_type: str,
@@ -1347,9 +1378,30 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
     ) -> List[CellSpec]:
         """Create graph construction cells using pattern library or custom generation."""
         architecture_type = workflow_design.get("architecture_type", "router")
-        nodes = workflow_design.get("nodes", [])
+        if architecture_type in {
+            "router",
+            "subagents",
+            "hybrid",
+            "autoagent",
+            "critique_loop",
+        }:
+            return self._create_pattern_graph_cells(
+                workflow_design,
+                architecture_type,
+                max_iterations,
+            )
 
-        # Use pattern library for known architectures
+        return self._wrap_graph_cells(self._generate_graph_fallback(workflow_design))
+
+    def _create_pattern_graph_cells(
+        self,
+        workflow_design: Dict[str, Any],
+        architecture_type: str,
+        max_iterations: int,
+    ) -> List[CellSpec]:
+        """Create graph construction cells for a known architecture pattern."""
+
+        nodes = workflow_design.get("nodes", [])
         if architecture_type == "router":
             routes = [
                 node.get("name") for node in nodes if node.get("name") != "router"
@@ -1380,14 +1432,17 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
                 workers,
                 max_iterations=max_iterations,
             )
-        elif architecture_type == "critique_loop":
+        else:
             graph_code = CritiqueLoopPattern.generate_graph_code(
                 max_revisions=max_iterations,
                 min_quality_score=0.8,
             )
-        else:
-            # Fallback to enhanced template-based generation
-            graph_code = self._generate_graph_fallback(workflow_design)
+
+        return self._wrap_graph_cells(graph_code)
+
+    @staticmethod
+    def _wrap_graph_cells(graph_code: str) -> List[CellSpec]:
+        """Wrap graph code with the standard notebook graph section cells."""
 
         return [
             CellSpec(

--- a/src/langgraph_system_generator/generator/notebook_composer_registry.py
+++ b/src/langgraph_system_generator/generator/notebook_composer_registry.py
@@ -1,0 +1,503 @@
+"""Internal registry for NotebookComposer section builders and plugins."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+import importlib
+from typing import Any, Awaitable, Callable, Mapping, Sequence
+
+from langgraph_system_generator.generator.state import (
+    CellSpec,
+    NotebookCompositionFeedback,
+    NotebookDependencyPlan,
+    NotebookPlan,
+)
+from langgraph_system_generator.utils.config import settings
+
+NotebookSectionResult = list[CellSpec] | Awaitable[list[CellSpec]]
+NotebookSectionBuilder = Callable[[Any, "NotebookComposerContext"], NotebookSectionResult]
+PluginHook = Callable[["NotebookComposerRegistry"], None]
+
+
+def _normalize_architecture_id(value: str) -> str:
+    """Return a normalized architecture identifier."""
+
+    normalized = str(value or "").strip().lower()
+    if not normalized:
+        raise ValueError(
+            "Notebook composer registrations must include a non-empty architecture_id."
+        )
+    return normalized
+
+
+def _normalize_builder_name(value: str, *, field_name: str) -> str:
+    """Return a normalized builder or hook name."""
+
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must reference a non-empty builder name.")
+    return normalized
+
+
+def _normalize_string_list(values: Sequence[str] | None) -> list[str]:
+    """Return an ordered, de-duplicated list of non-empty strings."""
+
+    normalized_values: list[str] = []
+    for raw_value in values or []:
+        normalized = str(raw_value or "").strip()
+        if normalized and normalized not in normalized_values:
+            normalized_values.append(normalized)
+    return normalized_values
+
+
+def _normalize_hook_mapping(values: Mapping[str, Sequence[str]] | None) -> dict[str, list[str]]:
+    """Return normalized per-section hook mappings."""
+
+    normalized: dict[str, list[str]] = {}
+    for raw_section, raw_builders in (values or {}).items():
+        section = str(raw_section or "").strip()
+        if not section:
+            continue
+        builder_names = _normalize_string_list(raw_builders)
+        if builder_names:
+            normalized[section] = builder_names
+    return normalized
+
+
+@dataclass
+class NotebookComposerContext:
+    """Internal notebook composition context shared across section builders."""
+
+    notebook_plan: NotebookPlan
+    workflow_design: dict[str, Any]
+    tools: list[dict[str, Any]]
+    architecture: dict[str, Any]
+    dependency_plan: NotebookDependencyPlan
+    feedback: NotebookCompositionFeedback
+
+
+@dataclass
+class NotebookComposerArchitectureRegistration:
+    """Registration for architecture-specific notebook-composer behavior."""
+
+    architecture_id: str
+    section_order: list[str] = field(default_factory=list)
+    section_overrides: dict[str, str] = field(default_factory=dict)
+    pre_section_hooks: dict[str, list[str]] = field(default_factory=dict)
+    post_section_hooks: dict[str, list[str]] = field(default_factory=dict)
+
+    def normalized(
+        self,
+        *,
+        default_section_order: Sequence[str],
+    ) -> "NotebookComposerArchitectureRegistration":
+        """Return a normalized copy of this registration."""
+
+        section_order = _normalize_string_list(self.section_order) or list(
+            default_section_order
+        )
+        for section_name in default_section_order:
+            if section_name not in section_order:
+                section_order.append(section_name)
+
+        normalized_overrides = {
+            str(section or "").strip(): _normalize_builder_name(
+                builder_name,
+                field_name=f"section_overrides[{section}]",
+            )
+            for section, builder_name in (self.section_overrides or {}).items()
+            if str(section or "").strip()
+        }
+        return NotebookComposerArchitectureRegistration(
+            architecture_id=_normalize_architecture_id(self.architecture_id),
+            section_order=section_order,
+            section_overrides=normalized_overrides,
+            pre_section_hooks=_normalize_hook_mapping(self.pre_section_hooks),
+            post_section_hooks=_normalize_hook_mapping(self.post_section_hooks),
+        )
+
+
+class NotebookComposerRegistry:
+    """Registry for notebook-composer section builders and architecture hooks."""
+
+    def __init__(self, *, default_section_order: Sequence[str] | None = None):
+        self.default_section_order = _normalize_string_list(
+            default_section_order
+            or ["intro", "install", "config", "state", "tools", "nodes", "graph", "execution"]
+        )
+        self._builders: dict[str, NotebookSectionBuilder] = {}
+        self._architectures: dict[str, NotebookComposerArchitectureRegistration] = {}
+
+    def clone(self) -> "NotebookComposerRegistry":
+        """Return a shallow clone suitable for per-composer customization."""
+
+        cloned = NotebookComposerRegistry(default_section_order=self.default_section_order)
+        cloned._builders = dict(self._builders)
+        cloned._architectures = {
+            architecture_id: NotebookComposerArchitectureRegistration(
+                architecture_id=registration.architecture_id,
+                section_order=list(registration.section_order),
+                section_overrides=dict(registration.section_overrides),
+                pre_section_hooks={
+                    section: list(builder_names)
+                    for section, builder_names in registration.pre_section_hooks.items()
+                },
+                post_section_hooks={
+                    section: list(builder_names)
+                    for section, builder_names in registration.post_section_hooks.items()
+                },
+            )
+            for architecture_id, registration in self._architectures.items()
+        }
+        return cloned
+
+    def register_builder(
+        self,
+        builder_name: str,
+        builder: NotebookSectionBuilder,
+    ) -> None:
+        """Register or replace a named section builder."""
+
+        normalized_name = _normalize_builder_name(builder_name, field_name="builder_name")
+        self._builders[normalized_name] = builder
+
+    def register(
+        self,
+        registration: NotebookComposerArchitectureRegistration,
+    ) -> None:
+        """Register architecture-specific section overrides and hooks."""
+
+        normalized = registration.normalized(
+            default_section_order=self.default_section_order
+        )
+        referenced_builders = list(normalized.section_overrides.values())
+        referenced_builders.extend(
+            builder_name
+            for builder_names in normalized.pre_section_hooks.values()
+            for builder_name in builder_names
+        )
+        referenced_builders.extend(
+            builder_name
+            for builder_names in normalized.post_section_hooks.values()
+            for builder_name in builder_names
+        )
+        missing_builders = sorted(
+            {
+                builder_name
+                for builder_name in referenced_builders
+                if builder_name not in self._builders
+            }
+        )
+        if missing_builders:
+            raise ValueError(
+                "Notebook composer registration "
+                f"'{normalized.architecture_id}' references unknown builders: "
+                + ", ".join(missing_builders)
+            )
+        self._architectures[normalized.architecture_id] = normalized
+
+    def get(self, architecture_id: str) -> NotebookComposerArchitectureRegistration:
+        """Return a registered architecture definition."""
+
+        normalized_id = _normalize_architecture_id(architecture_id)
+        try:
+            return self._architectures[normalized_id]
+        except KeyError as exc:
+            raise KeyError(
+                f"No notebook composer registration found for '{normalized_id}'."
+            ) from exc
+
+    def resolve(
+        self,
+        architecture_id: str,
+    ) -> NotebookComposerArchitectureRegistration:
+        """Return the matching registration or a generic default registration."""
+
+        normalized_id = str(architecture_id or "").strip().lower()
+        if normalized_id in self._architectures:
+            return self._architectures[normalized_id]
+        return NotebookComposerArchitectureRegistration(
+            architecture_id=normalized_id or "custom",
+            section_order=list(self.default_section_order),
+        ).normalized(default_section_order=self.default_section_order)
+
+    def builder_names(self) -> set[str]:
+        """Return the set of registered section builder names."""
+
+        return set(self._builders)
+
+    def resolve_builder(
+        self,
+        architecture_id: str,
+        section_name: str,
+    ) -> NotebookSectionBuilder:
+        """Resolve the main builder for a section."""
+
+        registration = self.resolve(architecture_id)
+        builder_name = registration.section_overrides.get(section_name, section_name)
+        try:
+            return self._builders[builder_name]
+        except KeyError as exc:
+            raise KeyError(
+                f"No notebook composer builder named '{builder_name}' is registered for section '{section_name}'."
+            ) from exc
+
+    def resolve_hooks(
+        self,
+        architecture_id: str,
+        section_name: str,
+        *,
+        when: str,
+    ) -> list[NotebookSectionBuilder]:
+        """Resolve pre- or post-section hook builders."""
+
+        registration = self.resolve(architecture_id)
+        hook_mapping = (
+            registration.pre_section_hooks
+            if when == "pre"
+            else registration.post_section_hooks
+        )
+        builders: list[NotebookSectionBuilder] = []
+        for builder_name in hook_mapping.get(section_name, []):
+            try:
+                builders.append(self._builders[builder_name])
+            except KeyError as exc:
+                raise KeyError(
+                    f"No notebook composer hook builder named '{builder_name}' is registered for section '{section_name}'."
+                ) from exc
+        return builders
+
+
+def _build_intro_section(composer: Any, context: NotebookComposerContext) -> list[CellSpec]:
+    return composer._create_intro_cells(
+        context.notebook_plan,
+        context.architecture.get("justification"),
+        context.workflow_design.get("graph_exports"),
+    )
+
+
+def _build_install_section(
+    composer: Any, context: NotebookComposerContext
+) -> list[CellSpec]:
+    return composer._create_install_cells(context.dependency_plan)
+
+
+def _build_config_section(
+    composer: Any, context: NotebookComposerContext
+) -> list[CellSpec]:
+    return composer._create_config_cells(context.dependency_plan, context.feedback)
+
+
+def _build_state_section(composer: Any, context: NotebookComposerContext) -> list[CellSpec]:
+    return composer._create_state_cells(context.workflow_design)
+
+
+async def _build_tools_section(
+    composer: Any,
+    context: NotebookComposerContext,
+) -> list[CellSpec]:
+    if not context.tools:
+        return []
+    return await composer._create_tool_cells(context.tools, context.feedback)
+
+
+async def _build_nodes_section(
+    composer: Any,
+    context: NotebookComposerContext,
+) -> list[CellSpec]:
+    return await composer._create_node_cells(context.workflow_design, context.feedback)
+
+
+async def _build_router_nodes_section(
+    composer: Any,
+    context: NotebookComposerContext,
+) -> list[CellSpec]:
+    return composer._create_pattern_node_cells(
+        context.workflow_design.get("nodes", []),
+        "router",
+        context.workflow_design,
+    )
+
+
+async def _build_subagents_nodes_section(
+    composer: Any,
+    context: NotebookComposerContext,
+) -> list[CellSpec]:
+    return composer._create_pattern_node_cells(
+        context.workflow_design.get("nodes", []),
+        "subagents",
+        context.workflow_design,
+    )
+
+
+async def _build_hybrid_nodes_section(
+    composer: Any,
+    context: NotebookComposerContext,
+) -> list[CellSpec]:
+    return composer._create_pattern_node_cells(
+        context.workflow_design.get("nodes", []),
+        "hybrid",
+        context.workflow_design,
+    )
+
+
+async def _build_autoagent_nodes_section(
+    composer: Any,
+    context: NotebookComposerContext,
+) -> list[CellSpec]:
+    return composer._create_pattern_node_cells(
+        context.workflow_design.get("nodes", []),
+        "autoagent",
+        context.workflow_design,
+    )
+
+
+async def _build_critique_loop_nodes_section(
+    composer: Any,
+    context: NotebookComposerContext,
+) -> list[CellSpec]:
+    return composer._create_pattern_node_cells(
+        context.workflow_design.get("nodes", []),
+        "critique_loop",
+        context.workflow_design,
+    )
+
+
+def _build_graph_section(composer: Any, context: NotebookComposerContext) -> list[CellSpec]:
+    return composer._create_graph_cells(
+        context.workflow_design,
+        context.feedback.resolved_max_iterations or 1,
+    )
+
+
+def _build_router_graph_section(
+    composer: Any,
+    context: NotebookComposerContext,
+) -> list[CellSpec]:
+    return composer._create_pattern_graph_cells(
+        context.workflow_design,
+        "router",
+        context.feedback.resolved_max_iterations or 1,
+    )
+
+
+def _build_subagents_graph_section(
+    composer: Any,
+    context: NotebookComposerContext,
+) -> list[CellSpec]:
+    return composer._create_pattern_graph_cells(
+        context.workflow_design,
+        "subagents",
+        context.feedback.resolved_max_iterations or 1,
+    )
+
+
+def _build_hybrid_graph_section(
+    composer: Any,
+    context: NotebookComposerContext,
+) -> list[CellSpec]:
+    return composer._create_pattern_graph_cells(
+        context.workflow_design,
+        "hybrid",
+        context.feedback.resolved_max_iterations or 1,
+    )
+
+
+def _build_autoagent_graph_section(
+    composer: Any,
+    context: NotebookComposerContext,
+) -> list[CellSpec]:
+    return composer._create_pattern_graph_cells(
+        context.workflow_design,
+        "autoagent",
+        context.feedback.resolved_max_iterations or 1,
+    )
+
+
+def _build_critique_loop_graph_section(
+    composer: Any,
+    context: NotebookComposerContext,
+) -> list[CellSpec]:
+    return composer._create_pattern_graph_cells(
+        context.workflow_design,
+        "critique_loop",
+        context.feedback.resolved_max_iterations or 1,
+    )
+
+
+def _build_execution_section(
+    composer: Any,
+    context: NotebookComposerContext,
+) -> list[CellSpec]:
+    return composer._create_execution_cells(context.workflow_design)
+
+
+def _load_plugin_modules(registry: NotebookComposerRegistry) -> None:
+    """Load configured notebook-composer plugin modules."""
+
+    for module_name in settings.notebook_composer_plugin_modules:
+        try:
+            module = importlib.import_module(module_name)
+        except Exception as exc:
+            raise ValueError(
+                f"Failed to import notebook composer plugin module '{module_name}': "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+        hook = getattr(module, "register_notebook_composer_builders", None)
+        if not callable(hook):
+            raise ValueError(
+                f"Notebook composer plugin module '{module_name}' must define a callable "
+                "'register_notebook_composer_builders(registry)'."
+            )
+        hook(registry)
+
+
+@lru_cache(maxsize=1)
+def get_notebook_composer_registry() -> NotebookComposerRegistry:
+    """Return the shared notebook-composer registry with built-ins and plugins."""
+
+    registry = NotebookComposerRegistry()
+    registry.register_builder("intro", _build_intro_section)
+    registry.register_builder("install", _build_install_section)
+    registry.register_builder("config", _build_config_section)
+    registry.register_builder("state", _build_state_section)
+    registry.register_builder("tools", _build_tools_section)
+    registry.register_builder("nodes", _build_nodes_section)
+    registry.register_builder("graph", _build_graph_section)
+    registry.register_builder("execution", _build_execution_section)
+
+    registry.register_builder("router_nodes", _build_router_nodes_section)
+    registry.register_builder("subagents_nodes", _build_subagents_nodes_section)
+    registry.register_builder("hybrid_nodes", _build_hybrid_nodes_section)
+    registry.register_builder("autoagent_nodes", _build_autoagent_nodes_section)
+    registry.register_builder("critique_loop_nodes", _build_critique_loop_nodes_section)
+
+    registry.register_builder("router_graph", _build_router_graph_section)
+    registry.register_builder("subagents_graph", _build_subagents_graph_section)
+    registry.register_builder("hybrid_graph", _build_hybrid_graph_section)
+    registry.register_builder("autoagent_graph", _build_autoagent_graph_section)
+    registry.register_builder(
+        "critique_loop_graph",
+        _build_critique_loop_graph_section,
+    )
+
+    for architecture_id, node_builder, graph_builder in [
+        ("router", "router_nodes", "router_graph"),
+        ("subagents", "subagents_nodes", "subagents_graph"),
+        ("hybrid", "hybrid_nodes", "hybrid_graph"),
+        ("autoagent", "autoagent_nodes", "autoagent_graph"),
+        ("critique_loop", "critique_loop_nodes", "critique_loop_graph"),
+    ]:
+        registry.register(
+            NotebookComposerArchitectureRegistration(
+                architecture_id=architecture_id,
+                section_overrides={
+                    "nodes": node_builder,
+                    "graph": graph_builder,
+                },
+            )
+        )
+
+    _load_plugin_modules(registry)
+    return registry

--- a/src/langgraph_system_generator/generator/notebook_composer_registry.py
+++ b/src/langgraph_system_generator/generator/notebook_composer_registry.py
@@ -97,9 +97,6 @@ class NotebookComposerArchitectureRegistration:
         section_order = _normalize_string_list(self.section_order) or list(
             default_section_order
         )
-        for section_name in default_section_order:
-            if section_name not in section_order:
-                section_order.append(section_name)
 
         normalized_overrides = {
             str(section or "").strip(): _normalize_builder_name(

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
 import ast
+import re
+import sys
+import types
 
 import pytest
 
 from langgraph_system_generator.generator.agents import notebook_composer as composer_module
-from langgraph_system_generator.generator.state import NotebookPlan
+import langgraph_system_generator.generator.notebook_composer_registry as registry_module
+from langgraph_system_generator.generator.notebook_composer_registry import (
+    NotebookComposerArchitectureRegistration,
+    get_notebook_composer_registry,
+)
+from langgraph_system_generator.generator.state import CellSpec, NotebookPlan
 from langgraph_system_generator.utils.config import ModelConfig
 
 
@@ -24,7 +33,213 @@ class DummyLLM:
             def __init__(self, content: str) -> None:
                 self.content = content
 
-        return Response("")
+        content = args[0] if args and isinstance(args[0], str) else ""
+        return Response(content)
+
+    async def ainvoke(self, *args, **kwargs):
+        """Async invoke stub matching the synchronous empty-response behavior."""
+
+        return self.invoke(*args, **kwargs)
+
+
+class TrackingLLM(DummyLLM):
+    """Async LLM stub that records concurrency and returns meaningful code."""
+
+    delay_map: dict[str, float] = {}
+    default_delay: float = 0.01
+    active_calls: int = 0
+    max_active_calls: int = 0
+    completed_items: list[str] = []
+
+    @classmethod
+    def reset(cls, *, delay_map: dict[str, float] | None = None) -> None:
+        cls.delay_map = dict(delay_map or {})
+        cls.active_calls = 0
+        cls.max_active_calls = 0
+        cls.completed_items = []
+
+    async def ainvoke(self, messages, *args, **kwargs):
+        user_content = getattr(messages[-1], "content", "")
+        tool_match = re.search(r"Tool Name:\s*(.+)", user_content)
+        node_match = re.search(r"Node Name:\s*(.+)", user_content)
+        label = ""
+        if tool_match:
+            label = tool_match.group(1).strip()
+            safe_identifier = composer_module.NotebookComposer._safe_identifier(
+                label, "tool"
+            )
+            content = (
+                f"def {safe_identifier}(query: str) -> str:\n"
+                f"    return {label!r}"
+            )
+        elif node_match:
+            label = node_match.group(1).strip()
+            safe_identifier = composer_module.NotebookComposer._safe_identifier(
+                label, "node"
+            )
+            content = (
+                f"def {safe_identifier}_node(state: WorkflowState) -> WorkflowState:\n"
+                "    updates = dict(state)\n"
+                f"    updates['last_node'] = {label!r}\n"
+                "    return updates"
+            )
+        else:
+            content = ""
+
+        type(self).active_calls += 1
+        type(self).max_active_calls = max(
+            type(self).max_active_calls,
+            type(self).active_calls,
+        )
+        await asyncio.sleep(type(self).delay_map.get(label, type(self).default_delay))
+        type(self).completed_items.append(label)
+        type(self).active_calls -= 1
+        return self.invoke(content)
+
+
+def test_notebook_composer_registry_includes_builtin_architectures():
+    registry = get_notebook_composer_registry().clone()
+
+    for architecture_type in [
+        "router",
+        "subagents",
+        "hybrid",
+        "autoagent",
+        "critique_loop",
+    ]:
+        registration = registry.get(architecture_type)
+        assert registration.section_overrides["nodes"].endswith("_nodes")
+        assert registration.section_overrides["graph"].endswith("_graph")
+
+
+@pytest.mark.asyncio
+async def test_notebook_composer_registry_plugins_can_inject_pre_section_cells(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module_name = "tests.fake_notebook_composer_plugin"
+    plugin_module = types.ModuleType(module_name)
+
+    def register_notebook_composer_builders(registry):
+        def plugin_intro_banner(_composer, _context):
+            return [
+                CellSpec(
+                    cell_type="markdown",
+                    content="> Plugin intro banner",
+                    section="intro",
+                )
+            ]
+
+        registry.register_builder("plugin_intro_banner", plugin_intro_banner)
+        base = registry.get("router")
+        registry.register(
+            NotebookComposerArchitectureRegistration(
+                architecture_id="router",
+                section_order=base.section_order,
+                section_overrides=dict(base.section_overrides),
+                pre_section_hooks={
+                    "intro": ["plugin_intro_banner"],
+                    **base.pre_section_hooks,
+                },
+                post_section_hooks=base.post_section_hooks,
+            )
+        )
+
+    plugin_module.register_notebook_composer_builders = (
+        register_notebook_composer_builders
+    )
+    monkeypatch.setitem(sys.modules, module_name, plugin_module)
+    monkeypatch.setattr(
+        registry_module.settings,
+        "notebook_composer_plugin_modules",
+        [module_name],
+    )
+    registry_module.get_notebook_composer_registry.cache_clear()
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+
+    composer = composer_module.NotebookComposer()
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Plugin Notebook",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["router"],
+            architecture_type="router",
+        ),
+        workflow_design={
+            "architecture_type": "router",
+            "state_schema": {"messages": "Conversation state"},
+            "nodes": [
+                {"name": "router", "purpose": "Route requests"},
+                {"name": "search", "purpose": "Search documents"},
+            ],
+        },
+        tools=[],
+        architecture={"architecture_type": "router", "justification": "Plugin test."},
+    )
+
+    intro_cells = [cell.content for cell in composition.cells if cell.section == "intro"]
+    assert any("Plugin intro banner" in cell for cell in intro_cells)
+    registry_module.get_notebook_composer_registry.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_custom_registry_can_override_graph_section_builder(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    registry = get_notebook_composer_registry().clone()
+
+    def custom_graph_section(_composer, _context):
+        return [
+            CellSpec(
+                cell_type="markdown",
+                content="## Custom Graph",
+                section="graph",
+            ),
+            CellSpec(
+                cell_type="code",
+                content="graph = 'custom_graph'",
+                section="graph",
+            ),
+        ]
+
+    registry.register_builder("custom_graph", custom_graph_section)
+    router_base = registry.get("router")
+    registry.register(
+        NotebookComposerArchitectureRegistration(
+            architecture_id="router",
+            section_order=router_base.section_order,
+            section_overrides={
+                **router_base.section_overrides,
+                "graph": "custom_graph",
+            },
+            pre_section_hooks=router_base.pre_section_hooks,
+            post_section_hooks=router_base.post_section_hooks,
+        )
+    )
+    composer = composer_module.NotebookComposer(registry=registry)
+
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Override Graph",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["router"],
+            architecture_type="router",
+        ),
+        workflow_design={
+            "architecture_type": "router",
+            "state_schema": {"messages": "Conversation state"},
+            "nodes": [
+                {"name": "router", "purpose": "Route requests"},
+                {"name": "search", "purpose": "Search documents"},
+            ],
+        },
+        tools=[],
+        architecture={"architecture_type": "router", "justification": "Override test."},
+    )
+
+    graph_cells = [cell.content for cell in composition.cells if cell.section == "graph"]
+    assert "## Custom Graph" in graph_cells[0]
+    assert "graph = 'custom_graph'" in graph_cells[1]
 
 
 @pytest.mark.asyncio
@@ -251,6 +466,171 @@ async def test_compose_notebook_sections_and_packages(
 
 
 @pytest.mark.asyncio
+async def test_compose_notebook_parallel_tool_generation_preserves_order_and_cap(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    TrackingLLM.reset(
+        delay_map={
+            "Tool Alpha": 0.04,
+            "Tool Beta": 0.01,
+            "Tool Gamma": 0.02,
+        }
+    )
+    monkeypatch.setattr(composer_module, "ChatOpenAI", TrackingLLM)
+    monkeypatch.setattr(
+        composer_module.settings,
+        "notebook_composer_parallelism_mode",
+        "parallel",
+    )
+    monkeypatch.setattr(
+        composer_module.settings,
+        "notebook_composer_max_concurrency",
+        2,
+    )
+    composer = composer_module.NotebookComposer()
+
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Parallel Tools",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["router"],
+            architecture_type="router",
+        ),
+        workflow_design={
+            "architecture_type": "router",
+            "state_schema": {"messages": "Conversation state"},
+            "nodes": [
+                {"name": "router", "purpose": "Route requests"},
+                {"name": "search", "purpose": "Search documents"},
+            ],
+        },
+        tools=[
+            {"name": "Tool Alpha", "purpose": "First tool", "category": "misc"},
+            {"name": "Tool Beta", "purpose": "Second tool", "category": "misc"},
+            {"name": "Tool Gamma", "purpose": "Third tool", "category": "misc"},
+        ],
+        architecture={"architecture_type": "router", "justification": "Parallel tools."},
+    )
+
+    tool_cells = [
+        cell.content
+        for cell in composition.cells
+        if cell.section == "tools" and cell.cell_type == "code"
+    ]
+    assert "def Tool_Alpha" in tool_cells[0]
+    assert "def Tool_Beta" in tool_cells[1]
+    assert "def Tool_Gamma" in tool_cells[2]
+    assert TrackingLLM.max_active_calls == 2
+    assert composition.feedback.fallback_used is False
+
+
+@pytest.mark.asyncio
+async def test_compose_notebook_parallel_custom_node_generation_preserves_order(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    TrackingLLM.reset(
+        delay_map={
+            "enrich": 0.04,
+            "summarize": 0.01,
+            "finalize": 0.02,
+        }
+    )
+    monkeypatch.setattr(composer_module, "ChatOpenAI", TrackingLLM)
+    monkeypatch.setattr(
+        composer_module.settings,
+        "notebook_composer_parallelism_mode",
+        "parallel",
+    )
+    monkeypatch.setattr(
+        composer_module.settings,
+        "notebook_composer_max_concurrency",
+        2,
+    )
+    composer = composer_module.NotebookComposer()
+
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Parallel Nodes",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["custom"],
+            architecture_type="custom",
+        ),
+        workflow_design={
+            "architecture_type": "custom",
+            "state_schema": {"last_node": "Last processed node"},
+            "nodes": [
+                {"name": "enrich", "purpose": "Enrich results"},
+                {"name": "summarize", "purpose": "Summarize results"},
+                {"name": "finalize", "purpose": "Finalize results"},
+            ],
+        },
+        tools=[],
+        architecture={"architecture_type": "custom", "justification": "Parallel nodes."},
+    )
+
+    node_cells = [
+        cell.content
+        for cell in composition.cells
+        if cell.section == "nodes" and cell.cell_type == "code"
+    ]
+    assert "def enrich_node" in node_cells[0]
+    assert "def summarize_node" in node_cells[1]
+    assert "def finalize_node" in node_cells[2]
+    assert TrackingLLM.max_active_calls == 2
+    assert composition.feedback.fallback_used is False
+
+
+@pytest.mark.asyncio
+async def test_compose_notebook_sequential_mode_serializes_llm_generation(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    TrackingLLM.reset(
+        delay_map={
+            "Tool One": 0.01,
+            "Tool Two": 0.01,
+            "Tool Three": 0.01,
+        }
+    )
+    monkeypatch.setattr(composer_module, "ChatOpenAI", TrackingLLM)
+    monkeypatch.setattr(
+        composer_module.settings,
+        "notebook_composer_parallelism_mode",
+        "sequential",
+    )
+    monkeypatch.setattr(
+        composer_module.settings,
+        "notebook_composer_max_concurrency",
+        3,
+    )
+    composer = composer_module.NotebookComposer()
+
+    await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Sequential Tools",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["router"],
+            architecture_type="router",
+        ),
+        workflow_design={
+            "architecture_type": "router",
+            "state_schema": {"messages": "Conversation state"},
+            "nodes": [
+                {"name": "router", "purpose": "Route requests"},
+                {"name": "search", "purpose": "Search documents"},
+            ],
+        },
+        tools=[
+            {"name": "Tool One", "purpose": "First tool", "category": "misc"},
+            {"name": "Tool Two", "purpose": "Second tool", "category": "misc"},
+            {"name": "Tool Three", "purpose": "Third tool", "category": "misc"},
+        ],
+        architecture={"architecture_type": "router", "justification": "Sequential tools."},
+    )
+
+    assert TrackingLLM.max_active_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_compose_notebook_hybrid_sparse_nodes_keep_defaults_aligned(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -399,14 +779,15 @@ async def test_compose_notebook_includes_graph_overview_from_exports(
     assert "terminal_nodes" in intro_markdown
 
 
-def test_generate_node_implementation_falls_back_to_meaningful_state_updates(
+@pytest.mark.asyncio
+async def test_generate_node_implementation_falls_back_to_meaningful_state_updates(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Custom architectures should fall back to runnable node code."""
     monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
     composer = composer_module.NotebookComposer()
 
-    node_code = composer._generate_node_implementation(
+    node_code = await composer._generate_node_implementation(
         {"name": "enrich", "purpose": "Enrich the current workflow results"},
         {
             "architecture_type": "custom",
@@ -426,14 +807,15 @@ def test_generate_node_implementation_falls_back_to_meaningful_state_updates(
     assert "TODO" not in node_code
 
 
-def test_generate_tool_implementation_records_visible_fallback_warning(
+@pytest.mark.asyncio
+async def test_generate_tool_implementation_records_visible_fallback_warning(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
     composer = composer_module.NotebookComposer()
     feedback = composer_module.NotebookCompositionFeedback()
 
-    fallback_code = composer._generate_tool_implementation(
+    fallback_code = await composer._generate_tool_implementation(
         {"name": "Example Tool", "purpose": "Fallback to a deterministic helper", "category": "misc"},
         feedback=feedback,
     )
@@ -443,14 +825,15 @@ def test_generate_tool_implementation_records_visible_fallback_warning(
     assert feedback.fallback_events[0].kind == "tool"
 
 
-def test_generate_node_implementation_records_visible_fallback_warning(
+@pytest.mark.asyncio
+async def test_generate_node_implementation_records_visible_fallback_warning(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
     composer = composer_module.NotebookComposer()
     feedback = composer_module.NotebookCompositionFeedback()
 
-    fallback_code = composer._generate_node_implementation(
+    fallback_code = await composer._generate_node_implementation(
         {"name": "enrich", "purpose": "Enrich the current workflow results"},
         {
             "architecture_type": "custom",

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -45,18 +45,18 @@ class DummyLLM:
 class TrackingLLM(DummyLLM):
     """Async LLM stub that records concurrency and returns meaningful code."""
 
-    delay_map: dict[str, float] = {}
+    _class_delay_map: dict[str, float] = {}
     default_delay: float = 0.01
-    active_calls: int = 0
-    max_active_calls: int = 0
-    completed_items: list[str] = []
+    _class_active_calls: int = 0
+    _class_max_active_calls: int = 0
+    _class_completed_items: list[str] = []
 
     @classmethod
     def reset(cls, *, delay_map: dict[str, float] | None = None) -> None:
-        cls.delay_map = dict(delay_map or {})
-        cls.active_calls = 0
-        cls.max_active_calls = 0
-        cls.completed_items = []
+        cls._class_delay_map = dict(delay_map or {})
+        cls._class_active_calls = 0
+        cls._class_max_active_calls = 0
+        cls._class_completed_items = []
 
     async def ainvoke(self, messages, *args, **kwargs):
         user_content = getattr(messages[-1], "content", "")
@@ -86,30 +86,32 @@ class TrackingLLM(DummyLLM):
         else:
             content = ""
 
-        type(self).active_calls += 1
-        type(self).max_active_calls = max(
-            type(self).max_active_calls,
-            type(self).active_calls,
+        type(self)._class_active_calls += 1
+        type(self)._class_max_active_calls = max(
+            type(self)._class_max_active_calls,
+            type(self)._class_active_calls,
         )
-        await asyncio.sleep(type(self).delay_map.get(label, type(self).default_delay))
-        type(self).completed_items.append(label)
-        type(self).active_calls -= 1
+        await asyncio.sleep(
+            type(self)._class_delay_map.get(label, type(self).default_delay)
+        )
+        type(self)._class_completed_items.append(label)
+        type(self)._class_active_calls -= 1
         return self.invoke(content)
 
 
 class DelayedEmptyLLM(DummyLLM):
     """Async LLM stub that delays and forces fallback behavior."""
 
-    delay_map: dict[str, float] = {}
+    _class_delay_map: dict[str, float] = {}
     default_delay: float = 0.01
-    active_calls: int = 0
-    max_active_calls: int = 0
+    _class_active_calls: int = 0
+    _class_max_active_calls: int = 0
 
     @classmethod
     def reset(cls, *, delay_map: dict[str, float] | None = None) -> None:
-        cls.delay_map = dict(delay_map or {})
-        cls.active_calls = 0
-        cls.max_active_calls = 0
+        cls._class_delay_map = dict(delay_map or {})
+        cls._class_active_calls = 0
+        cls._class_max_active_calls = 0
 
     async def ainvoke(self, messages, *args, **kwargs):
         user_content = getattr(messages[-1], "content", "")
@@ -121,13 +123,15 @@ class DelayedEmptyLLM(DummyLLM):
         elif node_match:
             label = node_match.group(1).strip()
 
-        type(self).active_calls += 1
-        type(self).max_active_calls = max(
-            type(self).max_active_calls,
-            type(self).active_calls,
+        type(self)._class_active_calls += 1
+        type(self)._class_max_active_calls = max(
+            type(self)._class_max_active_calls,
+            type(self)._class_active_calls,
         )
-        await asyncio.sleep(type(self).delay_map.get(label, type(self).default_delay))
-        type(self).active_calls -= 1
+        await asyncio.sleep(
+            type(self)._class_delay_map.get(label, type(self).default_delay)
+        )
+        type(self)._class_active_calls -= 1
         return self.invoke("")
 
 
@@ -567,7 +571,7 @@ async def test_compose_notebook_parallel_tool_generation_preserves_order_and_cap
     assert "def Tool_Alpha" in tool_cells[0]
     assert "def Tool_Beta" in tool_cells[1]
     assert "def Tool_Gamma" in tool_cells[2]
-    assert TrackingLLM.max_active_calls == 2
+    assert TrackingLLM._class_max_active_calls == 2
     assert composition.feedback.fallback_used is False
 
 
@@ -682,7 +686,7 @@ async def test_compose_notebook_parallel_custom_node_generation_preserves_order(
     assert "def enrich_node" in node_cells[0]
     assert "def summarize_node" in node_cells[1]
     assert "def finalize_node" in node_cells[2]
-    assert TrackingLLM.max_active_calls == 2
+    assert TrackingLLM._class_max_active_calls == 2
     assert composition.feedback.fallback_used is False
 
 
@@ -789,7 +793,7 @@ async def test_compose_notebook_sequential_mode_serializes_llm_generation(
         architecture={"architecture_type": "router", "justification": "Sequential tools."},
     )
 
-    assert TrackingLLM.max_active_calls == 1
+    assert TrackingLLM._class_max_active_calls == 1
 
 
 @pytest.mark.asyncio
@@ -837,7 +841,7 @@ async def test_compose_notebook_parallel_mode_treats_zero_concurrency_as_one(
         architecture={"architecture_type": "router", "justification": "Zero concurrency."},
     )
 
-    assert TrackingLLM.max_active_calls == 1
+    assert TrackingLLM._class_max_active_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -97,6 +97,40 @@ class TrackingLLM(DummyLLM):
         return self.invoke(content)
 
 
+class DelayedEmptyLLM(DummyLLM):
+    """Async LLM stub that delays and forces fallback behavior."""
+
+    delay_map: dict[str, float] = {}
+    default_delay: float = 0.01
+    active_calls: int = 0
+    max_active_calls: int = 0
+
+    @classmethod
+    def reset(cls, *, delay_map: dict[str, float] | None = None) -> None:
+        cls.delay_map = dict(delay_map or {})
+        cls.active_calls = 0
+        cls.max_active_calls = 0
+
+    async def ainvoke(self, messages, *args, **kwargs):
+        user_content = getattr(messages[-1], "content", "")
+        tool_match = re.search(r"Tool Name:\s*(.+)", user_content)
+        node_match = re.search(r"Node Name:\s*(.+)", user_content)
+        label = ""
+        if tool_match:
+            label = tool_match.group(1).strip()
+        elif node_match:
+            label = node_match.group(1).strip()
+
+        type(self).active_calls += 1
+        type(self).max_active_calls = max(
+            type(self).max_active_calls,
+            type(self).active_calls,
+        )
+        await asyncio.sleep(type(self).delay_map.get(label, type(self).default_delay))
+        type(self).active_calls -= 1
+        return self.invoke("")
+
+
 def test_notebook_composer_registry_includes_builtin_architectures():
     registry = get_notebook_composer_registry().clone()
 
@@ -110,6 +144,19 @@ def test_notebook_composer_registry_includes_builtin_architectures():
         registration = registry.get(architecture_type)
         assert registration.section_overrides["nodes"].endswith("_nodes")
         assert registration.section_overrides["graph"].endswith("_graph")
+
+
+def test_notebook_composer_registry_preserves_explicit_section_subset():
+    registry = get_notebook_composer_registry().clone()
+    registry.register(
+        NotebookComposerArchitectureRegistration(
+            architecture_id="focused",
+            section_order=["intro", "state"],
+        )
+    )
+
+    registration = registry.get("focused")
+    assert registration.section_order == ["intro", "state"]
 
 
 @pytest.mark.asyncio
@@ -525,6 +572,65 @@ async def test_compose_notebook_parallel_tool_generation_preserves_order_and_cap
 
 
 @pytest.mark.asyncio
+async def test_compose_notebook_parallel_tool_fallback_metadata_preserves_input_order(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    DelayedEmptyLLM.reset(
+        delay_map={
+            "Tool Alpha": 0.04,
+            "Tool Beta": 0.01,
+            "Tool Gamma": 0.02,
+        }
+    )
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DelayedEmptyLLM)
+    monkeypatch.setattr(
+        composer_module.settings,
+        "notebook_composer_parallelism_mode",
+        "parallel",
+    )
+    monkeypatch.setattr(
+        composer_module.settings,
+        "notebook_composer_max_concurrency",
+        2,
+    )
+    composer = composer_module.NotebookComposer()
+
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Parallel Tool Fallback Order",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["router"],
+            architecture_type="router",
+        ),
+        workflow_design={
+            "architecture_type": "router",
+            "state_schema": {"messages": "Conversation state"},
+            "nodes": [
+                {"name": "router", "purpose": "Route requests"},
+                {"name": "search", "purpose": "Search documents"},
+            ],
+        },
+        tools=[
+            {"name": "Tool Alpha", "purpose": "First tool", "category": "misc"},
+            {"name": "Tool Beta", "purpose": "Second tool", "category": "misc"},
+            {"name": "Tool Gamma", "purpose": "Third tool", "category": "misc"},
+        ],
+        architecture={"architecture_type": "router", "justification": "Parallel tools."},
+    )
+
+    assert [event.item_name for event in composition.feedback.fallback_events] == [
+        "Tool Alpha",
+        "Tool Beta",
+        "Tool Gamma",
+    ]
+    assert composition.feedback.warnings == [
+        'Deterministic fallback used for tool "Tool Alpha".',
+        'Deterministic fallback used for tool "Tool Beta".',
+        'Deterministic fallback used for tool "Tool Gamma".',
+    ]
+
+
+@pytest.mark.asyncio
 async def test_compose_notebook_parallel_custom_node_generation_preserves_order(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -581,6 +687,62 @@ async def test_compose_notebook_parallel_custom_node_generation_preserves_order(
 
 
 @pytest.mark.asyncio
+async def test_compose_notebook_parallel_node_fallback_metadata_preserves_input_order(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    DelayedEmptyLLM.reset(
+        delay_map={
+            "enrich": 0.04,
+            "summarize": 0.01,
+            "finalize": 0.02,
+        }
+    )
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DelayedEmptyLLM)
+    monkeypatch.setattr(
+        composer_module.settings,
+        "notebook_composer_parallelism_mode",
+        "parallel",
+    )
+    monkeypatch.setattr(
+        composer_module.settings,
+        "notebook_composer_max_concurrency",
+        2,
+    )
+    composer = composer_module.NotebookComposer()
+
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Parallel Node Fallback Order",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["custom"],
+            architecture_type="custom",
+        ),
+        workflow_design={
+            "architecture_type": "custom",
+            "state_schema": {"last_node": "Last processed node"},
+            "nodes": [
+                {"name": "enrich", "purpose": "Enrich results"},
+                {"name": "summarize", "purpose": "Summarize results"},
+                {"name": "finalize", "purpose": "Finalize results"},
+            ],
+        },
+        tools=[],
+        architecture={"architecture_type": "custom", "justification": "Parallel nodes."},
+    )
+
+    assert [event.item_name for event in composition.feedback.fallback_events] == [
+        "enrich",
+        "summarize",
+        "finalize",
+    ]
+    assert composition.feedback.warnings == [
+        'Deterministic fallback used for node "enrich".',
+        'Deterministic fallback used for node "summarize".',
+        'Deterministic fallback used for node "finalize".',
+    ]
+
+
+@pytest.mark.asyncio
 async def test_compose_notebook_sequential_mode_serializes_llm_generation(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -625,6 +787,54 @@ async def test_compose_notebook_sequential_mode_serializes_llm_generation(
             {"name": "Tool Three", "purpose": "Third tool", "category": "misc"},
         ],
         architecture={"architecture_type": "router", "justification": "Sequential tools."},
+    )
+
+    assert TrackingLLM.max_active_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_compose_notebook_parallel_mode_treats_zero_concurrency_as_one(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    TrackingLLM.reset(
+        delay_map={
+            "Tool One": 0.01,
+            "Tool Two": 0.01,
+        }
+    )
+    monkeypatch.setattr(composer_module, "ChatOpenAI", TrackingLLM)
+    monkeypatch.setattr(
+        composer_module.settings,
+        "notebook_composer_parallelism_mode",
+        "parallel",
+    )
+    monkeypatch.setattr(
+        composer_module.settings,
+        "notebook_composer_max_concurrency",
+        0,
+    )
+    composer = composer_module.NotebookComposer()
+
+    await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Zero Concurrency Tools",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["router"],
+            architecture_type="router",
+        ),
+        workflow_design={
+            "architecture_type": "router",
+            "state_schema": {"messages": "Conversation state"},
+            "nodes": [
+                {"name": "router", "purpose": "Route requests"},
+                {"name": "search", "purpose": "Search documents"},
+            ],
+        },
+        tools=[
+            {"name": "Tool One", "purpose": "First tool", "category": "misc"},
+            {"name": "Tool Two", "purpose": "Second tool", "category": "misc"},
+        ],
+        architecture={"architecture_type": "router", "justification": "Zero concurrency."},
     )
 
     assert TrackingLLM.max_active_calls == 1
@@ -676,6 +886,49 @@ async def test_compose_notebook_hybrid_sparse_nodes_keep_defaults_aligned(
     assert 'workflow.add_node("researcher", researcher_node)' in graph_code
     assert 'workflow.add_node("reviewer", reviewer_node)' in graph_code
     assert 'workflow.add_edge("specialist_1", "finish")' in graph_code
+
+
+@pytest.mark.asyncio
+async def test_compose_notebook_normalizes_mixed_case_architecture_type(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Mixed Case Router",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["router"],
+            architecture_type="router",
+        ),
+        workflow_design={
+            "architecture_type": "Router",
+            "state_schema": {"messages": "Conversation state"},
+            "nodes": [
+                {"name": "router", "purpose": "Route requests"},
+                {"name": "search", "purpose": "Search documents"},
+            ],
+        },
+        tools=[],
+        architecture={"architecture_type": "Router", "justification": "Mixed case input."},
+    )
+
+    state_code = next(
+        cell.content
+        for cell in composition.cells
+        if cell.section == "state" and cell.cell_type == "code"
+    )
+    execution_code = next(
+        cell.content
+        for cell in composition.cells
+        if cell.section == "execution" and cell.cell_type == "code"
+    )
+
+    assert "route: str" in state_code
+    assert '"route": ""' in execution_code
+    assert '"results": {}' in execution_code
+    assert '"final_output": ""' in execution_code
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- add an internal notebook composer registry with built-in architecture registrations and plugin loading hooks\n- move LLM-backed tool and custom-node generation to bounded async invoke execution while preserving stable cell ordering\n- document the new internal extension points and add registry plus concurrency regression coverage\n\n## Testing\n- pytest tests/unit/test_generator_notebook_composer.py tests/unit/test_generator_nodes.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py tests/unit/test_config.py -q\n- pytest tests/unit/test_generator_notebook_composer.py tests/unit/test_generator_nodes.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py tests/unit/test_notebook.py -q\n- pytest tests/unit -q\n- pytest --asyncio-mode=auto -q\n- python -m flake8 src/langgraph_system_generator/generator/agents/notebook_composer.py src/langgraph_system_generator/generator/notebook_composer_registry.py tests/unit/test_generator_notebook_composer.py --count --select=E9,F63,F7,F82 --show-source --statistics\n\nCloses #180\nCloses #184\nCloses #179