### PR TITLE
Implement ToolchainEngineer tranche 1

### DIFF
--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -27,10 +27,12 @@ from langgraph_system_generator.generator.state import (
     NotebookDependencyPlan,
     NotebookPlan,
     RequirementsFeedback,
+    ToolPlanningFeedback,
 )
 from langgraph_system_generator.generator.architecture_registry import (
     get_default_architecture_registry,
 )
+from langgraph_system_generator.generator.tool_registry import get_tool_registry
 from langgraph_system_generator.generator.graph_design_registry import (
     build_graph_exports,
     graph_design_issue_messages,
@@ -74,6 +76,12 @@ def _available_constraint_types() -> List[str]:
     return build_constraint_type_registry(settings.requirements_constraint_types)
 
 
+def _available_tool_ids() -> List[str]:
+    """Return canonical tool ids exposed by the internal tool registry."""
+
+    return get_tool_registry().supported_tool_ids()
+
+
 def _default_state(
     prompt: str,
     generation_config: GenerationConfig | None = None,
@@ -92,6 +100,10 @@ def _default_state(
         "architecture_feedback": ArchitectureFeedback(fallback_used=False),
         "graph_design_feedback": GraphDesignFeedback(fallback_used=False),
         "graph_exports": GraphExportBundle(),
+        "tool_planning_feedback": ToolPlanningFeedback(
+            fallback_used=False,
+            available_tool_ids=_available_tool_ids(),
+        ),
         "notebook_composition_feedback": NotebookCompositionFeedback(
             fallback_used=False
         ),
@@ -326,6 +338,70 @@ def _notebook_composition_warning_entries(
             "fallback_events": fallback_events,
         }
     ]
+
+
+def _tool_planning_warning_entries(
+    feedback: Dict[str, Any] | None,
+) -> List[Dict[str, Any]]:
+    """Convert tool-planning feedback into manifest warnings."""
+
+    if not isinstance(feedback, dict):
+        return []
+
+    warnings: List[Dict[str, Any]] = []
+    advisory_warnings = list(feedback.get("warnings") or [])
+    unresolved_tools = list(feedback.get("unresolved_tools") or [])
+    validation_errors = list(feedback.get("validation_errors") or [])
+    environment_notes = list(feedback.get("environment_notes") or [])
+    dependency_conflicts = list(feedback.get("dependency_conflicts") or [])
+
+    if feedback.get("fallback_used"):
+        warnings.append(
+            {
+                "code": "tool_planning_fallback",
+                "phase": "tool_planning",
+                "message": feedback.get("fallback_reason")
+                or "Tool planning used heuristic fallback inference.",
+                "warnings": advisory_warnings,
+                "unresolved_tools": unresolved_tools,
+            }
+        )
+
+    if validation_errors or unresolved_tools:
+        warnings.append(
+            {
+                "code": "tool_planning_validation",
+                "phase": "tool_planning",
+                "message": "Tool planning reported validation issues.",
+                "validation_errors": validation_errors,
+                "unresolved_tools": unresolved_tools,
+                "warnings": advisory_warnings,
+            }
+        )
+
+    if environment_notes:
+        warnings.append(
+            {
+                "code": "tool_planning_environment",
+                "phase": "tool_planning",
+                "message": "Tool planning reported environment considerations.",
+                "environment_notes": environment_notes,
+                "warnings": advisory_warnings,
+            }
+        )
+
+    if dependency_conflicts:
+        warnings.append(
+            {
+                "code": "tool_planning_dependency",
+                "phase": "tool_planning",
+                "message": "Tool planning reported dependency conflicts or gaps.",
+                "dependency_conflicts": dependency_conflicts,
+                "warnings": advisory_warnings,
+            }
+        )
+
+    return warnings
 
 
 class _PhaseTracker:
@@ -862,6 +938,10 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
         "architecture_feedback": architecture_feedback,
         "graph_design_feedback": graph_design_feedback,
         "graph_exports": graph_exports,
+        "tool_planning_feedback": ToolPlanningFeedback(
+            fallback_used=False,
+            available_tool_ids=_available_tool_ids(),
+        ),
         "notebook_composition_feedback": NotebookCompositionFeedback(
             fallback_used=False,
             resolved_model=settings.default_model,
@@ -1003,6 +1083,7 @@ async def generate_artifacts(
     architecture_feedback = serialized.get("architecture_feedback") or {}
     graph_design_feedback = serialized.get("graph_design_feedback") or {}
     graph_exports = serialized.get("graph_exports") or {}
+    tool_planning_feedback = serialized.get("tool_planning_feedback") or {}
     notebook_composition_feedback = (
         serialized.get("notebook_composition_feedback") or {}
     )
@@ -1018,12 +1099,14 @@ async def generate_artifacts(
         "architecture_feedback": architecture_feedback,
         "graph_design_feedback": graph_design_feedback,
         "graph_exports": graph_exports,
+        "tool_planning_feedback": tool_planning_feedback,
         "notebook_composition_feedback": notebook_composition_feedback,
         "notebook_dependency_plan": notebook_dependency_plan,
         "warnings": [
             *_requirements_warning_entries(requirements_feedback),
             *_architecture_warning_entries(architecture_feedback),
             *_graph_design_warning_entries(graph_design_feedback),
+            *_tool_planning_warning_entries(tool_planning_feedback),
             *_notebook_composition_warning_entries(notebook_composition_feedback),
         ],
         "export_results": {},

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -143,6 +143,26 @@ class NotebookComposer:
                     merged.append(text)
         return merged
 
+    @classmethod
+    def _normalize_provider_env_var(cls, value: Any) -> str:
+        """Normalize arbitrary env-var suggestions into notebook-safe keys."""
+
+        text = str(value or "").strip()
+        if not text:
+            return ""
+
+        normalized = re.sub(r"[^a-zA-Z0-9_]", "_", text)
+        normalized = re.sub(r"_+", "_", normalized).strip("_").upper()
+        if not normalized:
+            return ""
+        if normalized[0].isdigit():
+            normalized = f"ENV_{normalized}"
+        if not normalized.isidentifier():
+            normalized = cls._safe_identifier(normalized, "ENV_VAR").upper()
+            if normalized[0].isdigit():
+                normalized = f"ENV_{normalized}"
+        return normalized
+
     @staticmethod
     def _package_import_probe(package_name: str) -> str:
         """Return the import probe used to detect whether a package is installed."""
@@ -331,8 +351,19 @@ class NotebookComposer:
                 tool_configuration.get("provider_env_vars"),
             )
             for env_var in provider_env_vars:
-                if env_var not in plan.provider_env_vars:
-                    plan.provider_env_vars.append(env_var)
+                normalized_env_var = self._normalize_provider_env_var(env_var)
+                if not normalized_env_var:
+                    continue
+                raw_env_var = str(env_var or "").strip()
+                if raw_env_var and normalized_env_var != raw_env_var:
+                    note = (
+                        f"Normalized provider env var '{raw_env_var}' to "
+                        f"'{normalized_env_var}' for notebook-safe configuration."
+                    )
+                    if note not in plan.runtime_notes:
+                        plan.runtime_notes.append(note)
+                if normalized_env_var not in plan.provider_env_vars:
+                    plan.provider_env_vars.append(normalized_env_var)
 
         if "langchain-openai" in selected_packages and "OPENAI_API_KEY" not in plan.provider_env_vars:
             plan.provider_env_vars.append("OPENAI_API_KEY")
@@ -717,14 +748,17 @@ else:
             "# Prefer environment variables over hardcoded secrets in notebooks.",
         ]
         for env_var in dependency_plan.provider_env_vars:
+            safe_env_var = self._normalize_provider_env_var(env_var)
+            if not safe_env_var:
+                continue
             config_lines.extend(
                 [
-                    f'{env_var} = os.environ.get("{env_var}", "")',
-                    f'if not {env_var}:',
-                    f'    print("{env_var} is not set. Configure it in your environment before running live model cells.")',
+                    f'{safe_env_var} = os.environ.get("{safe_env_var}", "")',
+                    f'if not {safe_env_var}:',
+                    f'    print("{safe_env_var} is not set. Configure it in your environment before running live model cells.")',
                     "    # Optional interactive fallback for local notebook sessions:",
                     "    # from getpass import getpass",
-                    f'    # os.environ["{env_var}"] = getpass("Enter {env_var}: ")',
+                    f'    # os.environ["{safe_env_var}"] = getpass("Enter {safe_env_var}: ")',
                     "",
                 ]
             )

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -26,6 +26,7 @@ from langgraph_system_generator.generator.state import (
     NotebookDependencyPlan,
     NotebookFallbackEvent,
     NotebookPlan,
+    ToolPlanningFeedback,
 )
 from langgraph_system_generator.patterns import (
     AutoAgentPattern,
@@ -42,6 +43,7 @@ _PACKAGE_IMPORT_PROBES = {
     "langchain-core": "langchain_core",
     "langchain-openai": "langchain_openai",
     "langchain-community": "langchain_community",
+    "pydantic": "pydantic",
     "pypdf": "pypdf",
     "requests": "requests",
 }
@@ -122,6 +124,24 @@ class NotebookComposer:
         lines = [line.rstrip() for line in text.split("\n")]
         normalized = "\n    ".join(lines).strip()
         return normalized or fallback
+
+    @staticmethod
+    def _merge_string_lists(*values: Any) -> List[str]:
+        """Merge list-or-scalar string inputs into an ordered unique list."""
+
+        merged: List[str] = []
+        for value in values:
+            if value in (None, ""):
+                continue
+            if isinstance(value, list):
+                raw_items = value
+            else:
+                raw_items = [value]
+            for raw_item in raw_items:
+                text = str(raw_item or "").strip()
+                if text and text not in merged:
+                    merged.append(text)
+        return merged
 
     @staticmethod
     def _package_import_probe(package_name: str) -> str:
@@ -254,10 +274,26 @@ class NotebookComposer:
             )
 
         for tool in tools:
+            tool_status = self._normalize_inline_text(tool.get("status", ""), "").lower()
+            if tool_status == "unsupported":
+                continue
             category = self._normalize_inline_text(tool.get("category", ""), "").lower()
             tool_configuration = tool.get("configuration")
             if not isinstance(tool_configuration, dict):
                 tool_configuration = {}
+            top_level_packages = tool.get("packages", [])
+            if isinstance(top_level_packages, str):
+                top_level_packages = [top_level_packages]
+            if not isinstance(top_level_packages, list):
+                top_level_packages = []
+            for package_name in top_level_packages:
+                self._add_dependency_candidate(
+                    plan,
+                    selected_packages,
+                    selected_families,
+                    str(package_name),
+                    requested_by=self._normalize_inline_text(tool.get("name", ""), "tool"),
+                )
             requested_packages = tool_configuration.get("packages", [])
             if isinstance(requested_packages, str):
                 requested_packages = [requested_packages]
@@ -289,6 +325,14 @@ class NotebookComposer:
                     family=family,
                     requested_by=self._normalize_inline_text(tool.get("name", ""), "tool"),
                 )
+
+            provider_env_vars = self._merge_string_lists(
+                tool.get("provider_env_vars"),
+                tool_configuration.get("provider_env_vars"),
+            )
+            for env_var in provider_env_vars:
+                if env_var not in plan.provider_env_vars:
+                    plan.provider_env_vars.append(env_var)
 
         if "langchain-openai" in selected_packages and "OPENAI_API_KEY" not in plan.provider_env_vars:
             plan.provider_env_vars.append("OPENAI_API_KEY")
@@ -357,6 +401,7 @@ class NotebookComposer:
         workflow_design: Dict[str, Any],
         tools: List[Dict[str, Any]],
         architecture: Dict[str, Any],
+        tool_planning_feedback: ToolPlanningFeedback | None = None,
     ) -> NotebookCompositionResult:
         """Generate complete notebook cells plus composition metadata.
 
@@ -389,6 +434,9 @@ class NotebookComposer:
             architecture=architecture,
             dependency_plan=dependency_plan,
             feedback=feedback,
+            tool_planning_feedback=(
+                tool_planning_feedback or ToolPlanningFeedback(available_tool_ids=[])
+            ),
         )
 
         architecture_type = str(
@@ -434,6 +482,90 @@ class NotebookComposer:
             dependency_plan=dependency_plan,
             feedback=feedback,
         )
+
+    def _create_tool_planning_warning_cells(
+        self,
+        tool_planning_feedback: ToolPlanningFeedback | None,
+    ) -> List[CellSpec]:
+        """Create notebook-visible warnings for degraded tool planning."""
+
+        feedback = tool_planning_feedback
+        if feedback is None:
+            return []
+
+        has_advisories = any(
+            [
+                feedback.fallback_used,
+                feedback.validation_errors,
+                feedback.unresolved_tools,
+                feedback.environment_notes,
+                feedback.dependency_conflicts,
+                feedback.warnings,
+            ]
+        )
+        if not has_advisories:
+            return []
+
+        lines = [
+            "## Tool Planning Notes",
+            "",
+            "Review these advisories before relying on the generated tool plan as-is.",
+        ]
+        if feedback.fallback_used:
+            lines.extend(
+                [
+                    "",
+                    f"- Fallback used: {feedback.fallback_reason or 'Heuristic inference was used for tool planning.'}",
+                ]
+            )
+        if feedback.unresolved_tools:
+            lines.extend(
+                [
+                    "",
+                    "- Unresolved tools:",
+                    *[f"  - {tool_name}" for tool_name in feedback.unresolved_tools],
+                ]
+            )
+        if feedback.validation_errors:
+            lines.extend(
+                [
+                    "",
+                    "- Validation issues:",
+                    *[f"  - {message}" for message in feedback.validation_errors],
+                ]
+            )
+        if feedback.environment_notes:
+            lines.extend(
+                [
+                    "",
+                    "- Environment notes:",
+                    *[f"  - {message}" for message in feedback.environment_notes],
+                ]
+            )
+        if feedback.dependency_conflicts:
+            lines.extend(
+                [
+                    "",
+                    "- Dependency conflicts:",
+                    *[f"  - {message}" for message in feedback.dependency_conflicts],
+                ]
+            )
+        if feedback.warnings:
+            lines.extend(
+                [
+                    "",
+                    "- Additional warnings:",
+                    *[f"  - {message}" for message in feedback.warnings],
+                ]
+            )
+
+        return [
+            CellSpec(
+                cell_type="markdown",
+                content="\n".join(lines),
+                section="tools",
+            )
+        ]
 
     def _create_intro_cells(
         self,

--- a/src/langgraph_system_generator/generator/agents/toolchain_engineer.py
+++ b/src/langgraph_system_generator/generator/agents/toolchain_engineer.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Mapping
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from langgraph_system_generator.generator.agents._llm import build_chat_llm
-from langgraph_system_generator.generator.state import Constraint
+from langgraph_system_generator.generator.state import (
+    Constraint,
+    ToolPlanningFeedback,
+    ToolPlanningResult,
+    ToolSpec,
+)
+from langgraph_system_generator.generator.tool_registry import (
+    ToolRegistry,
+    get_tool_registry,
+    normalize_tool_token,
+)
 from langgraph_system_generator.generator.utils import extract_json_from_llm_response
 from langgraph_system_generator.utils.config import ModelConfig
 
@@ -20,16 +30,267 @@ class ToolchainEngineer:
         self,
         model: str | None = None,
         model_config: ModelConfig | None = None,
+        registry: ToolRegistry | None = None,
     ):
         self.llm = build_chat_llm(
             model=model,
             model_config=model_config,
             chat_openai_class=ChatOpenAI,
         )
+        self.registry = registry.clone() if registry is not None else get_tool_registry().clone()
+
+    @staticmethod
+    def _append_unique(items: List[str], value: str | None) -> None:
+        """Append a non-empty string once while preserving order."""
+
+        normalized = str(value or "").strip()
+        if normalized and normalized not in items:
+            items.append(normalized)
+
+    @staticmethod
+    def _string_list(value: Any) -> List[str]:
+        """Normalize list-or-scalar input into an ordered string list."""
+
+        if value in (None, ""):
+            return []
+        if isinstance(value, list):
+            raw_items = value
+        else:
+            raw_items = [value]
+
+        normalized: List[str] = []
+        for raw_item in raw_items:
+            text = str(raw_item or "").strip()
+            if text and text not in normalized:
+                normalized.append(text)
+        return normalized
+
+    @classmethod
+    def _merge_string_lists(cls, *values: Any) -> List[str]:
+        """Merge arbitrary string-list inputs into an ordered de-duplicated list."""
+
+        merged: List[str] = []
+        for value in values:
+            for item in cls._string_list(value):
+                if item not in merged:
+                    merged.append(item)
+        return merged
+
+    @staticmethod
+    def _normalize_configuration(value: Any) -> Dict[str, Any]:
+        """Return a normalized configuration mapping."""
+
+        if not isinstance(value, Mapping):
+            return {}
+        return {
+            str(key).strip(): item
+            for key, item in value.items()
+            if str(key or "").strip()
+        }
+
+    def _registration_tool_spec(
+        self,
+        tool_id: str,
+        *,
+        purpose: str,
+        configuration: Mapping[str, Any] | None = None,
+        status: str = "ready",
+        warnings: List[str] | None = None,
+        name: str | None = None,
+        packages: Any = None,
+        provider_env_vars: Any = None,
+    ) -> ToolSpec:
+        """Build a ToolSpec from a canonical registry entry."""
+
+        registration = self.registry.get(tool_id)
+        tool = registration.build_tool_spec(
+            purpose=purpose,
+            configuration=configuration,
+            status=status,
+            warnings=warnings,
+            name=name,
+        )
+        return tool.model_copy(
+            update={
+                "packages": self._merge_string_lists(tool.packages, packages),
+                "provider_env_vars": self._merge_string_lists(
+                    tool.provider_env_vars,
+                    provider_env_vars,
+                ),
+            }
+        )
+
+    def _unsupported_tool_spec(
+        self,
+        *,
+        raw_name: str,
+        raw_category: str,
+        purpose: str,
+        configuration: Mapping[str, Any] | None,
+        warning: str,
+    ) -> ToolSpec:
+        """Return an unsupported tool spec for unresolved suggestions."""
+
+        fallback_name = raw_name.strip() or "Unsupported Tool"
+        tool_token = raw_name or raw_category or "unsupported_tool"
+        return ToolSpec(
+            tool_id=normalize_tool_token(tool_token),
+            name=fallback_name,
+            category=(raw_category or "unsupported").strip() or "unsupported",
+            purpose=purpose.strip() or f"Unsupported tool suggestion: {fallback_name}",
+            configuration=dict(configuration or {}),
+            packages=self._string_list((configuration or {}).get("packages")),
+            provider_env_vars=self._string_list(
+                (configuration or {}).get("provider_env_vars")
+            ),
+            status="unsupported",
+            warnings=[warning],
+        )
+
+    def _infer_fallback_tools(
+        self,
+        workflow_design: Dict[str, Any],
+    ) -> List[ToolSpec]:
+        """Infer a conservative fallback tool plan from workflow nodes."""
+
+        nodes = list(workflow_design.get("nodes") or [])
+        heuristic_matches: Dict[str, List[str]] = {
+            "web_search": [],
+            "file_reader": [],
+            "http_client": [],
+            "data_processor": [],
+            "schema_validator": [],
+        }
+        heuristics = [
+            ("web_search", ("research", "search", "docs", "documentation")),
+            ("file_reader", ("file", "document", "pdf")),
+            ("http_client", ("api", "fetch", "http", "request")),
+            ("data_processor", ("parse", "transform", "data", "normalize")),
+            ("schema_validator", ("validate", "schema", "check", "verify")),
+        ]
+
+        for node in nodes:
+            node_name = str(node.get("name", "")).strip()
+            node_purpose = str(node.get("purpose", "")).strip()
+            node_text = f"{node_name} {node_purpose}".lower()
+            label = node_name or node_purpose or "workflow node"
+            for tool_id, tokens in heuristics:
+                if any(token in node_text for token in tokens):
+                    self._append_unique(heuristic_matches[tool_id], label)
+
+        fallback_tools: List[ToolSpec] = []
+        for tool_id in [
+            "web_search",
+            "file_reader",
+            "http_client",
+            "data_processor",
+            "schema_validator",
+        ]:
+            matched_nodes = heuristic_matches[tool_id]
+            if not matched_nodes:
+                continue
+            fallback_tools.append(
+                self._registration_tool_spec(
+                    tool_id,
+                    purpose=(
+                        "Heuristically inferred from workflow nodes: "
+                        + ", ".join(matched_nodes)
+                    ),
+                    status="fallback",
+                    warnings=[
+                        "Heuristic fallback inferred this tool from workflow node intent."
+                    ],
+                )
+            )
+
+        return fallback_tools
+
+    def _normalize_llm_tools(
+        self,
+        payload: Any,
+        feedback: ToolPlanningFeedback,
+    ) -> List[ToolSpec]:
+        """Normalize an LLM payload into registry-backed tool specs."""
+
+        if not isinstance(payload, list):
+            self._append_unique(
+                feedback.validation_errors,
+                "Tool planning response must be a JSON array of tool objects.",
+            )
+            return []
+
+        normalized_tools: List[ToolSpec] = []
+        for index, item in enumerate(payload):
+            if not isinstance(item, Mapping):
+                self._append_unique(
+                    feedback.validation_errors,
+                    f"Tool suggestion at index {index} must be an object.",
+                )
+                continue
+
+            raw_name = str(item.get("tool_id") or item.get("name") or "").strip()
+            raw_category = str(item.get("category") or "").strip().lower()
+            purpose = str(item.get("purpose") or "").strip()
+            configuration = self._normalize_configuration(item.get("configuration"))
+            extra_packages = self._merge_string_lists(
+                item.get("packages"),
+                configuration.get("packages"),
+            )
+            extra_provider_env_vars = self._merge_string_lists(
+                item.get("provider_env_vars"),
+                configuration.get("provider_env_vars"),
+            )
+
+            if not raw_name:
+                self._append_unique(
+                    feedback.validation_errors,
+                    f"Tool suggestion at index {index} is missing a name.",
+                )
+                continue
+
+            resolved_tool_id = self.registry.resolve_tool_id(raw_name)
+            if resolved_tool_id is None:
+                warning = (
+                    f"Unsupported tool suggestion '{raw_name}' could not be resolved to a canonical tool."
+                )
+                self._append_unique(feedback.validation_errors, warning)
+                self._append_unique(feedback.unresolved_tools, raw_name)
+                self._append_unique(feedback.warnings, warning)
+                normalized_tools.append(
+                    self._unsupported_tool_spec(
+                        raw_name=raw_name,
+                        raw_category=raw_category,
+                        purpose=purpose,
+                        configuration=configuration,
+                        warning=warning,
+                    )
+                )
+                continue
+
+            normalized_tools.append(
+                self._registration_tool_spec(
+                    resolved_tool_id,
+                    purpose=purpose or f"Use {resolved_tool_id} for this workflow.",
+                    configuration=configuration,
+                    status="ready",
+                    warnings=self._string_list(item.get("warnings")),
+                    name=raw_name,
+                    packages=extra_packages,
+                    provider_env_vars=extra_provider_env_vars,
+                )
+            )
+
+        return normalized_tools
+
+    @staticmethod
+    def _has_usable_tools(tools: List[ToolSpec]) -> bool:
+        """Return True when the plan contains at least one runnable tool."""
+
+        return any(tool.status != "unsupported" for tool in tools)
 
     async def plan_tools(
         self, workflow_design: Dict[str, Any], constraints: List[Constraint]
-    ) -> List[Dict[str, Any]]:
+    ) -> ToolPlanningResult:
         """Select tools needed for the workflow.
 
         Args:
@@ -37,7 +298,7 @@ class ToolchainEngineer:
             constraints: Project constraints
 
         Returns:
-            List of tool specifications with name, purpose, and configuration
+            Structured tool-planning output with normalized tool specs and feedback
         """
         nodes = workflow_design.get("nodes", [])
         nodes_text = "\n".join(
@@ -45,6 +306,10 @@ class ToolchainEngineer:
         )
 
         constraints_text = "\n".join([f"- [{c.type}] {c.value}" for c in constraints])
+        feedback = ToolPlanningFeedback(
+            available_tool_ids=self.registry.supported_tool_ids()
+        )
+        heuristic_tools = self._infer_fallback_tools(workflow_design)
 
         tools_prompt = SystemMessage(
             content="""You are a toolchain engineer for LangGraph workflows.
@@ -65,10 +330,18 @@ For each tool, specify:
 - purpose: Why this tool is needed
 - configuration: Any specific configuration
 
+Only recommend tools from this canonical registry:
+- web_search: web and docs search
+- file_reader: local files, documents, PDFs
+- http_client: HTTP/API calls
+- data_processor: parsing and data transformation
+- schema_validator: validation and schema checks
+
 Return a JSON array:
 [
   {
-    "name": "tool_name",
+    "tool_id": "canonical_tool_id_or_alias",
+    "name": "display_name",
     "category": "category",
     "purpose": "description",
     "configuration": {}
@@ -90,8 +363,27 @@ Identify needed tools."""
         response = await self.llm.ainvoke([tools_prompt, user_message])
 
         try:
-            tools = extract_json_from_llm_response(response.content)
-            return tools
-        except (ValueError, KeyError, TypeError):
-            # Fallback: no tools needed
-            return []
+            payload = extract_json_from_llm_response(response.content)
+        except (ValueError, KeyError, TypeError) as exc:
+            feedback.fallback_used = True
+            feedback.fallback_reason = (
+                f"Tool planning fell back to heuristic inference after payload parsing failed: {exc}"
+            )
+            self._append_unique(feedback.warnings, feedback.fallback_reason)
+            return ToolPlanningResult(tools=heuristic_tools, feedback=feedback)
+
+        normalized_tools = self._normalize_llm_tools(payload, feedback)
+        if self._has_usable_tools(normalized_tools):
+            return ToolPlanningResult(tools=normalized_tools, feedback=feedback)
+
+        feedback.fallback_used = True
+        feedback.fallback_reason = (
+            "Tool planning fell back to heuristic inference because the model returned no usable canonical tools."
+        )
+        self._append_unique(feedback.warnings, feedback.fallback_reason)
+
+        combined_tools: List[ToolSpec] = list(heuristic_tools)
+        combined_tools.extend(
+            tool for tool in normalized_tools if tool.status == "unsupported"
+        )
+        return ToolPlanningResult(tools=combined_tools, feedback=feedback)

--- a/src/langgraph_system_generator/generator/agents/toolchain_engineer.py
+++ b/src/langgraph_system_generator/generator/agents/toolchain_engineer.py
@@ -154,13 +154,6 @@ class ToolchainEngineer:
         """Infer a conservative fallback tool plan from workflow nodes."""
 
         nodes = list(workflow_design.get("nodes") or [])
-        heuristic_matches: Dict[str, List[str]] = {
-            "web_search": [],
-            "file_reader": [],
-            "http_client": [],
-            "data_processor": [],
-            "schema_validator": [],
-        }
         heuristics = [
             ("web_search", ("research", "search", "docs", "documentation")),
             ("file_reader", ("file", "document", "pdf")),
@@ -168,6 +161,9 @@ class ToolchainEngineer:
             ("data_processor", ("parse", "transform", "data", "normalize")),
             ("schema_validator", ("validate", "schema", "check", "verify")),
         ]
+        heuristic_matches: Dict[str, List[str]] = {
+            tool_id: [] for tool_id, _tokens in heuristics
+        }
 
         for node in nodes:
             node_name = str(node.get("name", "")).strip()
@@ -179,13 +175,7 @@ class ToolchainEngineer:
                     self._append_unique(heuristic_matches[tool_id], label)
 
         fallback_tools: List[ToolSpec] = []
-        for tool_id in [
-            "web_search",
-            "file_reader",
-            "http_client",
-            "data_processor",
-            "schema_validator",
-        ]:
+        for tool_id, _tokens in heuristics:
             matched_nodes = heuristic_matches[tool_id]
             if not matched_nodes:
                 continue
@@ -228,7 +218,9 @@ class ToolchainEngineer:
                 )
                 continue
 
-            raw_name = str(item.get("tool_id") or item.get("name") or "").strip()
+            raw_tool_token = str(item.get("tool_id") or "").strip()
+            display_name = str(item.get("name") or "").strip()
+            resolution_token = raw_tool_token or display_name
             raw_category = str(item.get("category") or "").strip().lower()
             purpose = str(item.get("purpose") or "").strip()
             configuration = self._normalize_configuration(item.get("configuration"))
@@ -241,24 +233,24 @@ class ToolchainEngineer:
                 configuration.get("provider_env_vars"),
             )
 
-            if not raw_name:
+            if not resolution_token:
                 self._append_unique(
                     feedback.validation_errors,
-                    f"Tool suggestion at index {index} is missing a name.",
+                    f"Tool suggestion at index {index} is missing a tool_id or alias.",
                 )
                 continue
 
-            resolved_tool_id = self.registry.resolve_tool_id(raw_name)
+            resolved_tool_id = self.registry.resolve_tool_id(resolution_token)
             if resolved_tool_id is None:
                 warning = (
-                    f"Unsupported tool suggestion '{raw_name}' could not be resolved to a canonical tool."
+                    f"Unsupported tool suggestion '{resolution_token}' could not be resolved to a canonical tool."
                 )
                 self._append_unique(feedback.validation_errors, warning)
-                self._append_unique(feedback.unresolved_tools, raw_name)
+                self._append_unique(feedback.unresolved_tools, resolution_token)
                 self._append_unique(feedback.warnings, warning)
                 normalized_tools.append(
                     self._unsupported_tool_spec(
-                        raw_name=raw_name,
+                        raw_name=display_name or resolution_token,
                         raw_category=raw_category,
                         purpose=purpose,
                         configuration=configuration,
@@ -274,7 +266,7 @@ class ToolchainEngineer:
                     configuration=configuration,
                     status="ready",
                     warnings=self._string_list(item.get("warnings")),
-                    name=raw_name,
+                    name=display_name or None,
                     packages=extra_packages,
                     provider_env_vars=extra_provider_env_vars,
                 )
@@ -312,7 +304,7 @@ class ToolchainEngineer:
         heuristic_tools = self._infer_fallback_tools(workflow_design)
 
         tools_prompt = SystemMessage(
-            content="""You are a toolchain engineer for LangGraph workflows.
+            content=f"""You are a toolchain engineer for LangGraph workflows.
 Analyze the workflow nodes and determine what tools are needed.
 
 Common tool categories:
@@ -325,27 +317,24 @@ Common tool categories:
 - **Validation**: Schema validation, content moderation
 
 For each tool, specify:
-- name: Tool identifier
+- tool_id: Canonical tool identifier or supported alias
+- name: Human-readable display name for the tool
 - category: Tool category
 - purpose: Why this tool is needed
 - configuration: Any specific configuration
 
 Only recommend tools from this canonical registry:
-- web_search: web and docs search
-- file_reader: local files, documents, PDFs
-- http_client: HTTP/API calls
-- data_processor: parsing and data transformation
-- schema_validator: validation and schema checks
+{self.registry.render_planning_prompt_catalog()}
 
 Return a JSON array:
 [
-  {
+  {{
     "tool_id": "canonical_tool_id_or_alias",
     "name": "display_name",
     "category": "category",
     "purpose": "description",
-    "configuration": {}
-  },
+    "configuration": {{}}
+  }},
   ...
 ]"""
         )

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -25,12 +25,13 @@ from langgraph_system_generator.generator.state import (
     CellSpec,
     DocSnippet,
     GeneratorState,
-    NotebookCompositionFeedback,
-    NotebookDependencyPlan,
     GraphDesignFeedback,
     GraphExportBundle,
+    NotebookCompositionFeedback,
+    NotebookDependencyPlan,
     NotebookPlan,
     QAReport,
+    ToolPlanningFeedback,
 )
 from langgraph_system_generator.notebook.composer import (
     NotebookComposer as NotebookFileComposer,
@@ -329,10 +330,13 @@ async def tooling_plan_node(state: GeneratorState) -> Dict[str, Any]:
     """
     engineer = ToolchainEngineer(model_config=_resolve_model_config(state))
 
-    workflow_design = state.get("workflow_design", {})
-    tools = await engineer.plan_tools(workflow_design, state["constraints"])
+    workflow_design = state.get("workflow_design") or {}
+    planning = await engineer.plan_tools(workflow_design, state["constraints"])
 
-    return {"tools_plan": tools}
+    return {
+        "tools_plan": planning.to_tools_plan_payload(),
+        "tool_planning_feedback": planning.feedback,
+    }
 
 
 async def notebook_assembly_node(state: GeneratorState) -> Dict[str, Any]:
@@ -356,6 +360,7 @@ async def notebook_assembly_node(state: GeneratorState) -> Dict[str, Any]:
             else graph_exports
         )
     tools_plan = state.get("tools_plan", [])
+    tool_planning_feedback = state.get("tool_planning_feedback")
 
     architecture = {
         "architecture_type": resolve_architecture_type(
@@ -366,7 +371,11 @@ async def notebook_assembly_node(state: GeneratorState) -> Dict[str, Any]:
     }
 
     composition = await composer.compose_notebook(
-        notebook_plan, workflow_design, tools_plan, architecture
+        notebook_plan,
+        workflow_design,
+        tools_plan,
+        architecture,
+        tool_planning_feedback=tool_planning_feedback,
     )
 
     return {
@@ -647,6 +656,7 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
     architecture_feedback = state.get("architecture_feedback")
     graph_design_feedback = state.get("graph_design_feedback")
     graph_exports = state.get("graph_exports")
+    tool_planning_feedback = state.get("tool_planning_feedback")
     notebook_composition_feedback = state.get("notebook_composition_feedback")
     notebook_dependency_plan = state.get("notebook_dependency_plan")
     manifest = {
@@ -679,6 +689,14 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
             graph_exports.model_dump(by_alias=True)
             if hasattr(graph_exports, "model_dump")
             else (graph_exports or GraphExportBundle().model_dump(by_alias=True))
+        ),
+        "tool_planning_feedback": (
+            tool_planning_feedback.model_dump()
+            if hasattr(tool_planning_feedback, "model_dump")
+            else (
+                tool_planning_feedback
+                or ToolPlanningFeedback(available_tool_ids=[]).model_dump()
+            )
         ),
         "notebook_composition_feedback": (
             notebook_composition_feedback.model_dump()

--- a/src/langgraph_system_generator/generator/notebook_composer_registry.py
+++ b/src/langgraph_system_generator/generator/notebook_composer_registry.py
@@ -12,6 +12,7 @@ from langgraph_system_generator.generator.state import (
     NotebookCompositionFeedback,
     NotebookDependencyPlan,
     NotebookPlan,
+    ToolPlanningFeedback,
 )
 from langgraph_system_generator.utils.config import settings
 
@@ -75,6 +76,7 @@ class NotebookComposerContext:
     architecture: dict[str, Any]
     dependency_plan: NotebookDependencyPlan
     feedback: NotebookCompositionFeedback
+    tool_planning_feedback: ToolPlanningFeedback
 
 
 @dataclass
@@ -294,9 +296,18 @@ async def _build_tools_section(
     composer: Any,
     context: NotebookComposerContext,
 ) -> list[CellSpec]:
-    if not context.tools:
-        return []
-    return await composer._create_tool_cells(context.tools, context.feedback)
+    warning_cells = composer._create_tool_planning_warning_cells(
+        context.tool_planning_feedback
+    )
+    runnable_tools = [
+        tool
+        for tool in context.tools
+        if str(tool.get("status", "ready")).strip().lower() != "unsupported"
+    ]
+    if not runnable_tools:
+        return warning_cells
+    tool_cells = await composer._create_tool_cells(runnable_tools, context.feedback)
+    return [*warning_cells, *tool_cells]
 
 
 async def _build_nodes_section(

--- a/src/langgraph_system_generator/generator/state.py
+++ b/src/langgraph_system_generator/generator/state.py
@@ -343,6 +343,93 @@ class GraphDesignResult(BaseModel):
         }
 
 
+ToolStatus = Literal["ready", "fallback", "unsupported"]
+
+
+class ToolSpec(BaseModel):
+    """Normalized tool specification for workflow planning."""
+
+    tool_id: str = Field(description="Canonical tool identifier.")
+    name: str = Field(description="Human-readable display name for the tool.")
+    category: str = Field(description="Normalized tool category.")
+    purpose: str = Field(description="Why the workflow needs this tool.")
+    configuration: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Normalized tool configuration payload.",
+    )
+    packages: List[str] = Field(
+        default_factory=list,
+        description="Packages required to support this tool in generated notebooks.",
+    )
+    provider_env_vars: List[str] = Field(
+        default_factory=list,
+        description="Provider credential environment variables needed by this tool.",
+    )
+    status: ToolStatus = Field(
+        default="ready",
+        description="Planning status: ready, fallback, or unsupported.",
+    )
+    warnings: List[str] = Field(
+        default_factory=list,
+        description="Tool-specific planning or validation warnings.",
+    )
+
+
+class ToolPlanningFeedback(BaseModel):
+    """Advisory feedback captured during tool planning."""
+
+    fallback_used: bool = Field(
+        default=False,
+        description="Whether the planner had to fall back to heuristic tool inference.",
+    )
+    fallback_reason: Optional[str] = Field(
+        default=None,
+        description="Reason fallback mode was used, when applicable.",
+    )
+    validation_errors: List[str] = Field(
+        default_factory=list,
+        description="Validation issues found in LLM-produced tool suggestions.",
+    )
+    unresolved_tools: List[str] = Field(
+        default_factory=list,
+        description="Suggested tools that could not be resolved to a canonical registry entry.",
+    )
+    environment_notes: List[str] = Field(
+        default_factory=list,
+        description="Environment-compatibility notes gathered during planning.",
+    )
+    dependency_conflicts: List[str] = Field(
+        default_factory=list,
+        description="Dependency conflicts or gaps discovered during planning.",
+    )
+    available_tool_ids: List[str] = Field(
+        default_factory=list,
+        description="Canonical tool identifiers available to the planner.",
+    )
+    warnings: List[str] = Field(
+        default_factory=list,
+        description="High-level planning warnings for manifests and notebook surfaces.",
+    )
+
+
+class ToolPlanningResult(BaseModel):
+    """Structured tool-planning output consumed by downstream stages."""
+
+    tools: List[ToolSpec] = Field(
+        default_factory=list,
+        description="Normalized planned tools for the workflow.",
+    )
+    feedback: ToolPlanningFeedback = Field(
+        default_factory=ToolPlanningFeedback,
+        description="Advisory tool-planning metadata.",
+    )
+
+    def to_tools_plan_payload(self) -> List[Dict[str, Any]]:
+        """Return the backward-compatible tools_plan payload."""
+
+        return [tool.model_dump() for tool in self.tools]
+
+
 class DocSnippet(BaseModel):
     """Retrieved documentation snippet."""
 
@@ -521,6 +608,7 @@ class GeneratorState(TypedDict):
     # Workflow design (added for graph designer)
     workflow_design: Optional[Dict[str, Any]]
     tools_plan: Optional[List[Dict[str, Any]]]
+    tool_planning_feedback: ToolPlanningFeedback
     notebook_composition_feedback: NotebookCompositionFeedback
     notebook_dependency_plan: NotebookDependencyPlan
 

--- a/src/langgraph_system_generator/generator/tool_registry.py
+++ b/src/langgraph_system_generator/generator/tool_registry.py
@@ -64,6 +64,7 @@ class ToolRegistration:
 
     tool_id: str
     name: str
+    description: str
     category: str
     aliases: list[str] = field(default_factory=list)
     default_packages: list[str] = field(default_factory=list)
@@ -76,10 +77,15 @@ class ToolRegistration:
 
         normalized_tool_id = _normalize_tool_id(self.tool_id)
         normalized_name = str(self.name or "").strip()
+        normalized_description = str(self.description or "").strip()
         normalized_category = str(self.category or "").strip().lower()
         if not normalized_name:
             raise ValueError(
                 f"Tool registration '{normalized_tool_id}' must include a default name."
+            )
+        if not normalized_description:
+            raise ValueError(
+                f"Tool registration '{normalized_tool_id}' must include a description."
             )
         if not normalized_category:
             raise ValueError(
@@ -93,6 +99,7 @@ class ToolRegistration:
         return ToolRegistration(
             tool_id=normalized_tool_id,
             name=normalized_name,
+            description=normalized_description,
             category=normalized_category,
             aliases=aliases,
             default_packages=_normalize_string_list(self.default_packages),
@@ -146,6 +153,21 @@ class ToolRegistry:
         """Register or replace a tool registration."""
 
         normalized = registration.normalized()
+        stale_aliases = [
+            alias
+            for alias, tool_id in self._aliases.items()
+            if tool_id == normalized.tool_id
+        ]
+        for alias in stale_aliases:
+            del self._aliases[alias]
+
+        for alias in normalized.aliases:
+            existing_tool_id = self._aliases.get(alias)
+            if existing_tool_id and existing_tool_id != normalized.tool_id:
+                raise ValueError(
+                    f"Alias '{alias}' is already registered to tool '{existing_tool_id}'."
+                )
+
         self._registrations[normalized.tool_id] = normalized
         for alias in normalized.aliases:
             self._aliases[alias] = normalized.tool_id
@@ -170,6 +192,20 @@ class ToolRegistry:
 
         return list(self._registrations.keys())
 
+    def render_planning_prompt_catalog(self) -> str:
+        """Render a human-readable tool catalog for the planner prompt."""
+
+        lines: list[str] = []
+        for registration in self._registrations.values():
+            aliases = [
+                alias for alias in registration.aliases if alias != registration.tool_id
+            ]
+            alias_text = f" Aliases: {', '.join(aliases)}." if aliases else ""
+            lines.append(
+                f"- {registration.tool_id}: {registration.description}.{alias_text}"
+            )
+        return "\n".join(lines)
+
 
 def _default_registrations() -> list[ToolRegistration]:
     """Return the built-in tool registry entries."""
@@ -178,6 +214,7 @@ def _default_registrations() -> list[ToolRegistration]:
         ToolRegistration(
             tool_id="web_search",
             name="Web Docs Search",
+            description="Search public web pages and documentation snippets",
             category="search",
             aliases=[
                 "search",
@@ -198,6 +235,7 @@ def _default_registrations() -> list[ToolRegistration]:
         ToolRegistration(
             tool_id="file_reader",
             name="File Reader",
+            description="Read local files, documents, and PDFs",
             category="file_io",
             aliases=[
                 "file",
@@ -217,6 +255,7 @@ def _default_registrations() -> list[ToolRegistration]:
         ToolRegistration(
             tool_id="http_client",
             name="HTTP Client",
+            description="Fetch remote HTTP and API resources",
             category="api",
             aliases=[
                 "http",
@@ -237,6 +276,7 @@ def _default_registrations() -> list[ToolRegistration]:
         ToolRegistration(
             tool_id="data_processor",
             name="Data Processor",
+            description="Parse and transform structured or semi-structured data",
             category="data_processing",
             aliases=[
                 "data",
@@ -257,6 +297,7 @@ def _default_registrations() -> list[ToolRegistration]:
         ToolRegistration(
             tool_id="schema_validator",
             name="Schema Validator",
+            description="Validate records, schemas, and structured outputs",
             category="validation",
             aliases=[
                 "validator",
@@ -318,7 +359,6 @@ def _load_plugin_modules(
     return registry
 
 
-@lru_cache(maxsize=16)
 def get_tool_registry(plugin_modules: tuple[str, ...] | None = None) -> ToolRegistry:
     """Return the built-in tool registry with optional plugin extensions."""
 
@@ -327,7 +367,14 @@ def get_tool_registry(plugin_modules: tuple[str, ...] | None = None) -> ToolRegi
         if plugin_modules is None
         else plugin_modules
     )
+    return _get_tool_registry_cached(normalized_modules)
+
+
+@lru_cache(maxsize=16)
+def _get_tool_registry_cached(plugin_modules: tuple[str, ...]) -> ToolRegistry:
+    """Return a cached registry keyed by explicit plugin module tuples."""
+
     registry = ToolRegistry(_default_registrations())
-    if normalized_modules:
-        registry = _load_plugin_modules(registry, normalized_modules)
+    if plugin_modules:
+        registry = _load_plugin_modules(registry, plugin_modules)
     return registry

--- a/src/langgraph_system_generator/generator/tool_registry.py
+++ b/src/langgraph_system_generator/generator/tool_registry.py
@@ -1,0 +1,333 @@
+"""Internal registry for ToolchainEngineer canonical tool metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+import importlib
+from typing import Any, Iterable, Mapping
+
+from langgraph_system_generator.generator.state import ToolSpec
+from langgraph_system_generator.utils.config import settings
+
+
+def _normalize_tool_id(value: str) -> str:
+    """Return a normalized tool identifier."""
+
+    normalized = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    if not normalized:
+        raise ValueError("Tool registrations must include a non-empty tool_id.")
+    return normalized
+
+
+def _normalize_string_list(values: Iterable[str] | None) -> list[str]:
+    """Return an ordered, de-duplicated list of non-empty strings."""
+
+    normalized_values: list[str] = []
+    for raw_value in values or []:
+        normalized = str(raw_value or "").strip()
+        if normalized and normalized not in normalized_values:
+            normalized_values.append(normalized)
+    return normalized_values
+
+
+def _normalize_token_list(values: Iterable[str] | None) -> list[str]:
+    """Return an ordered, de-duplicated list of normalized tool tokens."""
+
+    normalized_values: list[str] = []
+    for raw_value in values or []:
+        normalized = _normalize_tool_id(raw_value)
+        if normalized not in normalized_values:
+            normalized_values.append(normalized)
+    return normalized_values
+
+
+def _normalize_mapping(values: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return a shallow normalized mapping."""
+
+    return {
+        str(key).strip(): value
+        for key, value in (values or {}).items()
+        if str(key or "").strip()
+    }
+
+
+def normalize_tool_token(value: Any) -> str:
+    """Return a normalized tool token suitable for registry lookups."""
+
+    return _normalize_tool_id(str(value or ""))
+
+
+@dataclass(frozen=True)
+class ToolRegistration:
+    """Metadata describing a canonical supported tool."""
+
+    tool_id: str
+    name: str
+    category: str
+    aliases: list[str] = field(default_factory=list)
+    default_packages: list[str] = field(default_factory=list)
+    provider_env_vars: list[str] = field(default_factory=list)
+    environment_compatibility: dict[str, Any] = field(default_factory=dict)
+    fallback_configuration_defaults: dict[str, Any] = field(default_factory=dict)
+
+    def normalized(self) -> "ToolRegistration":
+        """Return a normalized copy suitable for registry storage."""
+
+        normalized_tool_id = _normalize_tool_id(self.tool_id)
+        normalized_name = str(self.name or "").strip()
+        normalized_category = str(self.category or "").strip().lower()
+        if not normalized_name:
+            raise ValueError(
+                f"Tool registration '{normalized_tool_id}' must include a default name."
+            )
+        if not normalized_category:
+            raise ValueError(
+                f"Tool registration '{normalized_tool_id}' must include a category."
+            )
+
+        aliases = _normalize_token_list(self.aliases)
+        if normalized_tool_id not in aliases:
+            aliases.insert(0, normalized_tool_id)
+
+        return ToolRegistration(
+            tool_id=normalized_tool_id,
+            name=normalized_name,
+            category=normalized_category,
+            aliases=aliases,
+            default_packages=_normalize_string_list(self.default_packages),
+            provider_env_vars=_normalize_string_list(self.provider_env_vars),
+            environment_compatibility=_normalize_mapping(self.environment_compatibility),
+            fallback_configuration_defaults=dict(self.fallback_configuration_defaults or {}),
+        )
+
+    def build_tool_spec(
+        self,
+        *,
+        purpose: str,
+        configuration: Mapping[str, Any] | None = None,
+        status: str = "ready",
+        warnings: Iterable[str] | None = None,
+        name: str | None = None,
+    ) -> ToolSpec:
+        """Build a normalized ToolSpec from this registration."""
+
+        merged_configuration = dict(self.fallback_configuration_defaults)
+        merged_configuration.update(dict(configuration or {}))
+        return ToolSpec(
+            tool_id=self.tool_id,
+            name=str(name or self.name).strip() or self.name,
+            category=self.category,
+            purpose=str(purpose or "").strip()
+            or f"Use the canonical {self.tool_id} capability.",
+            configuration=merged_configuration,
+            packages=list(self.default_packages),
+            provider_env_vars=list(self.provider_env_vars),
+            status=status,
+            warnings=[warning for warning in warnings or [] if str(warning or "").strip()],
+        )
+
+
+class ToolRegistry:
+    """Mutable in-memory registry for canonical tool metadata."""
+
+    def __init__(self, registrations: Iterable[ToolRegistration] | None = None):
+        self._registrations: dict[str, ToolRegistration] = {}
+        self._aliases: dict[str, str] = {}
+        for registration in registrations or []:
+            self.register(registration)
+
+    def clone(self) -> "ToolRegistry":
+        """Return a shallow copy of the registry."""
+
+        return ToolRegistry(self._registrations.values())
+
+    def register(self, registration: ToolRegistration) -> ToolRegistration:
+        """Register or replace a tool registration."""
+
+        normalized = registration.normalized()
+        self._registrations[normalized.tool_id] = normalized
+        for alias in normalized.aliases:
+            self._aliases[alias] = normalized.tool_id
+        return normalized
+
+    def get(self, tool_id: str) -> ToolRegistration:
+        """Return a registered tool by canonical id."""
+
+        return self._registrations[_normalize_tool_id(tool_id)]
+
+    def resolve_tool_id(self, value: Any) -> str | None:
+        """Resolve an arbitrary tool token or alias to a canonical tool id."""
+
+        text = str(value or "").strip()
+        if not text:
+            return None
+        normalized = normalize_tool_token(text)
+        return self._aliases.get(normalized)
+
+    def supported_tool_ids(self) -> list[str]:
+        """Return registered canonical tool identifiers in insertion order."""
+
+        return list(self._registrations.keys())
+
+
+def _default_registrations() -> list[ToolRegistration]:
+    """Return the built-in tool registry entries."""
+
+    return [
+        ToolRegistration(
+            tool_id="web_search",
+            name="Web Docs Search",
+            category="search",
+            aliases=[
+                "search",
+                "web search",
+                "docs_search",
+                "documentation_search",
+                "duckduckgo",
+            ],
+            default_packages=["langchain-community"],
+            provider_env_vars=[],
+            environment_compatibility={
+                "requires_network": True,
+                "public_web": True,
+                "notebook_safe": True,
+            },
+            fallback_configuration_defaults={"backend": "duckduckgo"},
+        ),
+        ToolRegistration(
+            tool_id="file_reader",
+            name="File Reader",
+            category="file_io",
+            aliases=[
+                "file",
+                "document_reader",
+                "pdf_reader",
+                "read_file",
+            ],
+            default_packages=["pypdf"],
+            provider_env_vars=[],
+            environment_compatibility={
+                "requires_network": False,
+                "public_web": False,
+                "notebook_safe": True,
+            },
+            fallback_configuration_defaults={"mode": "text"},
+        ),
+        ToolRegistration(
+            tool_id="http_client",
+            name="HTTP Client",
+            category="api",
+            aliases=[
+                "http",
+                "api",
+                "fetch",
+                "requests",
+                "webhook",
+            ],
+            default_packages=["requests"],
+            provider_env_vars=[],
+            environment_compatibility={
+                "requires_network": True,
+                "public_web": True,
+                "notebook_safe": True,
+            },
+            fallback_configuration_defaults={"method": "GET"},
+        ),
+        ToolRegistration(
+            tool_id="data_processor",
+            name="Data Processor",
+            category="data_processing",
+            aliases=[
+                "data",
+                "transform",
+                "parser",
+                "json_parser",
+                "csv_parser",
+            ],
+            default_packages=[],
+            provider_env_vars=[],
+            environment_compatibility={
+                "requires_network": False,
+                "public_web": False,
+                "notebook_safe": True,
+            },
+            fallback_configuration_defaults={"format": "auto"},
+        ),
+        ToolRegistration(
+            tool_id="schema_validator",
+            name="Schema Validator",
+            category="validation",
+            aliases=[
+                "validator",
+                "validate",
+                "schema",
+                "schema_check",
+                "checker",
+            ],
+            default_packages=["pydantic"],
+            provider_env_vars=[],
+            environment_compatibility={
+                "requires_network": False,
+                "public_web": False,
+                "notebook_safe": True,
+            },
+            fallback_configuration_defaults={"strict": True},
+        ),
+    ]
+
+
+def _normalize_plugin_modules(plugin_modules: Iterable[str] | None) -> tuple[str, ...]:
+    """Return normalized plugin module paths for cache keys and loading."""
+
+    normalized: list[str] = []
+    for raw_value in plugin_modules or []:
+        module_name = str(raw_value or "").strip()
+        if module_name and module_name not in normalized:
+            normalized.append(module_name)
+    return tuple(normalized)
+
+
+def _load_plugin_modules(
+    registry: ToolRegistry,
+    plugin_modules: tuple[str, ...],
+) -> ToolRegistry:
+    """Load plugin registrations into a cloned registry."""
+
+    for module_name in plugin_modules:
+        try:
+            module = importlib.import_module(module_name)
+        except Exception as exc:
+            raise ValueError(
+                f"Failed to import toolchain engineer plugin module '{module_name}': "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+        register = getattr(module, "register_toolchain_tools", None)
+        if not callable(register):
+            raise ValueError(
+                f"Toolchain engineer plugin module '{module_name}' must define "
+                "register_toolchain_tools(registry)."
+            )
+        try:
+            register(registry)
+        except Exception as exc:
+            raise ValueError(
+                f"Toolchain engineer plugin module '{module_name}' failed while "
+                f"running register_toolchain_tools(registry): {type(exc).__name__}: {exc}"
+            ) from exc
+    return registry
+
+
+@lru_cache(maxsize=16)
+def get_tool_registry(plugin_modules: tuple[str, ...] | None = None) -> ToolRegistry:
+    """Return the built-in tool registry with optional plugin extensions."""
+
+    normalized_modules = _normalize_plugin_modules(
+        settings.toolchain_engineer_plugin_modules
+        if plugin_modules is None
+        else plugin_modules
+    )
+    registry = ToolRegistry(_default_registrations())
+    if normalized_modules:
+        registry = _load_plugin_modules(registry, normalized_modules)
+    return registry

--- a/src/langgraph_system_generator/utils/config.py
+++ b/src/langgraph_system_generator/utils/config.py
@@ -174,6 +174,12 @@ class Settings(BaseSettings):
             "Optional notebook composer plugin modules loaded to extend internal section builders."
         ),
     )
+    toolchain_engineer_plugin_modules: Annotated[list[str], NoDecode] = Field(
+        default_factory=list,
+        description=(
+            "Optional ToolchainEngineer plugin modules loaded to extend the internal tool registry."
+        ),
+    )
     graph_designer_plugin_modules: Annotated[list[str], NoDecode] = Field(
         default_factory=list,
         description=(
@@ -319,6 +325,42 @@ class Settings(BaseSettings):
                 normalized.append(module_name)
         return normalized
 
+    @field_validator("toolchain_engineer_plugin_modules", mode="before")
+    @classmethod
+    def _parse_toolchain_engineer_plugin_modules(cls, value):
+        """Accept JSON arrays or comma-separated plugin module strings."""
+        if value in (None, ""):
+            return []
+        if isinstance(value, list):
+            raw_items = value
+        elif isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return []
+            if stripped.startswith("["):
+                try:
+                    parsed = json.loads(stripped)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"Invalid JSON in toolchain_engineer_plugin_modules: {exc}"
+                    ) from exc
+                if not isinstance(parsed, list):
+                    raise ValueError(
+                        "toolchain_engineer_plugin_modules must decode to a list"
+                    )
+                raw_items = parsed
+            else:
+                raw_items = stripped.split(",")
+        else:
+            return value
+
+        normalized: list[str] = []
+        for raw_item in raw_items:
+            module_name = str(raw_item or "").strip()
+            if module_name and module_name not in normalized:
+                normalized.append(module_name)
+        return normalized
+
     @field_validator("notebook_composer_plugin_modules", mode="before")
     @classmethod
     def _parse_notebook_composer_plugin_modules(cls, value):
@@ -388,6 +430,7 @@ _TEST_SETTINGS_ENV_KEYS = (
     "NOTEBOOK_COMPOSER_PARALLELISM_MODE",
     "NOTEBOOK_COMPOSER_MAX_CONCURRENCY",
     "NOTEBOOK_COMPOSER_PLUGIN_MODULES",
+    "TOOLCHAIN_ENGINEER_PLUGIN_MODULES",
     "GRAPH_DESIGNER_PLUGIN_MODULES",
 )
 

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -60,6 +60,7 @@ async def test_generate_artifacts_stub(tmp_path: Path, monkeypatch: pytest.Monke
     assert artifacts["manifest"]["architecture_feedback"]["docs_considered"] == []
     assert artifacts["manifest"]["graph_design_feedback"]["fallback_used"] is False
     assert "flowchart TD" in artifacts["manifest"]["graph_exports"]["mermaid"]
+    assert artifacts["manifest"]["tool_planning_feedback"]["fallback_used"] is False
     assert artifacts["manifest"]["notebook_composition_feedback"]["fallback_used"] is False
     assert "langgraph" in artifacts["manifest"]["notebook_dependency_plan"]["packages"]
     assert artifacts["result"]["requirements_feedback"]["fallback_used"] is False
@@ -67,6 +68,7 @@ async def test_generate_artifacts_stub(tmp_path: Path, monkeypatch: pytest.Monke
     assert artifacts["result"]["architecture_feedback"]["docs_considered"] == []
     assert artifacts["result"]["graph_design_feedback"]["fallback_used"] is False
     assert "flowchart TD" in artifacts["result"]["graph_exports"]["mermaid"]
+    assert artifacts["result"]["tool_planning_feedback"]["fallback_used"] is False
     assert artifacts["result"]["notebook_composition_feedback"]["fallback_used"] is False
     assert "OPENAI_API_KEY" in artifacts["result"]["notebook_dependency_plan"]["provider_env_vars"]
     assert Path(artifacts["manifest_path"]).exists()
@@ -88,9 +90,11 @@ def test_default_state_includes_generation_mode_and_qa_history():
     assert state["architecture_feedback"].fallback_used is False
     assert state["graph_design_feedback"].fallback_used is False
     assert state["graph_exports"].schema == {}
+    assert state["tool_planning_feedback"].fallback_used is False
     assert state["notebook_composition_feedback"].fallback_used is False
     assert state["notebook_dependency_plan"].packages == []
     assert "goal" in state["requirements_feedback"].available_constraint_types
+    assert "web_search" in state["tool_planning_feedback"].available_tool_ids
 
 
 def test_default_and_stub_results_normalize_constraint_type_registry(monkeypatch):
@@ -129,6 +133,7 @@ def test_default_and_stub_results_normalize_constraint_type_registry(monkeypatch
         stub_result["notebook_composition_feedback"].resolved_model
         == cli_module.settings.default_model
     )
+    assert stub_result["tool_planning_feedback"].fallback_used is False
     assert "langgraph" in stub_result["notebook_dependency_plan"].packages
 
 
@@ -260,6 +265,7 @@ async def test_api_generate_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert payload["output_dir"] == str(output_dir)
     assert payload["manifest"]["requirements_feedback"]["fallback_used"] is False
     assert payload["manifest"]["architecture_feedback"]["fallback_used"] is False
+    assert payload["manifest"]["tool_planning_feedback"]["fallback_used"] is False
     assert payload["manifest"]["notebook_composition_feedback"]["fallback_used"] is False
     assert "langgraph" in payload["manifest"]["notebook_dependency_plan"]["packages"]
 
@@ -418,6 +424,57 @@ async def test_generate_artifacts_surfaces_graph_design_feedback_as_warnings(
     assert "graph_design_validation" in warning_codes
     assert artifacts["manifest"]["graph_design_feedback"]["fallback_used"] is True
     assert "flowchart TD" in artifacts["manifest"]["graph_exports"]["mermaid"]
+
+
+@pytest.mark.asyncio
+async def test_generate_artifacts_surfaces_tool_planning_feedback_as_warnings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_tool_planning_feedback_warning")
+
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.cli as cli_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(cli_module)
+
+    original_build_stub_result = cli_module._build_stub_result
+
+    def build_stub_result_with_tool_feedback(prompt: str, agent_type: str | None = None):
+        result = original_build_stub_result(prompt, agent_type=agent_type)
+        result["tool_planning_feedback"] = {
+            "fallback_used": True,
+            "fallback_reason": "Tool planning used heuristic fallback inference.",
+            "validation_errors": ["Unsupported tool suggestion 'swarm_tool'."],
+            "unresolved_tools": ["swarm_tool"],
+            "environment_notes": ["Network access may be unavailable in the target runtime."],
+            "dependency_conflicts": ["Both 'requests' and a custom HTTP client were suggested."],
+            "available_tool_ids": ["web_search", "http_client"],
+            "warnings": ["Tool planning used heuristic fallback inference."],
+        }
+        return result
+
+    monkeypatch.setattr(
+        cli_module,
+        "_build_stub_result",
+        build_stub_result_with_tool_feedback,
+    )
+
+    output_dir = constants_module._BASE_OUTPUT / "tool_planning_feedback_stub"
+    artifacts = await cli_module.generate_artifacts(
+        "Tool planning feedback prompt",
+        output_dir=str(output_dir),
+        mode="stub",
+    )
+
+    warning_codes = {warning["code"] for warning in artifacts["manifest"]["warnings"]}
+    assert "tool_planning_fallback" in warning_codes
+    assert "tool_planning_validation" in warning_codes
+    assert "tool_planning_environment" in warning_codes
+    assert "tool_planning_dependency" in warning_codes
+    assert artifacts["manifest"]["tool_planning_feedback"]["fallback_used"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -203,6 +203,46 @@ def test_settings_parse_graph_designer_plugin_modules_from_csv(tmp_path):
     ]
 
 
+def test_settings_parse_toolchain_engineer_plugin_modules_from_json(tmp_path):
+    env_path = Path(tmp_path) / ".env"
+    env_path.write_text(
+        'TOOLCHAIN_ENGINEER_PLUGIN_MODULES=["pkg.plugins.alpha","pkg.plugins.beta"]\n',
+        encoding="utf-8",
+    )
+
+    class FileSettings(Settings):
+        model_config = SettingsConfigDict(
+            env_file=env_path, env_file_encoding="utf-8", extra="ignore"
+        )
+
+    loaded = FileSettings()
+
+    assert loaded.toolchain_engineer_plugin_modules == [
+        "pkg.plugins.alpha",
+        "pkg.plugins.beta",
+    ]
+
+
+def test_settings_parse_toolchain_engineer_plugin_modules_from_csv(tmp_path):
+    env_path = Path(tmp_path) / ".env"
+    env_path.write_text(
+        "TOOLCHAIN_ENGINEER_PLUGIN_MODULES=pkg.plugins.alpha, pkg.plugins.beta , pkg.plugins.alpha\n",
+        encoding="utf-8",
+    )
+
+    class FileSettings(Settings):
+        model_config = SettingsConfigDict(
+            env_file=env_path, env_file_encoding="utf-8", extra="ignore"
+        )
+
+    loaded = FileSettings()
+
+    assert loaded.toolchain_engineer_plugin_modules == [
+        "pkg.plugins.alpha",
+        "pkg.plugins.beta",
+    ]
+
+
 def test_settings_parse_notebook_composer_plugin_modules_from_json(tmp_path):
     env_path = Path(tmp_path) / ".env"
     env_path.write_text(

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -25,6 +27,12 @@ from langgraph_system_generator.generator.graph_design_registry import (
     get_graph_design_registry,
     normalize_graph_design,
     validate_graph_design,
+)
+from langgraph_system_generator.generator import tool_registry as tool_registry_module
+from langgraph_system_generator.generator.tool_registry import (
+    ToolRegistration,
+    ToolRegistry,
+    get_tool_registry,
 )
 from langgraph_system_generator.generator.state import (
     ArchitectureSelectionResult,
@@ -1172,6 +1180,157 @@ async def test_toolchain_engineer_normalizes_alias_to_canonical_tool_id(monkeypa
             warnings=[],
         )
     ]
+
+
+def test_tool_registry_replaces_stale_aliases_and_rejects_collisions():
+    """Overridden registrations should drop stale aliases and block alias collisions."""
+
+    registry = ToolRegistry(
+        [
+            ToolRegistration(
+                tool_id="web_search",
+                name="Web Search",
+                description="Search public docs.",
+                category="search",
+                aliases=["search", "docs_search"],
+            )
+        ]
+    )
+
+    registry.register(
+        ToolRegistration(
+            tool_id="web_search",
+            name="Web Search",
+            description="Search public docs.",
+            category="search",
+            aliases=["web_lookup"],
+        )
+    )
+
+    assert registry.resolve_tool_id("search") is None
+    assert registry.resolve_tool_id("docs_search") is None
+    assert registry.resolve_tool_id("web_lookup") == "web_search"
+
+    with pytest.raises(ValueError, match="Alias 'web_lookup' is already registered"):
+        registry.register(
+            ToolRegistration(
+                tool_id="file_reader",
+                name="File Reader",
+                description="Read local files.",
+                category="file_io",
+                aliases=["web_lookup"],
+            )
+        )
+
+
+def test_tool_registry_uses_current_plugin_settings_for_cache_keys(monkeypatch):
+    """Default registry loads should refresh when plugin-module settings change."""
+
+    module_a_name = "tests.fake_tool_registry_plugin_a"
+    module_b_name = "tests.fake_tool_registry_plugin_b"
+    plugin_a = types.ModuleType(module_a_name)
+    plugin_b = types.ModuleType(module_b_name)
+
+    def register_toolchain_tools_a(registry):
+        registry.register(
+            ToolRegistration(
+                tool_id="alpha_tool",
+                name="Alpha Tool",
+                description="Alpha plugin tool.",
+                category="search",
+                aliases=["alpha"],
+            )
+        )
+
+    def register_toolchain_tools_b(registry):
+        registry.register(
+            ToolRegistration(
+                tool_id="beta_tool",
+                name="Beta Tool",
+                description="Beta plugin tool.",
+                category="validation",
+                aliases=["beta"],
+            )
+        )
+
+    plugin_a.register_toolchain_tools = register_toolchain_tools_a
+    plugin_b.register_toolchain_tools = register_toolchain_tools_b
+    monkeypatch.setitem(sys.modules, module_a_name, plugin_a)
+    monkeypatch.setitem(sys.modules, module_b_name, plugin_b)
+
+    tool_registry_module._get_tool_registry_cached.cache_clear()
+    monkeypatch.setattr(
+        tool_registry_module.settings,
+        "toolchain_engineer_plugin_modules",
+        [module_a_name],
+    )
+    registry_a = get_tool_registry()
+    assert "alpha_tool" in registry_a.supported_tool_ids()
+    assert "beta_tool" not in registry_a.supported_tool_ids()
+
+    monkeypatch.setattr(
+        tool_registry_module.settings,
+        "toolchain_engineer_plugin_modules",
+        [module_b_name],
+    )
+    registry_b = get_tool_registry()
+    assert "beta_tool" in registry_b.supported_tool_ids()
+    assert "alpha_tool" not in registry_b.supported_tool_ids()
+
+    tool_registry_module._get_tool_registry_cached.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_toolchain_engineer_prompt_catalog_comes_from_registry(monkeypatch):
+    """Planner prompt should be generated from the current registry catalog."""
+
+    captured_messages: list = []
+    monkeypatch.setattr(
+        toolchain_engineer,
+        "ChatOpenAI",
+        make_recording_llm("[]", captured_messages),
+    )
+    registry = get_tool_registry().clone()
+    registry.register(
+        ToolRegistration(
+            tool_id="plugin_tool",
+            name="Plugin Tool",
+            description="Custom plugin-only capability for specialized workflows",
+            category="misc",
+            aliases=["plugin_alias"],
+        )
+    )
+
+    engineer = toolchain_engineer.ToolchainEngineer(registry=registry)
+    await engineer.plan_tools({"nodes": []}, [])
+
+    system_prompt = captured_messages[0][0].content
+    assert "- plugin_tool: Custom plugin-only capability for specialized workflows." in system_prompt
+    assert "- tool_id: Canonical tool identifier or supported alias" in system_prompt
+    assert "- name: Human-readable display name for the tool" in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_toolchain_engineer_preserves_display_name_when_tool_id_present(
+    monkeypatch,
+):
+    """Display names should not be overwritten by canonical tool ids."""
+
+    monkeypatch.setattr(
+        toolchain_engineer,
+        "ChatOpenAI",
+        make_stub_llm(
+            '[{"tool_id":"web_search","name":"Web Search Tool","category":"search","purpose":"Look up docs","configuration":{}}]'
+        ),
+    )
+    engineer = toolchain_engineer.ToolchainEngineer()
+    result = await engineer.plan_tools(
+        {"nodes": [{"name": "research", "purpose": "Search docs"}]},
+        [Constraint(type="goal", value="Research docs", priority=5)],
+    )
+
+    assert result.tools[0].tool_id == "web_search"
+    assert result.tools[0].name == "Web Search Tool"
 
 
 def test_requirements_analyst_uses_request_scoped_model_config(monkeypatch):

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -34,6 +34,7 @@ from langgraph_system_generator.generator.state import (
     GraphDesignResult,
     GraphEdgeSpec,
     GraphNodeSpec,
+    ToolSpec,
 )
 from langgraph_system_generator.utils.error_handling import GenerationError
 from langgraph_system_generator.utils.config import ModelConfig
@@ -1062,14 +1063,19 @@ def test_graph_design_exports_escape_mermaid_labels():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("payload", "expected_count"),
+    ("payload", "expected_count", "expected_fallback"),
     [
-        ('[{"name":"tool","category":"misc","purpose":"x","configuration":{}}]', 1),
-        ("invalid", 0),
+        ('[{"name":"search","category":"search","purpose":"x","configuration":{}}]', 1, False),
+        ("invalid", 0, True),
     ],
 )
-async def test_toolchain_engineer_parsing(payload, expected_count, monkeypatch):
-    """ToolchainEngineer returns empty list on parse errors."""
+async def test_toolchain_engineer_parsing(
+    payload,
+    expected_count,
+    expected_fallback,
+    monkeypatch,
+):
+    """ToolchainEngineer normalizes valid payloads and surfaces parse fallback."""
     monkeypatch.setattr(
         toolchain_engineer,
         "ChatOpenAI",
@@ -1078,7 +1084,94 @@ async def test_toolchain_engineer_parsing(payload, expected_count, monkeypatch):
     engineer = toolchain_engineer.ToolchainEngineer()
     constraints = [Constraint(type="goal", value="x", priority=5)]
     result = await engineer.plan_tools({"nodes": []}, constraints)
-    assert len(result) == expected_count
+    assert len(result.tools) == expected_count
+    assert result.feedback.fallback_used is expected_fallback
+
+
+@pytest.mark.asyncio
+async def test_toolchain_engineer_parse_failure_uses_heuristic_fallback_for_tool_nodes(
+    monkeypatch,
+):
+    """Parse failures should infer conservative fallback tools from workflow nodes."""
+
+    monkeypatch.setattr(
+        toolchain_engineer,
+        "ChatOpenAI",
+        make_stub_llm("not-json"),
+    )
+    engineer = toolchain_engineer.ToolchainEngineer()
+    result = await engineer.plan_tools(
+        {
+            "nodes": [
+                {"name": "researcher", "purpose": "Search docs and gather references"},
+                {"name": "validator", "purpose": "Validate the final schema"},
+            ]
+        },
+        [Constraint(type="goal", value="Build agents", priority=5)],
+    )
+
+    assert result.feedback.fallback_used is True
+    assert [tool.tool_id for tool in result.tools] == ["web_search", "schema_validator"]
+    assert all(tool.status == "fallback" for tool in result.tools)
+
+
+@pytest.mark.asyncio
+async def test_toolchain_engineer_marks_imaginary_tools_unsupported(monkeypatch):
+    """Unsupported tool suggestions should surface as warnings, not valid tools."""
+
+    monkeypatch.setattr(
+        toolchain_engineer,
+        "ChatOpenAI",
+        make_stub_llm(
+            '[{"name":"quantum_api","category":"api","purpose":"Call an imaginary endpoint","configuration":{}}]'
+        ),
+    )
+    engineer = toolchain_engineer.ToolchainEngineer()
+    result = await engineer.plan_tools(
+        {"nodes": [{"name": "fetch_data", "purpose": "Fetch remote data"}]},
+        [Constraint(type="goal", value="Fetch data", priority=5)],
+    )
+
+    assert result.feedback.fallback_used is True
+    assert result.feedback.unresolved_tools == ["quantum_api"]
+    assert result.tools[0].tool_id == "http_client"
+    assert result.tools[0].status == "fallback"
+    unsupported = [tool for tool in result.tools if tool.status == "unsupported"]
+    assert len(unsupported) == 1
+    assert unsupported[0].name == "quantum_api"
+
+
+@pytest.mark.asyncio
+async def test_toolchain_engineer_normalizes_alias_to_canonical_tool_id(monkeypatch):
+    """Registry aliases should resolve to canonical tool ids."""
+
+    monkeypatch.setattr(
+        toolchain_engineer,
+        "ChatOpenAI",
+        make_stub_llm(
+            '[{"name":"search","category":"search","purpose":"Look up docs","configuration":{}}]'
+        ),
+    )
+    engineer = toolchain_engineer.ToolchainEngineer()
+    result = await engineer.plan_tools(
+        {"nodes": [{"name": "research", "purpose": "Search docs"}]},
+        [Constraint(type="goal", value="Research docs", priority=5)],
+    )
+
+    assert result.feedback.fallback_used is False
+    assert result.tools == [
+        ToolSpec(
+            tool_id="web_search",
+            name="search",
+            category="search",
+            purpose="Look up docs",
+            configuration={"backend": "duckduckgo"},
+            packages=["langchain-community"],
+            provider_env_vars=[],
+            status="ready",
+            warnings=[],
+        )
+    ]
 
 
 def test_requirements_analyst_uses_request_scoped_model_config(monkeypatch):

--- a/tests/unit/test_generator_nodes.py
+++ b/tests/unit/test_generator_nodes.py
@@ -23,6 +23,9 @@ from langgraph_system_generator.generator.state import (
     NotebookPlan,
     RequirementsAnalysis,
     RequirementsFeedback,
+    ToolPlanningFeedback,
+    ToolPlanningResult,
+    ToolSpec,
 )
 
 
@@ -62,7 +65,23 @@ async def test_intake_node_returns_constraints():
 async def test_tooling_plan_node_returns_tools_plan():
     constraints = [Constraint(type="goal", value="Build agents", priority=5)]
     workflow_design = {"nodes": [{"name": "agent", "purpose": "coordinate"}]}
-    expected_tools = [{"name": "search", "category": "search"}]
+    expected_tools = [
+        ToolSpec(
+            tool_id="web_search",
+            name="search",
+            category="search",
+            purpose="Look up docs",
+            configuration={"backend": "duckduckgo"},
+            packages=["langchain-community"],
+            provider_env_vars=[],
+            status="ready",
+            warnings=[],
+        )
+    ]
+    expected_feedback = ToolPlanningFeedback(
+        fallback_used=False,
+        available_tool_ids=["web_search"],
+    )
 
     # Patch ChatOpenAI used inside ToolchainEngineer.__init__ to avoid requiring OPENAI_API_KEY
     with patch(
@@ -71,13 +90,21 @@ async def test_tooling_plan_node_returns_tools_plan():
     ):
         with patch(
             "langgraph_system_generator.generator.nodes.ToolchainEngineer.plan_tools",
-            new=AsyncMock(return_value=expected_tools),
+            new=AsyncMock(
+                return_value=ToolPlanningResult(
+                    tools=expected_tools,
+                    feedback=expected_feedback,
+                )
+            ),
         ) as mock_plan:
             result = await tooling_plan_node(
                 {"workflow_design": workflow_design, "constraints": constraints}
             )
 
-    assert result == {"tools_plan": expected_tools}
+    assert result == {
+        "tools_plan": [tool.model_dump() for tool in expected_tools],
+        "tool_planning_feedback": expected_feedback,
+    }
     mock_plan.assert_awaited_once_with(workflow_design, constraints)
 
 
@@ -105,11 +132,26 @@ async def test_notebook_assembly_node_passes_architecture_and_plans():
         packages=["langgraph", "langchain-openai"]
     )
 
-    async def capture_compose(plan, design, tools, architecture):
+    tool_planning_feedback = ToolPlanningFeedback(
+        fallback_used=True,
+        fallback_reason="Heuristic tool fallback used.",
+        available_tool_ids=["web_search"],
+        warnings=["Heuristic tool fallback used."],
+    )
+
+    async def capture_compose(
+        plan,
+        design,
+        tools,
+        architecture,
+        *,
+        tool_planning_feedback=None,
+    ):
         captured_args["plan"] = plan
         captured_args["design"] = design
         captured_args["tools"] = tools
         captured_args["architecture"] = architecture
+        captured_args["tool_planning_feedback"] = tool_planning_feedback
         return NotebookCompositionResult(
             cells=expected_cells,
             feedback=expected_feedback,
@@ -129,6 +171,7 @@ async def test_notebook_assembly_node_passes_architecture_and_plans():
                     "notebook_plan": notebook_plan,
                     "workflow_design": workflow_design,
                     "tools_plan": tools_plan,
+                    "tool_planning_feedback": tool_planning_feedback,
                     "constraints": constraints,
                     "selected_patterns": {"primary": "router"},
                     "architecture_justification": "Fits the request.",
@@ -147,6 +190,7 @@ async def test_notebook_assembly_node_passes_architecture_and_plans():
         "architecture_type": "router",
         "justification": "Fits the request.",
     }
+    assert captured_args["tool_planning_feedback"] == tool_planning_feedback
 
 
 @pytest.mark.asyncio
@@ -169,8 +213,9 @@ async def test_notebook_assembly_node_fallback_when_primary_missing():
     expected_feedback = NotebookCompositionFeedback(fallback_used=False)
     expected_dependency_plan = NotebookDependencyPlan()
 
-    async def capture_compose(plan, design, tools, architecture):
+    async def capture_compose(plan, design, tools, architecture, **kwargs):
         captured_args["architecture"] = architecture
+        captured_args["tool_planning_feedback"] = kwargs.get("tool_planning_feedback")
         return NotebookCompositionResult(
             cells=expected_cells,
             feedback=expected_feedback,
@@ -205,6 +250,7 @@ async def test_notebook_assembly_node_fallback_when_primary_missing():
         "architecture_type": "router",  # Should default to "router"
         "justification": "Fits the request.",
     }
+    assert captured_args["tool_planning_feedback"] is None
 
 
 @pytest.mark.asyncio
@@ -227,8 +273,9 @@ async def test_notebook_assembly_node_fallback_when_selected_patterns_missing():
     expected_feedback = NotebookCompositionFeedback(fallback_used=False)
     expected_dependency_plan = NotebookDependencyPlan()
 
-    async def capture_compose(plan, design, tools, architecture):
+    async def capture_compose(plan, design, tools, architecture, **kwargs):
         captured_args["architecture"] = architecture
+        captured_args["tool_planning_feedback"] = kwargs.get("tool_planning_feedback")
         return NotebookCompositionResult(
             cells=expected_cells,
             feedback=expected_feedback,
@@ -263,6 +310,7 @@ async def test_notebook_assembly_node_fallback_when_selected_patterns_missing():
         "architecture_type": "router",  # Should default to "router"
         "justification": "Fits the request.",
     }
+    assert captured_args["tool_planning_feedback"] is None
 @pytest.mark.parametrize("failure_mode", ["vector_store", "retrieve"])
 async def test_rag_retrieval_node_returns_empty_on_failure(
     monkeypatch, failure_mode

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -31,6 +31,7 @@ from langgraph_system_generator.generator.state import (
     NotebookCompositionResult,
     NotebookDependencyPlan,
     QAReport,
+    ToolPlanningFeedback,
 )
 from langgraph_system_generator.utils.config import GenerationConfig
 
@@ -294,8 +295,22 @@ async def test_tooling_plan_node_returns_tools_plan(monkeypatch):
     )
 
     assert result["tools_plan"] == [
-        {"name": "tool", "category": "misc", "purpose": "x", "configuration": {}}
+        {
+            "tool_id": "tool",
+            "name": "tool",
+            "category": "misc",
+            "purpose": "x",
+            "configuration": {},
+            "packages": [],
+            "provider_env_vars": [],
+            "status": "unsupported",
+            "warnings": [
+                "Unsupported tool suggestion 'tool' could not be resolved to a canonical tool."
+            ],
+        }
     ]
+    assert result["tool_planning_feedback"].fallback_used is True
+    assert result["tool_planning_feedback"].unresolved_tools == ["tool"]
 
 
 @pytest.mark.asyncio
@@ -342,6 +357,13 @@ async def test_notebook_assembly_node_returns_generated_cells(monkeypatch):
             schema={"entry_point": "router"},
         ),
         "tools_plan": [],
+        "tool_planning_feedback": ToolPlanningFeedback(
+            fallback_used=True,
+            fallback_reason="Heuristic tool fallback used.",
+            unresolved_tools=["imaginary_tool"],
+            available_tool_ids=["web_search"],
+            warnings=["Heuristic tool fallback used."],
+        ),
         "selected_patterns": {"primary": "router"},
         "architecture_justification": "Reason",
     }
@@ -612,6 +634,14 @@ async def test_package_outputs_node_manifest_fields():
                 },
             },
         ),
+        "tool_planning_feedback": ToolPlanningFeedback(
+            fallback_used=True,
+            fallback_reason="Tool planning used heuristic fallback inference.",
+            validation_errors=["Unsupported tool suggestion 'swarm_tool'."],
+            unresolved_tools=["swarm_tool"],
+            available_tool_ids=["web_search", "http_client"],
+            warnings=["Tool planning used heuristic fallback inference."],
+        ),
         "notebook_composition_feedback": NotebookCompositionFeedback(
             fallback_used=True,
             warnings=["Deterministic fallback used for node \"enrich\"."],
@@ -631,6 +661,7 @@ async def test_package_outputs_node_manifest_fields():
     assert manifest["architecture_feedback"]["fallback_used"] is True
     assert manifest["graph_design_feedback"]["fallback_used"] is True
     assert "flowchart TD" in manifest["graph_exports"]["mermaid"]
+    assert manifest["tool_planning_feedback"]["fallback_used"] is True
     assert manifest["notebook_composition_feedback"]["fallback_used"] is True
     assert "requests" in manifest["notebook_dependency_plan"]["packages"]
     assert result["generation_complete"] is True

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -16,7 +16,11 @@ from langgraph_system_generator.generator.notebook_composer_registry import (
     NotebookComposerArchitectureRegistration,
     get_notebook_composer_registry,
 )
-from langgraph_system_generator.generator.state import CellSpec, NotebookPlan
+from langgraph_system_generator.generator.state import (
+    CellSpec,
+    NotebookPlan,
+    ToolPlanningFeedback,
+)
 from langgraph_system_generator.utils.config import ModelConfig
 
 
@@ -230,6 +234,92 @@ async def test_notebook_composer_registry_plugins_can_inject_pre_section_cells(
     intro_cells = [cell.content for cell in composition.cells if cell.section == "intro"]
     assert any("Plugin intro banner" in cell for cell in intro_cells)
     registry_module.get_notebook_composer_registry.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_compose_notebook_emits_tool_planning_warning_cells(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Tool Planning Notes",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["router"],
+            architecture_type="router",
+        ),
+        workflow_design={
+            "architecture_type": "router",
+            "state_schema": {"messages": "Conversation state"},
+            "nodes": [
+                {"name": "router", "purpose": "Route requests"},
+                {"name": "search", "purpose": "Search documents"},
+            ],
+        },
+        tools=[],
+        architecture={"architecture_type": "router", "justification": "Warning test."},
+        tool_planning_feedback=ToolPlanningFeedback(
+            fallback_used=True,
+            fallback_reason="Tool planning used heuristic fallback inference.",
+            validation_errors=["Unsupported tool suggestion 'swarm_tool'."],
+            unresolved_tools=["swarm_tool"],
+            available_tool_ids=["web_search"],
+            warnings=["Tool planning used heuristic fallback inference."],
+        ),
+    )
+
+    tool_markdown = [
+        cell.content
+        for cell in composition.cells
+        if cell.section == "tools" and cell.cell_type == "markdown"
+    ]
+    assert any("Tool Planning Notes" in cell for cell in tool_markdown)
+    assert any("swarm_tool" in cell for cell in tool_markdown)
+
+
+@pytest.mark.asyncio
+async def test_compose_notebook_dependency_plan_uses_tool_packages_and_env_vars(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Dependency Plan",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["router"],
+            architecture_type="router",
+        ),
+        workflow_design={
+            "architecture_type": "router",
+            "state_schema": {"messages": "Conversation state"},
+            "nodes": [
+                {"name": "router", "purpose": "Route requests"},
+                {"name": "search", "purpose": "Search documents"},
+            ],
+        },
+        tools=[
+            {
+                "tool_id": "http_client",
+                "name": "HTTP Client",
+                "category": "api",
+                "purpose": "Fetch API data",
+                "configuration": {},
+                "packages": ["requests", "pydantic"],
+                "provider_env_vars": ["SERVICE_API_KEY"],
+                "status": "ready",
+                "warnings": [],
+            }
+        ],
+        architecture={"architecture_type": "router", "justification": "Dependency test."},
+    )
+
+    assert "requests" in composition.dependency_plan.packages
+    assert "pydantic" in composition.dependency_plan.packages
+    assert "SERVICE_API_KEY" in composition.dependency_plan.provider_env_vars
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -323,6 +323,82 @@ async def test_compose_notebook_dependency_plan_uses_tool_packages_and_env_vars(
 
 
 @pytest.mark.asyncio
+async def test_compose_notebook_sanitizes_provider_env_vars_for_config_code(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Sanitized Dependency Plan",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["router"],
+            architecture_type="router",
+        ),
+        workflow_design={
+            "architecture_type": "router",
+            "state_schema": {"messages": "Conversation state"},
+            "nodes": [
+                {"name": "router", "purpose": "Route requests"},
+                {"name": "search", "purpose": "Search documents"},
+            ],
+        },
+        tools=[
+            {
+                "tool_id": "http_client",
+                "name": "HTTP Client",
+                "category": "api",
+                "purpose": "Fetch API data",
+                "configuration": {
+                    "provider_env_vars": ["openai-api-key", "Service API Key"],
+                },
+                "packages": ["requests"],
+                "provider_env_vars": ["123 service key"],
+                "status": "ready",
+                "warnings": [],
+            }
+        ],
+        architecture={
+            "architecture_type": "router",
+            "justification": "Dependency sanitization test.",
+        },
+    )
+
+    assert "OPENAI_API_KEY" in composition.dependency_plan.provider_env_vars
+    assert "SERVICE_API_KEY" in composition.dependency_plan.provider_env_vars
+    assert "ENV_123_SERVICE_KEY" in composition.dependency_plan.provider_env_vars
+    assert any(
+        "Normalized provider env var 'openai-api-key' to 'OPENAI_API_KEY'"
+        in note
+        for note in composition.dependency_plan.runtime_notes
+    )
+    assert any(
+        "Normalized provider env var '123 service key' to 'ENV_123_SERVICE_KEY'"
+        in note
+        for note in composition.dependency_plan.runtime_notes
+    )
+
+    config_cells = [
+        cell.content
+        for cell in composition.cells
+        if cell.section == "setup"
+        and cell.cell_type == "code"
+        and "MODEL =" in cell.content
+    ]
+    assert config_cells
+    assert (
+        'OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")'
+        in config_cells[0]
+    )
+    assert (
+        'ENV_123_SERVICE_KEY = os.environ.get("ENV_123_SERVICE_KEY", "")'
+        in config_cells[0]
+    )
+    ast.parse(config_cells[0])
+
+
+@pytest.mark.asyncio
 async def test_custom_registry_can_override_graph_section_builder(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
## Summary
- add a typed ToolchainEngineer planning contract with registry-backed canonical tools and structured feedback
- replace empty parse fallbacks with heuristic tool inference and surface degraded planning through node, CLI/API, and notebook warning paths
- extend NotebookComposer dependency planning to consume normalized tool packages/env vars and render visible tool-planning notes

## Testing
- pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes.py tests/unit/test_generator_nodes_additional.py tests/unit/test_generator_notebook_composer.py tests/unit/test_cli_api.py tests/unit/test_config.py -q
- pytest tests/unit -q
- pytest --asyncio-mode=auto -q
- python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

Closes #167
Closes #168
Closes #170
