### PR TITLE
Finish ToolchainEngineer tranche 2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ These node functions are the clearest map of the runtime lifecycle:
 | Retrieval | `rag_retrieval_node` | `DocsRetriever` | `docs_context` |
 | Architecture selection | `architecture_selection_node` | `ArchitectureSelector` | `selected_patterns`, `architecture_type`, `architecture_justification`, `architecture_feedback` |
 | Workflow design | `graph_design_node` | `GraphDesigner` | `workflow_design`, `graph_design_feedback`, `graph_exports`, `notebook_plan` |
-| Tool planning | `tooling_plan_node` | `ToolchainEngineer` | `tools_plan` |
+| Tool planning | `tooling_plan_node` | `ToolchainEngineer` | `tools_plan`, `tool_planning_feedback` |
 | Notebook assembly | `notebook_assembly_node` | `NotebookComposer` | `generated_cells`, `notebook_composition_feedback`, `notebook_dependency_plan` |
 | Static QA | `static_qa_node` | validators under `src/langgraph_system_generator/qa/` | `qa_reports`, `qa_history` |
 | Runtime QA | `runtime_qa_node` | notebook runtime helpers | `qa_reports`, `qa_history` |
@@ -108,6 +108,7 @@ Important patterns:
 - `constraints` and `docs_context` are accumulated lists.
 - `requirements_feedback` is advisory metadata from intake. It should surface fallback/gap/conflict guidance without replacing `constraints` as the downstream source of truth.
 - `architecture_feedback` is advisory metadata from architecture selection. It should surface fallback, tradeoff, and validation guidance without replacing `architecture_type` or `selected_patterns` as the downstream contract.
+- `tools_plan` stays the backward-compatible downstream tool payload, while `tool_planning_feedback` carries fallback, environment, and dependency advisories for manifests and notebook warning surfaces.
 - `generated_cells` is authoritative for the current repair iteration and is
   replaced rather than concatenated.
 - `qa_reports` is the current QA snapshot for the active pass, while

--- a/docs/wiki/Architecture-Deep-Dive.md
+++ b/docs/wiki/Architecture-Deep-Dive.md
@@ -187,7 +187,7 @@ Designs the specific graph structure, nodes, and edges:
 
 #### 5. Tool Planning
 **Input**: Workflow design + Constraints  
-**Output**: Tool specifications
+**Output**: Tool specifications + advisory planning feedback
 
 Plans any tools/functions needed by the agents:
 
@@ -195,23 +195,23 @@ Plans any tools/functions needed by the agents:
 {
   "tools_plan": [
     {
-      "name": "search_knowledge_base",
-      "purpose": "Search internal documentation",
-      "parameters": ["query: str"],
-      "returns": "List[Document]"
-    },
-    {
-      "name": "create_ticket",
-      "purpose": "Create support ticket",
-      "parameters": ["title: str", "description: str", "priority: str"],
-      "returns": "Ticket"
+      "tool_id": "web_search",
+      "name": "Web Docs Search",
+      "purpose": "Search documentation relevant to the workflow",
+      "configuration": {"backend": "duckduckgo"},
+      "status": "ready"
     }
-  ]
+  ],
+  "tool_planning_feedback": {
+    "fallback_used": false,
+    "environment_notes": [],
+    "dependency_conflicts": []
+  }
 }
 ```
 
 **Agent**: `ToolchainEngineer`  
-**LLM-Powered**: Yes (live mode) / Basic stubs (stub mode)
+**LLM-Powered**: Yes (live mode) / Registry-backed deterministic fallbacks and validation (stub mode and recovery)
 
 #### 6. Notebook Composition
 **Input**: All previous context  

--- a/docs/wiki/CLI-and-API-Reference.md
+++ b/docs/wiki/CLI-and-API-Reference.md
@@ -229,6 +229,12 @@ Generate a multi-agent system from a prompt.
       "validation_errors": [],
       "warnings": []
     },
+    "tool_planning_feedback": {
+      "fallback_used": false,
+      "environment_notes": [],
+      "dependency_conflicts": [],
+      "warnings": []
+    },
     "graph_exports": {
       "mermaid": "flowchart TD ...",
       "schema": {
@@ -236,6 +242,10 @@ Generate a multi-agent system from a prompt.
         "terminal_nodes": ["finish"],
         "validation_summary": {"errors": [], "warnings": []}
       }
+    },
+    "notebook_dependency_plan": {
+      "packages": ["langgraph", "langchain-openai"],
+      "provider_env_vars": ["OPENAI_API_KEY"]
     },
     "warnings": [],
     "export_results": {

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -19,6 +19,13 @@ from langgraph_system_generator.generator.notebook_composer_registry import (
     NotebookComposerRegistry,
     get_notebook_composer_registry,
 )
+from langgraph_system_generator.generator.tool_dependency_utils import (
+    DependencyAccumulator,
+    accumulate_tool_dependencies,
+    merge_string_lists,
+    normalize_provider_env_var,
+    package_import_probe,
+)
 from langgraph_system_generator.generator.state import (
     CellSpec,
     NotebookCompositionFeedback,
@@ -37,22 +44,6 @@ from langgraph_system_generator.patterns import (
 )
 from langgraph_system_generator.utils.config import ModelConfig, settings
 
-
-_PACKAGE_IMPORT_PROBES = {
-    "langgraph": "langgraph",
-    "langchain-core": "langchain_core",
-    "langchain-openai": "langchain_openai",
-    "langchain-community": "langchain_community",
-    "pydantic": "pydantic",
-    "pypdf": "pypdf",
-    "requests": "requests",
-}
-
-_PACKAGE_FAMILIES = {
-    "pypdf": "pdf_parser",
-    "pdfminer.six": "pdf_parser",
-    "pymupdf": "pdf_parser",
-}
 
 _T = TypeVar("_T")
 logger = logging.getLogger(__name__)
@@ -129,48 +120,19 @@ class NotebookComposer:
     def _merge_string_lists(*values: Any) -> List[str]:
         """Merge list-or-scalar string inputs into an ordered unique list."""
 
-        merged: List[str] = []
-        for value in values:
-            if value in (None, ""):
-                continue
-            if isinstance(value, list):
-                raw_items = value
-            else:
-                raw_items = [value]
-            for raw_item in raw_items:
-                text = str(raw_item or "").strip()
-                if text and text not in merged:
-                    merged.append(text)
-        return merged
+        return merge_string_lists(*values)
 
     @classmethod
     def _normalize_provider_env_var(cls, value: Any) -> str:
         """Normalize arbitrary env-var suggestions into notebook-safe keys."""
 
-        text = str(value or "").strip()
-        if not text:
-            return ""
-
-        normalized = re.sub(r"[^a-zA-Z0-9_]", "_", text)
-        normalized = re.sub(r"_+", "_", normalized).strip("_").upper()
-        if not normalized:
-            return ""
-        if normalized[0].isdigit():
-            normalized = f"ENV_{normalized}"
-        if not normalized.isidentifier():
-            normalized = cls._safe_identifier(normalized, "ENV_VAR").upper()
-            if normalized[0].isdigit():
-                normalized = f"ENV_{normalized}"
-        return normalized
+        return normalize_provider_env_var(value)
 
     @staticmethod
     def _package_import_probe(package_name: str) -> str:
         """Return the import probe used to detect whether a package is installed."""
 
-        return _PACKAGE_IMPORT_PROBES.get(
-            package_name,
-            package_name.replace("-", "_").replace(".", "_"),
-        )
+        return package_import_probe(package_name)
 
     def _resolve_max_iterations(self, workflow_design: Dict[str, Any]) -> int:
         """Resolve the iteration limit embedded into notebook cells."""
@@ -235,40 +197,6 @@ class NotebookComposer:
             f"# Reason: {safe_reason}\n\n"
         )
 
-    def _add_dependency_candidate(
-        self,
-        plan: NotebookDependencyPlan,
-        selected_packages: List[str],
-        selected_families: Dict[str, str],
-        package_name: str,
-        *,
-        family: str | None = None,
-        requested_by: str | None = None,
-    ) -> None:
-        """Add a dependency candidate while deduplicating and resolving conflicts."""
-
-        normalized_package = str(package_name or "").strip()
-        if not normalized_package:
-            return
-
-        dependency_family = family or _PACKAGE_FAMILIES.get(normalized_package)
-        if dependency_family:
-            chosen = selected_families.get(dependency_family)
-            if chosen and chosen != normalized_package:
-                detail = (
-                    f"Kept '{chosen}' instead of '{normalized_package}' "
-                    f"for dependency family '{dependency_family}'."
-                )
-                if requested_by:
-                    detail += f" Requested by {requested_by}."
-                if detail not in plan.conflicts_resolved:
-                    plan.conflicts_resolved.append(detail)
-                return
-            selected_families[dependency_family] = normalized_package
-
-        if normalized_package not in selected_packages:
-            selected_packages.append(normalized_package)
-
     def _plan_dependencies(
         self,
         tools: List[Dict[str, Any]],
@@ -282,96 +210,30 @@ class NotebookComposer:
                 "Generated notebooks assume a Jupyter or Colab-style environment with pip available.",
             ]
         )
-        selected_packages: List[str] = []
-        selected_families: Dict[str, str] = {}
+        accumulator = DependencyAccumulator(runtime_notes=list(plan.runtime_notes))
 
         for package_name in ["langgraph", "langchain-core", "langchain-openai"]:
-            self._add_dependency_candidate(
-                plan,
-                selected_packages,
-                selected_families,
-                package_name,
-            )
+            accumulator.packages.append(package_name)
 
         for tool in tools:
             tool_status = self._normalize_inline_text(tool.get("status", ""), "").lower()
             if tool_status == "unsupported":
                 continue
-            category = self._normalize_inline_text(tool.get("category", ""), "").lower()
-            tool_configuration = tool.get("configuration")
-            if not isinstance(tool_configuration, dict):
-                tool_configuration = {}
-            top_level_packages = tool.get("packages", [])
-            if isinstance(top_level_packages, str):
-                top_level_packages = [top_level_packages]
-            if not isinstance(top_level_packages, list):
-                top_level_packages = []
-            for package_name in top_level_packages:
-                self._add_dependency_candidate(
-                    plan,
-                    selected_packages,
-                    selected_families,
-                    str(package_name),
-                    requested_by=self._normalize_inline_text(tool.get("name", ""), "tool"),
-                )
-            requested_packages = tool_configuration.get("packages", [])
-            if isinstance(requested_packages, str):
-                requested_packages = [requested_packages]
-            if not isinstance(requested_packages, list):
-                requested_packages = []
-            for package_name in requested_packages:
-                self._add_dependency_candidate(
-                    plan,
-                    selected_packages,
-                    selected_families,
-                    str(package_name),
-                    requested_by=self._normalize_inline_text(tool.get("name", ""), "tool"),
-                )
+            accumulate_tool_dependencies(accumulator, tool)
 
-            inferred_packages: List[tuple[str, str | None]] = []
-            if "search" in category:
-                inferred_packages.append(("langchain-community", None))
-            if any(token in category for token in {"file", "document", "pdf"}):
-                inferred_packages.append(("pypdf", "pdf_parser"))
-            if "api" in category:
-                inferred_packages.append(("requests", None))
+        if (
+            "langchain-openai" in accumulator.packages
+            and "OPENAI_API_KEY" not in accumulator.provider_env_vars
+        ):
+            accumulator.provider_env_vars.append("OPENAI_API_KEY")
 
-            for package_name, family in inferred_packages:
-                self._add_dependency_candidate(
-                    plan,
-                    selected_packages,
-                    selected_families,
-                    package_name,
-                    family=family,
-                    requested_by=self._normalize_inline_text(tool.get("name", ""), "tool"),
-                )
-
-            provider_env_vars = self._merge_string_lists(
-                tool.get("provider_env_vars"),
-                tool_configuration.get("provider_env_vars"),
-            )
-            for env_var in provider_env_vars:
-                normalized_env_var = self._normalize_provider_env_var(env_var)
-                if not normalized_env_var:
-                    continue
-                raw_env_var = str(env_var or "").strip()
-                if raw_env_var and normalized_env_var != raw_env_var:
-                    note = (
-                        f"Normalized provider env var '{raw_env_var}' to "
-                        f"'{normalized_env_var}' for notebook-safe configuration."
-                    )
-                    if note not in plan.runtime_notes:
-                        plan.runtime_notes.append(note)
-                if normalized_env_var not in plan.provider_env_vars:
-                    plan.provider_env_vars.append(normalized_env_var)
-
-        if "langchain-openai" in selected_packages and "OPENAI_API_KEY" not in plan.provider_env_vars:
-            plan.provider_env_vars.append("OPENAI_API_KEY")
-
-        plan.packages = selected_packages
-        if selected_packages:
+        plan.packages = accumulator.packages
+        plan.runtime_notes = accumulator.runtime_notes
+        plan.conflicts_resolved = accumulator.conflicts_resolved
+        plan.provider_env_vars = accumulator.provider_env_vars
+        if accumulator.packages:
             plan.install_commands = [
-                "python -m pip install -q " + " ".join(selected_packages)
+                "python -m pip install -q " + " ".join(accumulator.packages)
             ]
         return plan
 

--- a/src/langgraph_system_generator/generator/agents/toolchain_engineer.py
+++ b/src/langgraph_system_generator/generator/agents/toolchain_engineer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+import json
 from typing import Any, Dict, List, Mapping
 
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -14,6 +16,11 @@ from langgraph_system_generator.generator.state import (
     ToolPlanningResult,
     ToolSpec,
 )
+from langgraph_system_generator.generator.tool_dependency_utils import (
+    DependencyAccumulator,
+    accumulate_tool_dependencies,
+    merge_string_lists,
+)
 from langgraph_system_generator.generator.tool_registry import (
     ToolRegistry,
     get_tool_registry,
@@ -21,6 +28,27 @@ from langgraph_system_generator.generator.tool_registry import (
 )
 from langgraph_system_generator.generator.utils import extract_json_from_llm_response
 from langgraph_system_generator.utils.config import ModelConfig
+
+
+@dataclass(frozen=True)
+class _RuntimeEnvironmentProfile:
+    """Normalized runtime/environment constraints relevant to tool planning."""
+
+    offline_evidence: tuple[str, ...] = ()
+    firewalled_evidence: tuple[str, ...] = ()
+    notebook_evidence: tuple[str, ...] = ()
+
+    @property
+    def offline(self) -> bool:
+        return bool(self.offline_evidence)
+
+    @property
+    def firewalled(self) -> bool:
+        return bool(self.firewalled_evidence)
+
+    @property
+    def notebook_runtime(self) -> bool:
+        return bool(self.notebook_evidence)
 
 
 class ToolchainEngineer:
@@ -69,24 +97,62 @@ class ToolchainEngineer:
     def _merge_string_lists(cls, *values: Any) -> List[str]:
         """Merge arbitrary string-list inputs into an ordered de-duplicated list."""
 
-        merged: List[str] = []
-        for value in values:
-            for item in cls._string_list(value):
-                if item not in merged:
-                    merged.append(item)
-        return merged
+        return merge_string_lists(*values)
 
     @staticmethod
-    def _normalize_configuration(value: Any) -> Dict[str, Any]:
+    def _is_empty_configuration_value(value: Any) -> bool:
+        """Return True when a normalized configuration value is empty."""
+
+        return value is None or value == "" or value == [] or value == {}
+
+    @classmethod
+    def _canonicalize_configuration_value(cls, value: Any) -> Any:
+        """Recursively normalize configuration values for comparison and storage."""
+
+        if isinstance(value, Mapping):
+            normalized_items: Dict[str, Any] = {}
+            for raw_key, raw_item in value.items():
+                key = str(raw_key or "").strip()
+                if not key:
+                    continue
+                normalized_item = cls._canonicalize_configuration_value(raw_item)
+                if cls._is_empty_configuration_value(normalized_item):
+                    continue
+                normalized_items[key] = normalized_item
+            return {
+                key: normalized_items[key]
+                for key in sorted(normalized_items.keys())
+            }
+
+        if isinstance(value, list):
+            normalized_list: List[Any] = []
+            for raw_item in value:
+                normalized_item = cls._canonicalize_configuration_value(raw_item)
+                if cls._is_empty_configuration_value(normalized_item):
+                    continue
+                if normalized_item not in normalized_list:
+                    normalized_list.append(normalized_item)
+            return normalized_list
+
+        if isinstance(value, str):
+            return value.strip()
+
+        return value
+
+    @staticmethod
+    def _configuration_signature(configuration: Mapping[str, Any]) -> str:
+        """Return a stable signature for a normalized configuration mapping."""
+
+        return json.dumps(configuration, sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def _normalize_configuration(cls, value: Any) -> Dict[str, Any]:
         """Return a normalized configuration mapping."""
 
         if not isinstance(value, Mapping):
             return {}
-        return {
-            str(key).strip(): item
-            for key, item in value.items()
-            if str(key or "").strip()
-        }
+        normalized = cls._canonicalize_configuration_value(value)
+        return normalized if isinstance(normalized, dict) else {}
 
     def _registration_tool_spec(
         self,
@@ -102,10 +168,11 @@ class ToolchainEngineer:
     ) -> ToolSpec:
         """Build a ToolSpec from a canonical registry entry."""
 
+        normalized_configuration = self._normalize_configuration(configuration)
         registration = self.registry.get(tool_id)
         tool = registration.build_tool_spec(
             purpose=purpose,
-            configuration=configuration,
+            configuration=normalized_configuration,
             status=status,
             warnings=warnings,
             name=name,
@@ -138,7 +205,7 @@ class ToolchainEngineer:
             name=fallback_name,
             category=(raw_category or "unsupported").strip() or "unsupported",
             purpose=purpose.strip() or f"Unsupported tool suggestion: {fallback_name}",
-            configuration=dict(configuration or {}),
+            configuration=self._normalize_configuration(configuration),
             packages=self._string_list((configuration or {}).get("packages")),
             provider_env_vars=self._string_list(
                 (configuration or {}).get("provider_env_vars")
@@ -280,6 +347,244 @@ class ToolchainEngineer:
 
         return any(tool.status != "unsupported" for tool in tools)
 
+    @staticmethod
+    def _status_rank(status: str) -> int:
+        """Return merge precedence for tool statuses."""
+
+        return {
+            "unsupported": 0,
+            "fallback": 1,
+            "ready": 2,
+        }.get(str(status or "").strip().lower(), 0)
+
+    @staticmethod
+    def _constraint_label(constraint: Constraint) -> str:
+        """Return a human-readable label for one constraint."""
+
+        constraint_type = str(constraint.type or "").strip() or "constraint"
+        constraint_value = str(constraint.value or "").strip()
+        return f"[{constraint_type}] {constraint_value}".strip()
+
+    def _parse_runtime_environment(
+        self, constraints: List[Constraint]
+    ) -> _RuntimeEnvironmentProfile:
+        """Extract runtime/environment hints that affect tool compatibility."""
+
+        offline_evidence: List[str] = []
+        firewalled_evidence: List[str] = []
+        notebook_evidence: List[str] = []
+
+        for constraint in constraints:
+            haystack = (
+                f"{str(constraint.type or '').strip()} "
+                f"{str(constraint.value or '').strip()}"
+            ).lower()
+            label = self._constraint_label(constraint)
+            if any(
+                token in haystack
+                for token in (
+                    "offline",
+                    "no network",
+                    "no-network",
+                    "without network",
+                    "no external api",
+                    "no external apis",
+                    "no external api calls",
+                )
+            ):
+                self._append_unique(offline_evidence, label)
+            if any(
+                token in haystack
+                for token in (
+                    "firewalled",
+                    "internal only",
+                    "internal-only",
+                    "private network only",
+                )
+            ):
+                self._append_unique(firewalled_evidence, label)
+            if any(
+                token in haystack
+                for token in (
+                    "google colab",
+                    "colab",
+                    "jupyter",
+                    "notebook runtime",
+                )
+            ):
+                self._append_unique(notebook_evidence, label)
+
+        return _RuntimeEnvironmentProfile(
+            offline_evidence=tuple(offline_evidence),
+            firewalled_evidence=tuple(firewalled_evidence),
+            notebook_evidence=tuple(notebook_evidence),
+        )
+
+    def _apply_environment_constraints(
+        self,
+        tools: List[ToolSpec],
+        constraints: List[Constraint],
+        feedback: ToolPlanningFeedback,
+    ) -> List[ToolSpec]:
+        """Downgrade incompatible tools based on runtime/environment constraints."""
+
+        profile = self._parse_runtime_environment(constraints)
+        if not (profile.offline or profile.firewalled or profile.notebook_runtime):
+            return tools
+
+        filtered_tools: List[ToolSpec] = []
+        for tool in tools:
+            if tool.status == "unsupported":
+                filtered_tools.append(tool)
+                continue
+
+            compatibility = self.registry.get(tool.tool_id).environment_compatibility
+            reasons: List[str] = []
+            label = tool.name.strip() or tool.tool_id
+
+            if profile.offline and compatibility.get("requires_network") is True:
+                evidence = ", ".join(profile.offline_evidence)
+                reasons.append(
+                    f"Blocked tool '{label}' because offline/no-network constraints "
+                    f"disallow network-dependent tools ({evidence})."
+                )
+            if profile.firewalled and compatibility.get("public_web") is True:
+                evidence = ", ".join(profile.firewalled_evidence)
+                reasons.append(
+                    f"Blocked tool '{label}' because firewalled/internal-only constraints "
+                    f"disallow public-web tools ({evidence})."
+                )
+            if (
+                profile.notebook_runtime
+                and compatibility.get("notebook_safe") is False
+            ):
+                evidence = ", ".join(profile.notebook_evidence)
+                reasons.append(
+                    f"Blocked tool '{label}' because the target notebook runtime requires "
+                    f"notebook-safe tools ({evidence})."
+                )
+
+            if reasons:
+                for reason in reasons:
+                    self._append_unique(feedback.environment_notes, reason)
+                self._append_unique(feedback.unresolved_tools, label)
+                filtered_tools.append(
+                    tool.model_copy(
+                        update={
+                            "status": "unsupported",
+                            "warnings": self._merge_string_lists(tool.warnings, reasons),
+                        }
+                    )
+                )
+                continue
+
+            filtered_tools.append(tool)
+
+        return filtered_tools
+
+    def _deduplicate_tools(
+        self,
+        tools: List[ToolSpec],
+        feedback: ToolPlanningFeedback,
+    ) -> List[ToolSpec]:
+        """Merge duplicate tool suggestions deterministically and keep conflicts visible."""
+
+        merged: Dict[tuple[str, str], ToolSpec] = {}
+        ordered_keys: List[tuple[str, str]] = []
+        configurations_by_tool_id: Dict[str, List[str]] = {}
+
+        for tool in tools:
+            normalized_configuration = self._normalize_configuration(tool.configuration)
+            signature = self._configuration_signature(normalized_configuration)
+            key = (tool.tool_id, signature)
+
+            configs_for_tool = configurations_by_tool_id.setdefault(tool.tool_id, [])
+            if signature not in configs_for_tool:
+                configs_for_tool.append(signature)
+
+            if key not in merged:
+                merged[key] = tool.model_copy(update={"configuration": normalized_configuration})
+                ordered_keys.append(key)
+                continue
+
+            existing = merged[key]
+            preferred = (
+                tool
+                if self._status_rank(tool.status) > self._status_rank(existing.status)
+                else existing
+            )
+            merged[key] = preferred.model_copy(
+                update={
+                    "configuration": normalized_configuration,
+                    "name": existing.name or preferred.name,
+                    "purpose": existing.purpose or preferred.purpose,
+                    "packages": self._merge_string_lists(existing.packages, tool.packages),
+                    "provider_env_vars": self._merge_string_lists(
+                        existing.provider_env_vars,
+                        tool.provider_env_vars,
+                    ),
+                    "warnings": self._merge_string_lists(existing.warnings, tool.warnings),
+                }
+            )
+
+        for tool_id, configurations in configurations_by_tool_id.items():
+            if len(configurations) > 1:
+                self._append_unique(
+                    feedback.dependency_conflicts,
+                    f"Tool '{tool_id}' was suggested with multiple configurations; keeping separate entries.",
+                )
+
+        return [merged[key] for key in ordered_keys]
+
+    def _validate_dependencies(
+        self,
+        tools: List[ToolSpec],
+        feedback: ToolPlanningFeedback,
+    ) -> None:
+        """Validate deduplicated tool dependencies with shared normalization helpers."""
+
+        combined_dependencies = DependencyAccumulator()
+        for tool in tools:
+            if tool.status == "unsupported":
+                continue
+
+            tool_mapping = tool.model_dump()
+            raw_configuration = tool.configuration if isinstance(tool.configuration, Mapping) else {}
+            declared_env_vars = self._merge_string_lists(
+                tool.provider_env_vars,
+                raw_configuration.get("provider_env_vars"),
+            )
+
+            per_tool_dependencies = DependencyAccumulator()
+            accumulate_tool_dependencies(per_tool_dependencies, tool_mapping)
+            accumulate_tool_dependencies(combined_dependencies, tool_mapping)
+
+            if declared_env_vars and not per_tool_dependencies.provider_env_vars:
+                self._append_unique(
+                    feedback.dependency_conflicts,
+                    f"Tool '{tool.name or tool.tool_id}' declared provider env vars but none normalized into a usable notebook-safe key.",
+                )
+
+        for detail in combined_dependencies.conflicts_resolved:
+            self._append_unique(feedback.dependency_conflicts, detail)
+
+    def _finalize_tools(
+        self,
+        tools: List[ToolSpec],
+        constraints: List[Constraint],
+        feedback: ToolPlanningFeedback,
+    ) -> List[ToolSpec]:
+        """Apply environment filtering, dedupe, and dependency validation."""
+
+        constrained_tools = self._apply_environment_constraints(
+            tools,
+            constraints,
+            feedback,
+        )
+        deduplicated_tools = self._deduplicate_tools(constrained_tools, feedback)
+        self._validate_dependencies(deduplicated_tools, feedback)
+        return deduplicated_tools
+
     async def plan_tools(
         self, workflow_design: Dict[str, Any], constraints: List[Constraint]
     ) -> ToolPlanningResult:
@@ -359,11 +664,17 @@ Identify needed tools."""
                 f"Tool planning fell back to heuristic inference after payload parsing failed: {exc}"
             )
             self._append_unique(feedback.warnings, feedback.fallback_reason)
-            return ToolPlanningResult(tools=heuristic_tools, feedback=feedback)
+            return ToolPlanningResult(
+                tools=self._finalize_tools(heuristic_tools, constraints, feedback),
+                feedback=feedback,
+            )
 
         normalized_tools = self._normalize_llm_tools(payload, feedback)
         if self._has_usable_tools(normalized_tools):
-            return ToolPlanningResult(tools=normalized_tools, feedback=feedback)
+            return ToolPlanningResult(
+                tools=self._finalize_tools(normalized_tools, constraints, feedback),
+                feedback=feedback,
+            )
 
         feedback.fallback_used = True
         feedback.fallback_reason = (
@@ -375,4 +686,7 @@ Identify needed tools."""
         combined_tools.extend(
             tool for tool in normalized_tools if tool.status == "unsupported"
         )
-        return ToolPlanningResult(tools=combined_tools, feedback=feedback)
+        return ToolPlanningResult(
+            tools=self._finalize_tools(combined_tools, constraints, feedback),
+            feedback=feedback,
+        )

--- a/src/langgraph_system_generator/generator/agents/toolchain_engineer.py
+++ b/src/langgraph_system_generator/generator/agents/toolchain_engineer.py
@@ -15,6 +15,7 @@ from langgraph_system_generator.generator.state import (
     ToolPlanningFeedback,
     ToolPlanningResult,
     ToolSpec,
+    normalize_constraint_type,
 )
 from langgraph_system_generator.generator.tool_dependency_utils import (
     DependencyAccumulator,
@@ -375,6 +376,11 @@ class ToolchainEngineer:
         notebook_evidence: List[str] = []
 
         for constraint in constraints:
+            if normalize_constraint_type(str(constraint.type or "")) not in {
+                "runtime",
+                "environment",
+            }:
+                continue
             haystack = (
                 f"{str(constraint.type or '').strip()} "
                 f"{str(constraint.value or '').strip()}"
@@ -440,18 +446,23 @@ class ToolchainEngineer:
 
             compatibility = self.registry.get(tool.tool_id).environment_compatibility
             reasons: List[str] = []
-            label = tool.name.strip() or tool.tool_id
+            display_label = tool.name.strip() or tool.tool_id
+            tool_reference = (
+                display_label
+                if display_label == tool.tool_id
+                else f"{display_label} ({tool.tool_id})"
+            )
 
             if profile.offline and compatibility.get("requires_network") is True:
                 evidence = ", ".join(profile.offline_evidence)
                 reasons.append(
-                    f"Blocked tool '{label}' because offline/no-network constraints "
+                    f"Blocked tool '{tool_reference}' because offline/no-network constraints "
                     f"disallow network-dependent tools ({evidence})."
                 )
             if profile.firewalled and compatibility.get("public_web") is True:
                 evidence = ", ".join(profile.firewalled_evidence)
                 reasons.append(
-                    f"Blocked tool '{label}' because firewalled/internal-only constraints "
+                    f"Blocked tool '{tool_reference}' because firewalled/internal-only constraints "
                     f"disallow public-web tools ({evidence})."
                 )
             if (
@@ -460,14 +471,14 @@ class ToolchainEngineer:
             ):
                 evidence = ", ".join(profile.notebook_evidence)
                 reasons.append(
-                    f"Blocked tool '{label}' because the target notebook runtime requires "
+                    f"Blocked tool '{tool_reference}' because the target notebook runtime requires "
                     f"notebook-safe tools ({evidence})."
                 )
 
             if reasons:
                 for reason in reasons:
                     self._append_unique(feedback.environment_notes, reason)
-                self._append_unique(feedback.unresolved_tools, label)
+                self._append_unique(feedback.unresolved_tools, tool.tool_id)
                 filtered_tools.append(
                     tool.model_copy(
                         update={
@@ -670,21 +681,26 @@ Identify needed tools."""
             )
 
         normalized_tools = self._normalize_llm_tools(payload, feedback)
-        if self._has_usable_tools(normalized_tools):
+        finalized_normalized_tools = self._finalize_tools(
+            normalized_tools,
+            constraints,
+            feedback,
+        )
+        if self._has_usable_tools(finalized_normalized_tools):
             return ToolPlanningResult(
-                tools=self._finalize_tools(normalized_tools, constraints, feedback),
+                tools=finalized_normalized_tools,
                 feedback=feedback,
             )
 
         feedback.fallback_used = True
         feedback.fallback_reason = (
-            "Tool planning fell back to heuristic inference because the model returned no usable canonical tools."
+            "Tool planning fell back to heuristic inference because the model returned no usable canonical tools after validation and environment filtering."
         )
         self._append_unique(feedback.warnings, feedback.fallback_reason)
 
         combined_tools: List[ToolSpec] = list(heuristic_tools)
         combined_tools.extend(
-            tool for tool in normalized_tools if tool.status == "unsupported"
+            tool for tool in finalized_normalized_tools if tool.status == "unsupported"
         )
         return ToolPlanningResult(
             tools=self._finalize_tools(combined_tools, constraints, feedback),

--- a/src/langgraph_system_generator/generator/tool_dependency_utils.py
+++ b/src/langgraph_system_generator/generator/tool_dependency_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import keyword
 import re
 from typing import Any, Mapping
 
@@ -14,6 +15,8 @@ _PACKAGE_IMPORT_PROBES = {
     "langchain-community": "langchain_community",
     "pydantic": "pydantic",
     "pypdf": "pypdf",
+    "pdfminer.six": "pdfminer",
+    "pymupdf": "fitz",
     "requests": "requests",
 }
 
@@ -62,6 +65,8 @@ def normalize_provider_env_var(value: Any) -> str:
     if not normalized:
         return ""
     if normalized[0].isdigit():
+        normalized = f"ENV_{normalized}"
+    if keyword.iskeyword(normalized.lower()) or not normalized.isidentifier():
         normalized = f"ENV_{normalized}"
     return normalized
 

--- a/src/langgraph_system_generator/generator/tool_dependency_utils.py
+++ b/src/langgraph_system_generator/generator/tool_dependency_utils.py
@@ -1,0 +1,192 @@
+"""Shared dependency normalization helpers for tool planning and notebooks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+from typing import Any, Mapping
+
+
+_PACKAGE_IMPORT_PROBES = {
+    "langgraph": "langgraph",
+    "langchain-core": "langchain_core",
+    "langchain-openai": "langchain_openai",
+    "langchain-community": "langchain_community",
+    "pydantic": "pydantic",
+    "pypdf": "pypdf",
+    "requests": "requests",
+}
+
+_PACKAGE_FAMILIES = {
+    "pypdf": "pdf_parser",
+    "pdfminer.six": "pdf_parser",
+    "pymupdf": "pdf_parser",
+}
+
+
+def normalize_inline_text(value: Any, fallback: str) -> str:
+    """Normalize arbitrary text for safe single-line comments and messages."""
+
+    text = str(value or fallback).replace("\r\n", "\n").replace("\r", "\n")
+    text = " ".join(part.strip() for part in text.split("\n") if part.strip())
+    return text or fallback
+
+
+def merge_string_lists(*values: Any) -> list[str]:
+    """Merge list-or-scalar string inputs into an ordered unique list."""
+
+    merged: list[str] = []
+    for value in values:
+        if value in (None, ""):
+            continue
+        if isinstance(value, list):
+            raw_items = value
+        else:
+            raw_items = [value]
+        for raw_item in raw_items:
+            text = str(raw_item or "").strip()
+            if text and text not in merged:
+                merged.append(text)
+    return merged
+
+
+def normalize_provider_env_var(value: Any) -> str:
+    """Normalize arbitrary env-var suggestions into notebook-safe keys."""
+
+    text = str(value or "").strip()
+    if not text:
+        return ""
+
+    normalized = re.sub(r"[^a-zA-Z0-9_]", "_", text)
+    normalized = re.sub(r"_+", "_", normalized).strip("_").upper()
+    if not normalized:
+        return ""
+    if normalized[0].isdigit():
+        normalized = f"ENV_{normalized}"
+    return normalized
+
+
+def package_import_probe(package_name: str) -> str:
+    """Return the import probe used to detect whether a package is installed."""
+
+    return _PACKAGE_IMPORT_PROBES.get(
+        package_name,
+        package_name.replace("-", "_").replace(".", "_"),
+    )
+
+
+@dataclass
+class DependencyAccumulator:
+    """Mutable normalized dependency accumulator used by planner and composer."""
+
+    packages: list[str] = field(default_factory=list)
+    provider_env_vars: list[str] = field(default_factory=list)
+    runtime_notes: list[str] = field(default_factory=list)
+    conflicts_resolved: list[str] = field(default_factory=list)
+    selected_families: dict[str, str] = field(default_factory=dict, repr=False)
+
+
+def add_dependency_candidate(
+    accumulator: DependencyAccumulator,
+    package_name: str,
+    *,
+    family: str | None = None,
+    requested_by: str | None = None,
+) -> None:
+    """Add a dependency candidate while deduplicating and resolving conflicts."""
+
+    normalized_package = str(package_name or "").strip()
+    if not normalized_package:
+        return
+
+    dependency_family = family or _PACKAGE_FAMILIES.get(normalized_package)
+    if dependency_family:
+        chosen = accumulator.selected_families.get(dependency_family)
+        if chosen and chosen != normalized_package:
+            detail = (
+                f"Kept '{chosen}' instead of '{normalized_package}' "
+                f"for dependency family '{dependency_family}'."
+            )
+            if requested_by:
+                detail += f" Requested by {requested_by}."
+            if detail not in accumulator.conflicts_resolved:
+                accumulator.conflicts_resolved.append(detail)
+            return
+        accumulator.selected_families[dependency_family] = normalized_package
+
+    if normalized_package not in accumulator.packages:
+        accumulator.packages.append(normalized_package)
+
+
+def iter_tool_package_candidates(tool: Mapping[str, Any]) -> list[tuple[str, str | None]]:
+    """Return package candidates implied by a normalized tool mapping."""
+
+    category = normalize_inline_text(tool.get("category", ""), "").lower()
+    tool_configuration = tool.get("configuration")
+    if not isinstance(tool_configuration, Mapping):
+        tool_configuration = {}
+
+    candidates: list[tuple[str, str | None]] = [
+        (package_name, None)
+        for package_name in merge_string_lists(
+            tool.get("packages"),
+            tool_configuration.get("packages"),
+        )
+    ]
+
+    if "search" in category:
+        candidates.append(("langchain-community", None))
+    if any(token in category for token in {"file", "document", "pdf"}):
+        candidates.append(("pypdf", "pdf_parser"))
+    if "api" in category:
+        candidates.append(("requests", None))
+
+    return candidates
+
+
+def accumulate_tool_dependencies(
+    accumulator: DependencyAccumulator,
+    tool: Mapping[str, Any],
+) -> None:
+    """Merge one tool's dependencies into the shared accumulator."""
+
+    requested_by = normalize_inline_text(tool.get("name", ""), "tool")
+
+    for package_name, family in iter_tool_package_candidates(tool):
+        add_dependency_candidate(
+            accumulator,
+            package_name,
+            family=family,
+            requested_by=requested_by,
+        )
+
+    tool_configuration = tool.get("configuration")
+    if not isinstance(tool_configuration, Mapping):
+        tool_configuration = {}
+
+    provider_env_vars = merge_string_lists(
+        tool.get("provider_env_vars"),
+        tool_configuration.get("provider_env_vars"),
+    )
+    for env_var in provider_env_vars:
+        raw_env_var = str(env_var or "").strip()
+        normalized_env_var = normalize_provider_env_var(env_var)
+        if not normalized_env_var:
+            if raw_env_var:
+                note = (
+                    f"Ignored provider env var '{raw_env_var}' because it could not "
+                    "be normalized into a notebook-safe key."
+                )
+                if note not in accumulator.runtime_notes:
+                    accumulator.runtime_notes.append(note)
+            continue
+
+        if raw_env_var and normalized_env_var != raw_env_var:
+            note = (
+                f"Normalized provider env var '{raw_env_var}' to "
+                f"'{normalized_env_var}' for notebook-safe configuration."
+            )
+            if note not in accumulator.runtime_notes:
+                accumulator.runtime_notes.append(note)
+        if normalized_env_var not in accumulator.provider_env_vars:
+            accumulator.provider_env_vars.append(normalized_env_var)

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -1333,6 +1333,181 @@ async def test_toolchain_engineer_preserves_display_name_when_tool_id_present(
     assert result.tools[0].name == "Web Search Tool"
 
 
+@pytest.mark.asyncio
+async def test_toolchain_engineer_blocks_network_tools_for_offline_constraints(
+    monkeypatch,
+):
+    """Offline constraints should downgrade network-dependent tools to unsupported."""
+
+    monkeypatch.setattr(
+        toolchain_engineer,
+        "ChatOpenAI",
+        make_stub_llm(
+            """[
+                {"tool_id":"web_search","name":"web_search","category":"search","purpose":"Look up docs","configuration":{}},
+                {"tool_id":"file_reader","name":"file_reader","category":"file_io","purpose":"Read local files","configuration":{}},
+                {"tool_id":"http_client","name":"http_client","category":"api","purpose":"Fetch remote APIs","configuration":{}}
+            ]"""
+        ),
+    )
+    engineer = toolchain_engineer.ToolchainEngineer()
+    result = await engineer.plan_tools(
+        {"nodes": [{"name": "research", "purpose": "Search docs and fetch APIs"}]},
+        [Constraint(type="environment", value="Offline only, no network access", priority=5)],
+    )
+
+    statuses = {tool.tool_id: tool.status for tool in result.tools}
+    assert statuses["web_search"] == "unsupported"
+    assert statuses["http_client"] == "unsupported"
+    assert statuses["file_reader"] == "ready"
+    assert any("web_search" in note for note in result.feedback.environment_notes)
+    assert any("http_client" in note for note in result.feedback.environment_notes)
+    assert result.feedback.unresolved_tools == ["web_search", "http_client"]
+
+
+@pytest.mark.asyncio
+async def test_toolchain_engineer_honors_plugin_environment_metadata(
+    monkeypatch,
+):
+    """Plugin-registered tools should honor the same environment rules as built-ins."""
+
+    monkeypatch.setattr(
+        toolchain_engineer,
+        "ChatOpenAI",
+        make_stub_llm(
+            """[
+                {"tool_id":"internal_api","name":"internal_api","category":"api","purpose":"Call internal APIs","configuration":{}},
+                {"tool_id":"web_search","name":"web_search","category":"search","purpose":"Search public docs","configuration":{}}
+            ]"""
+        ),
+    )
+    registry = get_tool_registry().clone()
+    registry.register(
+        ToolRegistration(
+            tool_id="internal_api",
+            name="Internal API Client",
+            description="Call internal-only APIs over the network.",
+            category="api",
+            aliases=["internal_http_client"],
+            default_packages=["requests"],
+            environment_compatibility={
+                "requires_network": True,
+                "public_web": False,
+                "notebook_safe": True,
+            },
+        )
+    )
+
+    engineer = toolchain_engineer.ToolchainEngineer(registry=registry)
+    result = await engineer.plan_tools(
+        {"nodes": [{"name": "fetch", "purpose": "Call internal APIs and search docs"}]},
+        [Constraint(type="environment", value="Firewalled internal only runtime", priority=5)],
+    )
+
+    statuses = {tool.tool_id: tool.status for tool in result.tools}
+    assert statuses["internal_api"] == "ready"
+    assert statuses["web_search"] == "unsupported"
+    assert any("web_search" in note for note in result.feedback.environment_notes)
+    assert "internal_api" not in result.feedback.unresolved_tools
+
+
+@pytest.mark.asyncio
+async def test_toolchain_engineer_blocks_non_notebook_safe_tools_for_jupyter(
+    monkeypatch,
+):
+    """Explicit notebook runtimes should downgrade non-notebook-safe tools."""
+
+    monkeypatch.setattr(
+        toolchain_engineer,
+        "ChatOpenAI",
+        make_stub_llm(
+            """[
+                {"tool_id":"shell_runner","name":"shell_runner","category":"code_execution","purpose":"Run shell commands","configuration":{}}
+            ]"""
+        ),
+    )
+    registry = get_tool_registry().clone()
+    registry.register(
+        ToolRegistration(
+            tool_id="shell_runner",
+            name="Shell Runner",
+            description="Execute local shell commands.",
+            category="code_execution",
+            aliases=["shell"],
+            environment_compatibility={
+                "requires_network": False,
+                "public_web": False,
+                "notebook_safe": False,
+            },
+        )
+    )
+
+    engineer = toolchain_engineer.ToolchainEngineer(registry=registry)
+    result = await engineer.plan_tools(
+        {"nodes": [{"name": "executor", "purpose": "Run shell commands"}]},
+        [Constraint(type="runtime", value="Run in Jupyter notebook", priority=5)],
+    )
+
+    assert result.tools[0].status == "unsupported"
+    assert any("notebook-safe tools" in note for note in result.feedback.environment_notes)
+    assert result.feedback.unresolved_tools == ["shell_runner"]
+
+
+@pytest.mark.asyncio
+async def test_toolchain_engineer_deduplicates_identical_tool_suggestions(monkeypatch):
+    """Repeated canonical-equivalent suggestions should collapse into one tool spec."""
+
+    monkeypatch.setattr(
+        toolchain_engineer,
+        "ChatOpenAI",
+        make_stub_llm(
+            """[
+                {"tool_id":"web_search","name":"Web Search","category":"search","purpose":"Look up docs","configuration":{}},
+                {"name":"search","category":"search","purpose":"Look up docs","configuration":{"backend":"duckduckgo"},"provider_env_vars":["SEARCH_API_KEY"]}
+            ]"""
+        ),
+    )
+    engineer = toolchain_engineer.ToolchainEngineer()
+    result = await engineer.plan_tools(
+        {"nodes": [{"name": "research", "purpose": "Search docs"}]},
+        [Constraint(type="goal", value="Research docs", priority=5)],
+    )
+
+    assert len(result.tools) == 1
+    assert result.tools[0].tool_id == "web_search"
+    assert result.tools[0].provider_env_vars == ["SEARCH_API_KEY"]
+
+
+@pytest.mark.asyncio
+async def test_toolchain_engineer_keeps_conflicting_tool_configs_separate(
+    monkeypatch,
+):
+    """Conflicting configurations should remain visible instead of being merged away."""
+
+    monkeypatch.setattr(
+        toolchain_engineer,
+        "ChatOpenAI",
+        make_stub_llm(
+            """[
+                {"tool_id":"file_reader","name":"File Reader","category":"file_io","purpose":"Read PDFs","configuration":{"mode":"text","packages":["pypdf"]}},
+                {"tool_id":"file_reader","name":"File Reader","category":"file_io","purpose":"Read PDFs quickly","configuration":{"mode":"binary","packages":["pdfminer.six"]}}
+            ]"""
+        ),
+    )
+    engineer = toolchain_engineer.ToolchainEngineer()
+    result = await engineer.plan_tools(
+        {"nodes": [{"name": "reader", "purpose": "Read PDF documents"}]},
+        [Constraint(type="goal", value="Read PDFs", priority=5)],
+    )
+
+    assert len(result.tools) == 2
+    assert any(
+        "multiple configurations" in message
+        for message in result.feedback.dependency_conflicts
+    )
+    assert any("pdf_parser" in message for message in result.feedback.dependency_conflicts)
+
+
 def test_requirements_analyst_uses_request_scoped_model_config(monkeypatch):
     """RequirementsAnalyst should pass request-scoped model settings to ChatOpenAI."""
     captured_kwargs = {}

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -29,6 +29,7 @@ from langgraph_system_generator.generator.graph_design_registry import (
     validate_graph_design,
 )
 from langgraph_system_generator.generator import tool_registry as tool_registry_module
+from langgraph_system_generator.generator import tool_dependency_utils
 from langgraph_system_generator.generator.tool_registry import (
     ToolRegistration,
     ToolRegistry,
@@ -1366,6 +1367,31 @@ async def test_toolchain_engineer_blocks_network_tools_for_offline_constraints(
 
 
 @pytest.mark.asyncio
+async def test_toolchain_engineer_ignores_offline_tokens_in_non_runtime_constraints(
+    monkeypatch,
+):
+    """Only runtime/environment constraints should trigger environment filtering."""
+
+    monkeypatch.setattr(
+        toolchain_engineer,
+        "ChatOpenAI",
+        make_stub_llm(
+            '[{"tool_id":"web_search","name":"Web Docs Search","category":"search","purpose":"Look up docs","configuration":{}}]'
+        ),
+    )
+    engineer = toolchain_engineer.ToolchainEngineer()
+    result = await engineer.plan_tools(
+        {"nodes": [{"name": "research", "purpose": "Search docs"}]},
+        [Constraint(type="goal", value="Build an offline-first assistant", priority=5)],
+    )
+
+    assert result.tools[0].tool_id == "web_search"
+    assert result.tools[0].status == "ready"
+    assert result.feedback.environment_notes == []
+    assert result.feedback.unresolved_tools == []
+
+
+@pytest.mark.asyncio
 async def test_toolchain_engineer_honors_plugin_environment_metadata(
     monkeypatch,
 ):
@@ -1454,6 +1480,39 @@ async def test_toolchain_engineer_blocks_non_notebook_safe_tools_for_jupyter(
 
 
 @pytest.mark.asyncio
+async def test_toolchain_engineer_uses_heuristic_fallback_after_environment_filtering(
+    monkeypatch,
+):
+    """Heuristic fallback should re-run if validation/environment filtering removes all usable tools."""
+
+    monkeypatch.setattr(
+        toolchain_engineer,
+        "ChatOpenAI",
+        make_stub_llm(
+            """[
+                {"tool_id":"http_client","name":"HTTP Client","category":"api","purpose":"Call remote APIs","configuration":{}}
+            ]"""
+        ),
+    )
+    engineer = toolchain_engineer.ToolchainEngineer()
+    result = await engineer.plan_tools(
+        {
+            "nodes": [
+                {"name": "doc_reader", "purpose": "Read local PDF documents"},
+                {"name": "api_fetcher", "purpose": "Fetch remote APIs"},
+            ]
+        },
+        [Constraint(type="environment", value="Offline only", priority=5)],
+    )
+
+    statuses = {tool.tool_id: tool.status for tool in result.tools}
+    assert result.feedback.fallback_used is True
+    assert "file_reader" in statuses
+    assert statuses["file_reader"] == "fallback"
+    assert statuses["http_client"] == "unsupported"
+
+
+@pytest.mark.asyncio
 async def test_toolchain_engineer_deduplicates_identical_tool_suggestions(monkeypatch):
     """Repeated canonical-equivalent suggestions should collapse into one tool spec."""
 
@@ -1506,6 +1565,13 @@ async def test_toolchain_engineer_keeps_conflicting_tool_configs_separate(
         for message in result.feedback.dependency_conflicts
     )
     assert any("pdf_parser" in message for message in result.feedback.dependency_conflicts)
+
+
+def test_package_import_probe_maps_non_module_distribution_names():
+    """Shared dependency probes should use the actual import module names."""
+
+    assert tool_dependency_utils.package_import_probe("pdfminer.six") == "pdfminer"
+    assert tool_dependency_utils.package_import_probe("pymupdf") == "fitz"
 
 
 def test_requirements_analyst_uses_request_scoped_model_config(monkeypatch):

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -314,6 +314,39 @@ async def test_tooling_plan_node_returns_tools_plan(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_tooling_plan_node_preserves_environment_feedback(monkeypatch):
+    payload = (
+        '[{"tool_id":"web_search","name":"web_search","category":"search",'
+        '"purpose":"Look up docs","configuration":{}}]'
+    )
+
+    monkeypatch.setattr(
+        toolchain_engineer,
+        "ChatOpenAI",
+        make_stub_llm(payload),
+    )
+
+    result = await tooling_plan_node(
+        {
+            "workflow_design": {
+                "nodes": [{"name": "research", "purpose": "Search docs"}]
+            },
+            "constraints": [
+                Constraint(
+                    type="environment",
+                    value="Offline only, no network access",
+                    priority=5,
+                )
+            ],
+        }
+    )
+
+    assert result["tools_plan"][0]["status"] == "unsupported"
+    assert result["tool_planning_feedback"].environment_notes
+    assert result["tool_planning_feedback"].unresolved_tools == ["web_search"]
+
+
+@pytest.mark.asyncio
 async def test_notebook_assembly_node_returns_generated_cells(monkeypatch):
     cells = [CellSpec(cell_type="markdown", content="Hi", metadata={})]
     feedback = NotebookCompositionFeedback(

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -265,6 +265,8 @@ async def test_compose_notebook_emits_tool_planning_warning_cells(
             fallback_reason="Tool planning used heuristic fallback inference.",
             validation_errors=["Unsupported tool suggestion 'swarm_tool'."],
             unresolved_tools=["swarm_tool"],
+            environment_notes=["Blocked tool 'web_search' for an offline runtime."],
+            dependency_conflicts=["Kept 'pypdf' instead of 'pdfminer.six' for PDF parsing."],
             available_tool_ids=["web_search"],
             warnings=["Tool planning used heuristic fallback inference."],
         ),
@@ -277,6 +279,8 @@ async def test_compose_notebook_emits_tool_planning_warning_cells(
     ]
     assert any("Tool Planning Notes" in cell for cell in tool_markdown)
     assert any("swarm_tool" in cell for cell in tool_markdown)
+    assert any("Environment notes" in cell for cell in tool_markdown)
+    assert any("Dependency conflicts" in cell for cell in tool_markdown)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -355,7 +355,7 @@ async def test_compose_notebook_sanitizes_provider_env_vars_for_config_code(
                 "category": "api",
                 "purpose": "Fetch API data",
                 "configuration": {
-                    "provider_env_vars": ["openai-api-key", "Service API Key"],
+                    "provider_env_vars": ["openai-api-key", "Service API Key", "for"],
                 },
                 "packages": ["requests"],
                 "provider_env_vars": ["123 service key"],
@@ -372,6 +372,7 @@ async def test_compose_notebook_sanitizes_provider_env_vars_for_config_code(
     assert "OPENAI_API_KEY" in composition.dependency_plan.provider_env_vars
     assert "SERVICE_API_KEY" in composition.dependency_plan.provider_env_vars
     assert "ENV_123_SERVICE_KEY" in composition.dependency_plan.provider_env_vars
+    assert "ENV_FOR" in composition.dependency_plan.provider_env_vars
     assert any(
         "Normalized provider env var 'openai-api-key' to 'OPENAI_API_KEY'"
         in note
@@ -380,6 +381,10 @@ async def test_compose_notebook_sanitizes_provider_env_vars_for_config_code(
     assert any(
         "Normalized provider env var '123 service key' to 'ENV_123_SERVICE_KEY'"
         in note
+        for note in composition.dependency_plan.runtime_notes
+    )
+    assert any(
+        "Normalized provider env var 'for' to 'ENV_FOR'" in note
         for note in composition.dependency_plan.runtime_notes
     )
 


### PR DESCRIPTION
## Summary
- enforce runtime and environment constraints during tool planning
- deduplicate tool specs and validate dependency/package-family conflicts before notebook assembly
- share dependency normalization between ToolchainEngineer and NotebookComposer and extend regression coverage

## Verification
- pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes.py tests/unit/test_generator_nodes_additional.py tests/unit/test_generator_notebook_composer.py tests/unit/test_cli_api.py tests/unit/test_config.py -q
- pytest tests/unit -q
- pytest --asyncio-mode=auto -q
- python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

Closes #169
Closes #171
Closes #172
Closes #166