### PR TITLE
QARepairAgent tranche 2: deterministic repair engine

### DIFF
--- a/src/langgraph_system_generator/generator/agents/qa_repair_agent.py
+++ b/src/langgraph_system_generator/generator/agents/qa_repair_agent.py
@@ -9,7 +9,6 @@ from typing import List
 
 from langchain_openai import ChatOpenAI
 
-from langgraph_system_generator.generator.agents._llm import build_chat_llm
 from langgraph_system_generator.generator.state import CellSpec, QAReport
 from langgraph_system_generator.notebook.composer import (
     NotebookComposer as NotebookFileComposer,
@@ -27,11 +26,9 @@ class QARepairAgent:
         model: str | None = None,
         model_config: ModelConfig | None = None,
     ):
-        self.llm = build_chat_llm(
-            model=model,
-            model_config=model_config,
-            chat_openai_class=ChatOpenAI,
-        )
+        self.model = model
+        self.model_config = model_config
+        self.chat_openai_class = ChatOpenAI
         self.repair_engine = NotebookRepairAgent()
 
     async def validate(self, cells: List[CellSpec]) -> List[QAReport]:
@@ -127,7 +124,10 @@ class QARepairAgent:
         )
 
     async def repair(
-        self, cells: List[CellSpec], qa_reports: List[QAReport]
+        self,
+        cells: List[CellSpec],
+        qa_reports: List[QAReport],
+        attempt: int = 0,
     ) -> List[CellSpec]:
         """Attempt to fix issues identified in QA through the shared repair engine.
 
@@ -145,6 +145,6 @@ class QARepairAgent:
             self.repair_engine.repair_cells,
             cells,
             qa_reports,
-            0,
+            attempt,
         )
         return outcome.cells if outcome.success else cells

--- a/src/langgraph_system_generator/generator/agents/qa_repair_agent.py
+++ b/src/langgraph_system_generator/generator/agents/qa_repair_agent.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List
 
-from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from langgraph_system_generator.generator.agents._llm import build_chat_llm
@@ -14,6 +14,7 @@ from langgraph_system_generator.generator.state import CellSpec, QAReport
 from langgraph_system_generator.notebook.composer import (
     NotebookComposer as NotebookFileComposer,
 )
+from langgraph_system_generator.qa.repair import NotebookRepairAgent
 from langgraph_system_generator.qa.validators import NotebookValidator
 from langgraph_system_generator.utils.config import ModelConfig
 
@@ -31,6 +32,7 @@ class QARepairAgent:
             model_config=model_config,
             chat_openai_class=ChatOpenAI,
         )
+        self.repair_engine = NotebookRepairAgent()
 
     async def validate(self, cells: List[CellSpec]) -> List[QAReport]:
         """Run all quality checks on generated cells.
@@ -127,7 +129,7 @@ class QARepairAgent:
     async def repair(
         self, cells: List[CellSpec], qa_reports: List[QAReport]
     ) -> List[CellSpec]:
-        """Attempt to fix issues identified in QA.
+        """Attempt to fix issues identified in QA through the shared repair engine.
 
         Args:
             cells: Original cell specifications
@@ -136,47 +138,13 @@ class QARepairAgent:
         Returns:
             Repaired cell specifications
         """
-        failed_reports = [r for r in qa_reports if not r.passed]
-
-        if not failed_reports:
+        if not any(not report.passed for report in qa_reports):
             return cells
 
-        # Create repair prompt
-        issues = "\n".join([f"- {r.check_name}: {r.message}" for r in failed_reports])
-
-        repair_prompt = SystemMessage(
-            content="""You are a notebook repair specialist.
-Fix the identified issues in the notebook cells while maintaining their structure and purpose.
-
-Focus on:
-1. Replacing placeholders with working code
-2. Adding missing imports
-3. Ensuring proper cell structure
-4. Maintaining code quality
-
-Return suggestions as a list of specific changes."""
+        outcome = await asyncio.to_thread(
+            self.repair_engine.repair_cells,
+            cells,
+            qa_reports,
+            0,
         )
-
-        cells_summary = "\n".join(
-            [
-                f"Cell {i} ({cell.cell_type}): {cell.content[:100]}..."
-                for i, cell in enumerate(cells[:10])
-            ]
-        )
-
-        user_message = HumanMessage(
-            content=f"""Issues Found:
-{issues}
-
-Cells:
-{cells_summary}
-
-Suggest specific repairs."""
-        )
-
-        # Get repair suggestions from LLM (currently unused as repair is not fully implemented)
-        await self.llm.ainvoke([repair_prompt, user_message])
-
-        # For now, return original cells as we need more context for repairs
-        # In a full implementation, we'd parse the LLM response and apply fixes
-        return cells
+        return outcome.cells if outcome.success else cells

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -781,7 +781,7 @@ async def repair_node(state: GeneratorState) -> Dict[str, Any]:
             suggestions=outcome.next_steps,
         ),
         stage="repair",
-        attempt=attempt,
+        attempt=attempt + 1,
         evidence={
             "repair_success": outcome.success,
             "repair_status": outcome.status,

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -176,6 +176,7 @@ def _qa_repair_feedback_from_reports(
     existing_feedback: QARepairFeedback | None = None,
     rollback_used: bool = False,
     extra_warnings: List[str] | None = None,
+    extra_next_steps: List[str] | None = None,
 ) -> QARepairFeedback:
     """Build compact QA/repair feedback from the current report set."""
 
@@ -211,6 +212,10 @@ def _qa_repair_feedback_from_reports(
         warning_text = str(warning or "").strip()
         if warning_text and warning_text not in warnings:
             warnings.append(warning_text)
+    for step in extra_next_steps or []:
+        step_text = str(step or "").strip()
+        if step_text and step_text not in next_steps:
+            next_steps.append(step_text)
 
     prior = existing_feedback or QARepairFeedback()
     return QARepairFeedback(
@@ -220,6 +225,81 @@ def _qa_repair_feedback_from_reports(
         next_steps=next_steps,
         warnings=warnings,
     )
+
+
+def _qa_repair_summary_markdown(
+    feedback: QARepairFeedback,
+    *,
+    status: str,
+) -> str:
+    """Render a notebook-visible QA and repair summary."""
+
+    if status == "applied":
+        status_line = "Applied a non-regressive deterministic repair."
+    elif status == "rolled_back":
+        status_line = "Rolled back the repair candidate to preserve the last safe notebook snapshot."
+    elif status == "skipped":
+        status_line = "Skipped repair because no safe deterministic fix matched the current QA failures."
+    else:
+        status_line = "No repair was needed for the current notebook snapshot."
+
+    lines = [
+        "## QA and Repair Summary",
+        "",
+        f"Status: {status_line}",
+        f"Repair attempts so far: {feedback.repair_attempts}",
+        f"Rollback used: {'Yes' if feedback.rollback_used else 'No'}",
+    ]
+
+    if feedback.unrepaired_failures:
+        lines.extend(
+            [
+                "",
+                "Blocking unresolved failures:",
+                *[f"- {failure}" for failure in feedback.unrepaired_failures],
+            ]
+        )
+    else:
+        lines.extend(["", "Blocking unresolved failures: none."])
+
+    if feedback.next_steps:
+        lines.extend(
+            [
+                "",
+                "Next steps:",
+                *[f"- {step}" for step in feedback.next_steps],
+            ]
+        )
+    elif status == "applied":
+        lines.extend(["", "Next steps: no manual follow-up is currently required."])
+
+    return "\n".join(lines)
+
+
+def _upsert_qa_repair_summary_cell(
+    cells: List[CellSpec],
+    feedback: QARepairFeedback,
+    *,
+    status: str,
+) -> List[CellSpec]:
+    """Replace any existing QA repair summary cell with the latest summary."""
+
+    retained_cells = [
+        cell.model_copy(deep=True)
+        for cell in cells
+        if cell.section != "qa_repair_summary"
+        and cell.metadata.get("kind") != "qa_repair_summary"
+        and cell.metadata.get("section") != "qa_repair_summary"
+    ]
+    retained_cells.append(
+        CellSpec(
+            cell_type="markdown",
+            content=_qa_repair_summary_markdown(feedback, status=status),
+            metadata={"section": "qa_repair_summary", "kind": "qa_repair_summary"},
+            section="qa_repair_summary",
+        )
+    )
+    return retained_cells
 
 
 async def intake_node(state: GeneratorState) -> Dict[str, Any]:
@@ -670,78 +750,62 @@ async def repair_node(state: GeneratorState) -> Dict[str, Any]:
         Updated state with incremented repair attempts and repaired notebook data.
     """
     repair_agent = NotebookRepairAgent()
-    notebook_builder = NotebookFileComposer()
 
     cells = state.get("generated_cells", [])
     qa_reports = list(state.get("qa_reports", []))
     attempt = int(state.get("repair_attempts", 0))
-
-    with TemporaryDirectory() as temp_dir:
-        notebook = notebook_builder.build_notebook(cells)
-        notebook_path = Path(temp_dir) / "generated.ipynb"
-        notebook_builder.write(notebook, notebook_path)
-
-        repair_success, updated_reports = repair_agent.repair_notebook(
-            notebook_path,
-            qa_reports,
-            attempt=attempt,
-        )
-
-        # Only reload cells if repair was successful
-        if repair_success:
-            try:
-                regenerated_cells = _cells_from_notebook(notebook_path)
-            except ValueError as e:
-                # If cell rehydration fails after successful repair, log and keep original cells
-                logger.warning(f"Failed to reload cells after repair: {e}")
-                regenerated_cells = cells
-        else:
-            # If repair failed (e.g., notebook not safely written), keep original cells
-            logger.info(
-                f"Repair attempt {attempt} failed. "
-                "Keeping original cells for potential retry."
-            )
-            regenerated_cells = cells
+    outcome = repair_agent.repair_cells(cells, qa_reports, attempt=attempt)
 
     normalized_reports = _stamp_reports(
-        updated_reports,
+        outcome.qa_reports,
         stage="static",
         attempt=attempt + 1,
     )
+    extra_warnings: List[str] = []
+    if outcome.status == "rolled_back":
+        extra_warnings.append(
+            "Repair candidate was rolled back after validation to preserve the last safe notebook snapshot."
+        )
+    elif outcome.status == "skipped":
+        extra_warnings.append(outcome.message)
+
     repair_summary = _stamp_report(
         QAReport(
             check_name="Repair Attempt",
-            passed=repair_success,
-            message=(
-                "Notebook repair produced an updated notebook snapshot."
-                if repair_success
-                else "Notebook repair could not resolve the current QA failures."
-            ),
-            rule_id="repair_attempt_summary",
-            severity="info" if repair_success else "warning",
+            passed=outcome.success,
+            message=outcome.message,
+            rule_id="repair_attempt",
+            severity="info" if outcome.success else "warning",
             category="repair",
             repairable=False,
-            suggestions=[] if repair_success else ["Inspect the latest QA reports before retrying."],
+            suggestions=outcome.next_steps,
         ),
         stage="repair",
         attempt=attempt,
         evidence={
-            "repair_success": repair_success,
+            "repair_success": outcome.success,
+            "repair_status": outcome.status,
+            "attempted_fixes": outcome.attempted_fixes,
+            "validation_after_repair": outcome.validation_summary,
+            "rollback_used": outcome.rollback_used,
+            "persisted_repaired_cells": outcome.persisted,
             "input_report_count": len(qa_reports),
             "output_report_count": len(normalized_reports),
-            "regenerated_cell_count": len(regenerated_cells),
+            "regenerated_cell_count": len(outcome.cells),
         },
     )
     qa_repair_feedback = _qa_repair_feedback_from_reports(
         normalized_reports,
         repair_attempts=attempt + 1,
         existing_feedback=_qa_repair_feedback_from_state(state),
-        rollback_used=False,
-        extra_warnings=(
-            []
-            if repair_success
-            else ["Repair attempt did not resolve the current blocking QA issues."]
-        ),
+        rollback_used=outcome.rollback_used,
+        extra_warnings=extra_warnings,
+        extra_next_steps=outcome.next_steps,
+    )
+    regenerated_cells = _upsert_qa_repair_summary_cell(
+        outcome.cells,
+        qa_repair_feedback,
+        status=outcome.status,
     )
 
     return {

--- a/src/langgraph_system_generator/qa/repair.py
+++ b/src/langgraph_system_generator/qa/repair.py
@@ -40,9 +40,6 @@ recovered_workflow.add_edge("recovered_start", END)
 graph = recovered_workflow.compile()
 """
 _PLACEHOLDER_REPLACEMENTS = {
-    "TODO": "",
-    "FIXME": "",
-    "PLACEHOLDER": "",
     "# Your code here": "pass",
     "pass  # implement": "pass",
 }
@@ -127,9 +124,12 @@ class NotebookRepairAgent:
             baseline_reports = self._validate_cells(original_cells)
         except Exception:  # pragma: no cover - defensive fallback
             baseline_reports = list(qa_reports)
+        preserved_baseline_reports = self._merge_preserved_failures(
+            baseline_reports, qa_reports
+        )
         baseline_summary = self._validation_summary(
-            baseline_reports,
-            baseline_reports,
+            preserved_baseline_reports,
+            preserved_baseline_reports,
             accepted=True,
         )
 
@@ -141,7 +141,7 @@ class NotebookRepairAgent:
             return RepairOutcome(
                 status="skipped",
                 cells=original_cells,
-                qa_reports=baseline_reports,
+                qa_reports=preserved_baseline_reports,
                 attempted_fixes=[],
                 message="No safe deterministic repair matched the current QA failures.",
                 next_steps=[
@@ -163,7 +163,7 @@ class NotebookRepairAgent:
             return RepairOutcome(
                 status="rolled_back",
                 cells=original_cells,
-                qa_reports=baseline_reports,
+                qa_reports=preserved_baseline_reports,
                 attempted_fixes=attempted_fixes,
                 rollback_used=True,
                 message="Repair candidate could not be validated safely and was rolled back.",
@@ -193,7 +193,7 @@ class NotebookRepairAgent:
         return RepairOutcome(
             status="rolled_back",
             cells=original_cells,
-            qa_reports=baseline_reports,
+            qa_reports=preserved_baseline_reports,
             attempted_fixes=attempted_fixes,
             rollback_used=True,
             message="Repair candidate was rolled back because it regressed or did not improve validation.",
@@ -267,16 +267,41 @@ class NotebookRepairAgent:
                 continue
 
             original = str(cell.source or "")
-            modified = original
-            for placeholder, replacement in _PLACEHOLDER_REPLACEMENTS.items():
-                modified = modified.replace(placeholder, replacement)
-
             filtered_lines: List[str] = []
-            for line in modified.splitlines():
+            for line in original.splitlines():
                 stripped = line.strip()
                 if stripped in {"...", "# ..."}:
                     continue
+
+                exact_replacement = _PLACEHOLDER_REPLACEMENTS.get(stripped)
+                if exact_replacement is not None:
+                    filtered_lines.append(exact_replacement)
+                    continue
+
+                if re.fullmatch(
+                    r"#\s*(TODO|FIXME|PLACEHOLDER)\b.*",
+                    stripped,
+                    flags=re.IGNORECASE,
+                ):
+                    continue
+                if re.fullmatch(
+                    r"(TODO|FIXME|PLACEHOLDER)\b.*",
+                    stripped,
+                    flags=re.IGNORECASE,
+                ):
+                    continue
+
+                inline_placeholder = re.match(
+                    r"^(?P<code>.+?)\s+#\s*(TODO|FIXME|PLACEHOLDER)\b.*$",
+                    line,
+                    flags=re.IGNORECASE,
+                )
+                if inline_placeholder:
+                    filtered_lines.append(inline_placeholder.group("code").rstrip())
+                    continue
+
                 filtered_lines.append(line)
+
             modified = "\n".join(filtered_lines)
 
             while "\n\n\n" in modified:
@@ -376,7 +401,10 @@ class NotebookRepairAgent:
             header_cell.metadata["section"] = section
             code_cell = nbformat.v4.new_code_cell(source=code_source)
             code_cell.metadata["section"] = section
-            notebook.cells.extend([header_cell, code_cell])
+            if section == "setup":
+                notebook.cells[0:0] = [header_cell, code_cell]
+            else:
+                notebook.cells.extend([header_cell, code_cell])
             fixes.append(f"Added missing '{section}' section with deterministic fallback content.")
 
         return fixes
@@ -396,11 +424,11 @@ class NotebookRepairAgent:
             cell_index = issue.get("cell_index")
             if not isinstance(suggestion, str) or not isinstance(name, str):
                 continue
-            if not isinstance(cell_index, int) or not (0 <= cell_index < len(notebook.cells)):
+            if not isinstance(cell_index, int):
                 continue
 
-            cell = notebook.cells[cell_index]
-            if cell.cell_type != "code":
+            notebook_index, cell = self._resolve_code_cell(notebook, cell_index)
+            if cell is None:
                 continue
 
             pattern = re.compile(rf"\b{re.escape(name)}\b")
@@ -408,7 +436,7 @@ class NotebookRepairAgent:
             if count > 0:
                 cell.source = updated_source
                 fixes.append(
-                    f"Replaced likely typo '{name}' with '{suggestion}' in code cell {cell_index}."
+                    f"Replaced likely typo '{name}' with '{suggestion}' in code cell {notebook_index}."
                 )
 
         return fixes
@@ -425,11 +453,9 @@ class NotebookRepairAgent:
         message = str(syntax_error.get("message") or "")
         if not isinstance(cell_index, int) or not isinstance(line_in_cell, int):
             return []
-        if not (0 <= cell_index < len(notebook.cells)):
-            return []
 
-        cell = notebook.cells[cell_index]
-        if cell.cell_type != "code":
+        notebook_index, cell = self._resolve_code_cell(notebook, cell_index)
+        if cell is None:
             return []
 
         lines = str(cell.source or "").splitlines()
@@ -448,7 +474,7 @@ class NotebookRepairAgent:
         lines[target_index] = updated_line
         cell.source = "\n".join(lines)
         return [
-            f"Applied bounded syntax repair in code cell {cell_index} at line {line_in_cell}."
+            f"Applied bounded syntax repair in code cell {notebook_index} at line {line_in_cell}."
         ]
 
     def _repair_graph_scaffold(
@@ -593,6 +619,20 @@ class NotebookRepairAgent:
 
         return [cell.model_copy(deep=True) for cell in cells]
 
+    def _resolve_code_cell(
+        self, notebook: NotebookNode, code_cell_index: int
+    ) -> tuple[int, NotebookNode | None]:
+        """Map a code-only cell index from validator evidence to notebook.cells."""
+
+        current_code_index = 0
+        for notebook_index, cell in enumerate(notebook.cells):
+            if cell.cell_type != "code":
+                continue
+            if current_code_index == code_cell_index:
+                return notebook_index, cell
+            current_code_index += 1
+        return -1, None
+
     def _cells_from_notebook(self, notebook: NotebookNode) -> List[CellSpec]:
         """Convert an in-memory notebook into CellSpec entries."""
 
@@ -600,7 +640,14 @@ class NotebookRepairAgent:
         for cell in notebook.cells:
             metadata = dict(cell.metadata or {})
             section = metadata.pop("section", None)
-            source = cell.source if isinstance(cell.source, str) else "".join(cell.source or [])
+            if isinstance(cell.source, str):
+                source = cell.source
+            else:
+                source_parts = list(cell.source or [])
+                if source_parts and all(part.endswith("\n") for part in source_parts):
+                    source = "".join(source_parts)
+                else:
+                    source = "\n".join(source_parts)
             regenerated_cells.append(
                 CellSpec(
                     cell_type=cell.cell_type,
@@ -611,15 +658,46 @@ class NotebookRepairAgent:
             )
         return regenerated_cells
 
-    def _report_key(self, report: QAReport) -> tuple[str, str, str, str]:
+    def _report_key(self, report: QAReport) -> tuple[str, str, str]:
         """Return a stable key for comparing report severity across attempts."""
 
         return (
             report.rule_id,
             report.check_name,
             report.severity,
+        )
+
+    def _preserved_report_key(
+        self, report: QAReport
+    ) -> tuple[str, str, str | None, str, str]:
+        """Return a key for preserving unresolved failures across repair outcomes."""
+
+        return (
+            report.rule_id,
+            report.check_name,
+            report.stage,
+            report.severity,
             report.message,
         )
+
+    def _merge_preserved_failures(
+        self,
+        refreshed_reports: Sequence[QAReport],
+        original_reports: Sequence[QAReport],
+    ) -> List[QAReport]:
+        """Keep unresolved incoming failures visible when repair keeps original cells."""
+
+        merged_reports = [report.model_copy(deep=True) for report in refreshed_reports]
+        seen = {self._preserved_report_key(report) for report in merged_reports}
+        for report in original_reports:
+            if report.passed:
+                continue
+            key = self._preserved_report_key(report)
+            if key in seen:
+                continue
+            merged_reports.append(report.model_copy(deep=True))
+            seen.add(key)
+        return merged_reports
 
     def _is_non_regressive(
         self,

--- a/src/langgraph_system_generator/qa/repair.py
+++ b/src/langgraph_system_generator/qa/repair.py
@@ -3,14 +3,75 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List
+from tempfile import TemporaryDirectory
+from typing import Any, Dict, List, Sequence
 
 import nbformat
 from nbformat import NotebookNode
 
-from langgraph_system_generator.generator.state import QAReport
+from langgraph_system_generator.generator.state import CellSpec, QAReport
+from langgraph_system_generator.notebook.composer import (
+    NotebookComposer as NotebookFileComposer,
+)
 from langgraph_system_generator.qa.validators import NotebookValidator
+
+_GRAPH_SCAFFOLD_MARKER = "# Recovered deterministic graph scaffold"
+_GRAPH_SCAFFOLD_TEMPLATE = f"""{_GRAPH_SCAFFOLD_MARKER}
+from langgraph.graph import END, START, StateGraph
+from typing import TypedDict
+
+
+class RecoveredWorkflowState(TypedDict, total=False):
+    messages: list
+
+
+recovered_workflow = StateGraph(RecoveredWorkflowState)
+
+
+def recovered_start(state: RecoveredWorkflowState):
+    return state
+
+
+recovered_workflow.add_node("recovered_start", recovered_start)
+recovered_workflow.add_edge(START, "recovered_start")
+recovered_workflow.add_edge("recovered_start", END)
+graph = recovered_workflow.compile()
+"""
+_PLACEHOLDER_REPLACEMENTS = {
+    "TODO": "",
+    "FIXME": "",
+    "PLACEHOLDER": "",
+    "# Your code here": "pass",
+    "pass  # implement": "pass",
+}
+_LANGGRAPH_IMPORT_ORDER = {
+    "END": 0,
+    "START": 1,
+    "StateGraph": 2,
+}
+
+
+@dataclass
+class RepairOutcome:
+    """Structured result from a deterministic repair attempt."""
+
+    status: str
+    cells: List[CellSpec] = field(default_factory=list)
+    qa_reports: List[QAReport] = field(default_factory=list)
+    attempted_fixes: List[str] = field(default_factory=list)
+    rollback_used: bool = False
+    persisted: bool = False
+    message: str = ""
+    next_steps: List[str] = field(default_factory=list)
+    validation_summary: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def success(self) -> bool:
+        """Whether repaired cells were accepted and persisted in memory."""
+
+        return self.status == "applied" and self.persisted
 
 
 class NotebookRepairAgent:
@@ -26,6 +87,122 @@ class NotebookRepairAgent:
         """
         self.max_attempts = max_attempts
         self.validator = NotebookValidator()
+        self.notebook_builder = NotebookFileComposer()
+
+    def repair_cells(
+        self,
+        cells: Sequence[CellSpec],
+        qa_reports: List[QAReport],
+        attempt: int = 0,
+    ) -> RepairOutcome:
+        """Repair generated cells in memory and validate before accepting them."""
+
+        original_cells = self._clone_cells(cells)
+        failed_reports = [report for report in qa_reports if not report.passed]
+        baseline_summary = self._validation_summary(qa_reports, qa_reports, accepted=True)
+
+        if attempt >= self.max_attempts:
+            return RepairOutcome(
+                status="skipped",
+                cells=original_cells,
+                qa_reports=list(qa_reports),
+                message="Repair attempt limit reached before another repair could run.",
+                next_steps=[
+                    "Inspect the latest QA reports and resolve the remaining issues manually."
+                ],
+                validation_summary=baseline_summary,
+            )
+
+        if not failed_reports:
+            return RepairOutcome(
+                status="not_needed",
+                cells=original_cells,
+                qa_reports=list(qa_reports),
+                persisted=True,
+                message="No repair was needed because all QA checks already passed.",
+                validation_summary=baseline_summary,
+            )
+
+        try:
+            baseline_reports = self._validate_cells(original_cells)
+        except Exception:  # pragma: no cover - defensive fallback
+            baseline_reports = list(qa_reports)
+        baseline_summary = self._validation_summary(
+            baseline_reports,
+            baseline_reports,
+            accepted=True,
+        )
+
+        notebook = self.notebook_builder.build_notebook(original_cells)
+        candidate_notebook = nbformat.from_dict(notebook)
+        attempted_fixes = self._apply_repairs(candidate_notebook, failed_reports)
+
+        if not attempted_fixes:
+            return RepairOutcome(
+                status="skipped",
+                cells=original_cells,
+                qa_reports=baseline_reports,
+                attempted_fixes=[],
+                message="No safe deterministic repair matched the current QA failures.",
+                next_steps=[
+                    "Inspect the latest QA reports and resolve the remaining issues manually."
+                ],
+                validation_summary=baseline_summary,
+            )
+
+        try:
+            candidate_cells = self._cells_from_notebook(candidate_notebook)
+            candidate_reports = self._validate_cells(candidate_cells)
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            validation_summary = self._validation_summary(
+                baseline_reports,
+                baseline_reports,
+                accepted=False,
+                error=str(exc),
+            )
+            return RepairOutcome(
+                status="rolled_back",
+                cells=original_cells,
+                qa_reports=baseline_reports,
+                attempted_fixes=attempted_fixes,
+                rollback_used=True,
+                message="Repair candidate could not be validated safely and was rolled back.",
+                next_steps=[
+                    "Inspect the generated notebook around the reported QA failures before retrying."
+                ],
+                validation_summary=validation_summary,
+            )
+
+        accepted = self._is_non_regressive(baseline_reports, candidate_reports)
+        validation_summary = self._validation_summary(
+            baseline_reports,
+            candidate_reports,
+            accepted=accepted,
+        )
+        if accepted:
+            return RepairOutcome(
+                status="applied",
+                cells=candidate_cells,
+                qa_reports=candidate_reports,
+                attempted_fixes=attempted_fixes,
+                persisted=True,
+                message="Repair candidate passed validation and was accepted.",
+                validation_summary=validation_summary,
+            )
+
+        return RepairOutcome(
+            status="rolled_back",
+            cells=original_cells,
+            qa_reports=baseline_reports,
+            attempted_fixes=attempted_fixes,
+            rollback_used=True,
+            message="Repair candidate was rolled back because it regressed or did not improve validation.",
+            next_steps=[
+                "Inspect the QA and Repair Summary cell for the attempted deterministic fixes.",
+                "Resolve the remaining blocking QA failures manually before retrying."
+            ],
+            validation_summary=validation_summary,
+        )
 
     def repair_notebook(
         self,
@@ -33,353 +210,494 @@ class NotebookRepairAgent:
         qa_reports: List[QAReport],
         attempt: int = 0,
     ) -> tuple[bool, List[QAReport]]:
-        """Attempt to repair notebook based on QA failures.
-
-        Args:
-            notebook_path: Path to the notebook file
-            qa_reports: List of QA reports identifying issues
-            attempt: Current attempt number (0-indexed)
-
-        Returns:
-            Tuple of (success, new_qa_reports)
-            - success: True if all issues were fixed
-            - new_qa_reports: Updated QA reports after repair attempt
-        """
-        if attempt >= self.max_attempts:
-            return False, qa_reports
-
-        failed_reports = [r for r in qa_reports if not r.passed]
-        if not failed_reports:
-            return True, qa_reports
+        """Attempt to repair a notebook file while preserving legacy behavior."""
 
         path = Path(notebook_path)
         try:
-            with path.open("r", encoding="utf-8") as f:
-                nb = nbformat.read(f, as_version=4)
+            with path.open("r", encoding="utf-8") as handle:
+                notebook = nbformat.read(handle, as_version=4)
         except Exception:
-            # Can't repair if we can't read the notebook
             return False, qa_reports
 
-        # Apply repairs based on failed checks
-        repaired = False
+        cells = self._cells_from_notebook(notebook)
+        outcome = self.repair_cells(cells, qa_reports, attempt=attempt)
+        if outcome.status == "not_needed":
+            return True, outcome.qa_reports
+        if not outcome.success:
+            return False, outcome.qa_reports
+
+        try:
+            repaired_notebook = self.notebook_builder.build_notebook(outcome.cells)
+            self.notebook_builder.write(repaired_notebook, path)
+        except Exception:
+            return False, qa_reports
+
+        return True, outcome.qa_reports
+
+    def _apply_repairs(
+        self,
+        notebook: NotebookNode,
+        failed_reports: Sequence[QAReport],
+    ) -> List[str]:
+        """Apply deterministic repairs for the currently failing QA reports."""
+
+        attempted_fixes: List[str] = []
         for report in failed_reports:
-            if report.check_name == "No Placeholders":
-                repaired = self._repair_placeholders(nb) or repaired
-            elif report.check_name == "Required Imports":
-                repaired = self._repair_imports(nb, report) or repaired
-            elif report.check_name == "Required Sections":
-                repaired = self._repair_sections(nb, report) or repaired
-            elif report.check_name == "Graph Compilation":
-                repaired = self._repair_compilation(nb, report) or repaired
+            if report.rule_id == "placeholder_content" or report.check_name == "No Placeholders":
+                attempted_fixes.extend(self._repair_placeholders(notebook))
+            elif report.rule_id == "required_sections" or report.check_name == "Required Sections":
+                attempted_fixes.extend(self._repair_sections(notebook, report))
+            elif report.rule_id == "required_import_symbols" or report.check_name == "Required Imports":
+                attempted_fixes.extend(self._repair_imports(notebook, report))
+            elif report.rule_id == "undefined_names":
+                attempted_fixes.extend(self._repair_undefined_names(notebook, report))
+            elif report.rule_id == "python_syntax":
+                attempted_fixes.extend(self._repair_syntax(notebook, report))
+            elif report.rule_id == "graph_structure" or report.check_name == "Graph Compilation":
+                attempted_fixes.extend(self._repair_graph_scaffold(notebook, report))
 
-        if repaired:
-            # Save the repaired notebook
-            try:
-                with path.open("w", encoding="utf-8") as f:
-                    nbformat.write(nb, f)
-            except Exception:
-                return False, qa_reports
+        return list(dict.fromkeys(fix for fix in attempted_fixes if fix.strip()))
 
-            # Re-validate
-            new_reports = self.validator.validate_all(notebook_path)
-            return all(r.passed for r in new_reports), new_reports
+    def _repair_placeholders(self, notebook: NotebookNode) -> List[str]:
+        """Remove deterministic placeholder content from notebook code cells."""
 
-        return False, qa_reports
-
-    def _repair_placeholders(self, nb: NotebookNode) -> bool:
-        """Remove or replace placeholder text in cells.
-
-        Args:
-            nb: Notebook to repair
-
-        Returns:
-            True if any repairs were made
-        """
-        repaired = False
-        placeholder_replacements = {
-            "TODO": "",
-            "FIXME": "",
-            "PLACEHOLDER": "",
-            "# Your code here": "pass",
-            "pass  # implement": "pass",
-        }
-
-        for cell in nb.cells:
-            if cell.cell_type == "code":
-                original = cell.source
-                modified = original
-
-                # Remove placeholder comments
-                for placeholder, replacement in placeholder_replacements.items():
-                    if placeholder in modified:
-                        modified = modified.replace(placeholder, replacement)
-                        repaired = True
-
-                # Remove ellipsis that appear as placeholders (not in strings)
-                # Only remove standalone ellipsis lines
-                lines = modified.split("\n")
-                filtered_lines = []
-                for line in lines:
-                    stripped = line.strip()
-                    if stripped == "..." or stripped == "# ...":
-                        repaired = True
-                        continue  # Skip this line
-                    filtered_lines.append(line)
-                
-                modified = "\n".join(filtered_lines)
-
-                # Clean up multiple blank lines
-                while "\n\n\n" in modified:
-                    modified = modified.replace("\n\n\n", "\n\n")
-                    repaired = True
-
-                cell.source = modified
-
-        return repaired
-
-    def _repair_imports(self, nb: NotebookNode, report: QAReport) -> bool:
-        """Add missing imports to the notebook.
-
-        Args:
-            nb: Notebook to repair
-            report: QA report with import issues
-
-        Returns:
-            True if any repairs were made
-        """
-        # Extract missing imports from the report message
-        match = re.search(r"Missing required imports: (.+)", report.message)
-        if not match:
-            return False
-
-        missing_imports_str = match.group(1)
-        missing_imports = [imp.strip() for imp in missing_imports_str.split(",")]
-
-        # Find the first code cell (typically installation/import section)
-        import_cell_idx = None
-        for idx, cell in enumerate(nb.cells):
-            if cell.cell_type == "code":
-                import_cell_idx = idx
-                break
-
-        if import_cell_idx is None:
-            return False
-
-        # Add missing imports to the first code cell
-        cell = nb.cells[import_cell_idx]
-        source = cell.source or ""
-        
-        # Determine which symbols are actually needed and not already present
-        needs_stategraph = any("langgraph" in imp.lower() for imp in missing_imports) and "StateGraph" not in source
-        needs_end = any("END" in imp for imp in missing_imports) and "END" not in source
-
-        if not (needs_stategraph or needs_end):
-            return False
-
-        lines = source.splitlines()
-        updated = False
-
-        # Try to consolidate into existing 'from langgraph.graph import ...' imports
-        for i, line in enumerate(lines):
-            match_import = re.match(r"^(\s*from\s+langgraph\.graph\s+import\s+)(.+)$", line)
-            if not match_import:
+        fixes: List[str] = []
+        for index, cell in enumerate(notebook.cells):
+            if cell.cell_type != "code":
                 continue
 
-            prefix, names_str = match_import.groups()
-            names = [n.strip() for n in names_str.split(",") if n.strip()]
+            original = str(cell.source or "")
+            modified = original
+            for placeholder, replacement in _PLACEHOLDER_REPLACEMENTS.items():
+                modified = modified.replace(placeholder, replacement)
 
-            if needs_stategraph and "StateGraph" not in names:
-                names.append("StateGraph")
-                needs_stategraph = False
-                updated = True
+            filtered_lines: List[str] = []
+            for line in modified.splitlines():
+                stripped = line.strip()
+                if stripped in {"...", "# ..."}:
+                    continue
+                filtered_lines.append(line)
+            modified = "\n".join(filtered_lines)
 
-            if needs_end and "END" not in names:
-                names.append("END")
-                needs_end = False
-                updated = True
+            while "\n\n\n" in modified:
+                modified = modified.replace("\n\n\n", "\n\n")
 
-            # Reconstruct the import line with updated names
-            lines[i] = prefix + ", ".join(names)
+            if modified != original:
+                cell.source = modified or "pass"
+                fixes.append(
+                    f"Removed placeholder content from code cell {index}."
+                )
 
-            # If we've satisfied all needs, no need to keep scanning
-            if not (needs_stategraph or needs_end):
-                break
+        return fixes
 
-        additions: List[str] = []
-        # If still missing any symbols, add a new consolidated import line
-        missing_names: List[str] = []
-        if needs_stategraph:
-            missing_names.append("StateGraph")
-        if needs_end:
-            missing_names.append("END")
-        if missing_names:
-            additions.append(f"from langgraph.graph import {', '.join(missing_names)}")
-            updated = True
+    def _repair_imports(self, notebook: NotebookNode, report: QAReport) -> List[str]:
+        """Add missing LangGraph imports to the setup/import area."""
 
-        if not updated:
-            return False
+        missing_symbols = [
+            str(symbol).strip()
+            for symbol in (report.evidence.get("missing_symbols") or [])
+            if str(symbol).strip()
+        ]
+        if not missing_symbols:
+            match = re.search(r"Missing required imports: (.+)", report.message)
+            if match:
+                missing_symbols = [
+                    item.strip() for item in match.group(1).split(",") if item.strip()
+                ]
 
-        # Update the cell source, appending any new consolidated import
-        new_source = "\n".join(lines)
-        if additions:
-            if new_source:
-                new_source = new_source.rstrip() + "\n" + "\n".join(additions)
-            else:
-                new_source = "\n".join(additions)
+        if not missing_symbols:
+            return []
 
-        cell.source = new_source
-        return True
+        names_to_add: set[str] = set()
+        if "langgraph" in missing_symbols:
+            names_to_add.update({"StateGraph", "END", "START"})
+        if "StateGraph" in missing_symbols:
+            names_to_add.add("StateGraph")
+        if "END" in missing_symbols:
+            names_to_add.add("END")
+        if "START" in missing_symbols:
+            names_to_add.add("START")
 
-    def _repair_sections(self, nb: NotebookNode, report: QAReport) -> bool:
-        """Add missing required sections to the notebook.
+        if not names_to_add:
+            return []
 
-        Args:
-            nb: Notebook to repair
-            report: QA report with section issues
+        cell = self._ensure_setup_code_cell(notebook)
+        source = str(cell.source or "")
+        updated_source = self._merge_langgraph_imports(source, names_to_add)
+        if updated_source == source:
+            return []
 
-        Returns:
-            True if any repairs were made
-        """
-        # Extract missing sections from the report message
-        match = re.search(r"Missing required sections: (.+)", report.message)
-        if not match:
-            return False
+        cell.source = updated_source
+        sorted_names = sorted(
+            names_to_add,
+            key=lambda item: (_LANGGRAPH_IMPORT_ORDER.get(item, 99), item),
+        )
+        return [
+            "Added LangGraph imports to the setup section: "
+            + ", ".join(sorted_names)
+            + "."
+        ]
 
-        missing_sections_str = match.group(1)
-        missing_sections = [sec.strip() for sec in missing_sections_str.split(",")]
+    def _repair_sections(self, notebook: NotebookNode, report: QAReport) -> List[str]:
+        """Add missing required notebook sections with deterministic defaults."""
 
-        repaired = False
+        missing_sections = [
+            str(section).strip()
+            for section in (report.evidence.get("missing_sections") or [])
+            if str(section).strip()
+        ]
+        if not missing_sections:
+            match = re.search(r"Missing required sections: (.+)", report.message)
+            if match:
+                missing_sections = [
+                    item.strip() for item in match.group(1).split(",") if item.strip()
+                ]
+
+        fixes: List[str] = []
         for section in missing_sections:
-            section = section.strip()
+            if section == "graph":
+                code_source = _GRAPH_SCAFFOLD_TEMPLATE
+            elif section == "setup":
+                code_source = (
+                    "from pathlib import Path\n\nworkspace_dir = Path.cwd()\nworkspace_dir"
+                )
+            elif section == "config":
+                code_source = 'MODEL = "gpt-5-mini"\nMAX_ITERATIONS = 10'
+            elif section == "execution":
+                code_source = 'result = graph.invoke({})\nprint(result)'
+            else:
+                code_source = (
+                    f'section_status = "Recovered {section}"\nprint(section_status)'
+                )
+
             header_cell = nbformat.v4.new_markdown_cell(
                 source=f"## {section.title()}\n\nRecovered automatically during notebook repair."
             )
             header_cell.metadata["section"] = section
+            code_cell = nbformat.v4.new_code_cell(source=code_source)
+            code_cell.metadata["section"] = section
+            notebook.cells.extend([header_cell, code_cell])
+            fixes.append(f"Added missing '{section}' section with deterministic fallback content.")
 
-            code_templates = {
-                "setup": "from pathlib import Path\n\nworkspace_dir = Path.cwd()\nworkspace_dir",
-                "config": 'MODEL = "gpt-5-mini"\nMAX_ITERATIONS = 10',
-                "graph": (
-                    "from langgraph.graph import END, START, StateGraph\n\n"
-                    "workflow = StateGraph(dict)\n"
-                    "workflow.add_node(\"start\", lambda state: state)\n"
-                    "workflow.add_edge(START, \"start\")\n"
-                    "workflow.add_edge(\"start\", END)\n"
-                    "graph = workflow.compile()"
-                ),
-                "execution": 'result = graph.invoke({})\nprint(result)',
-            }
-            code_cell = nbformat.v4.new_code_cell(
-                source=code_templates.get(
-                    section,
-                    f'section_status = "Recovered {section}"\nprint(section_status)',
+        return fixes
+
+    def _repair_undefined_names(
+        self, notebook: NotebookNode, report: QAReport
+    ) -> List[str]:
+        """Apply close-match typo replacements for undefined notebook symbols."""
+
+        fixes: List[str] = []
+        issues = report.evidence.get("undefined_names") or []
+        for issue in issues:
+            if not isinstance(issue, dict):
+                continue
+            suggestion = issue.get("suggestion")
+            name = issue.get("name")
+            cell_index = issue.get("cell_index")
+            if not isinstance(suggestion, str) or not isinstance(name, str):
+                continue
+            if not isinstance(cell_index, int) or not (0 <= cell_index < len(notebook.cells)):
+                continue
+
+            cell = notebook.cells[cell_index]
+            if cell.cell_type != "code":
+                continue
+
+            pattern = re.compile(rf"\b{re.escape(name)}\b")
+            updated_source, count = pattern.subn(suggestion, str(cell.source or ""))
+            if count > 0:
+                cell.source = updated_source
+                fixes.append(
+                    f"Replaced likely typo '{name}' with '{suggestion}' in code cell {cell_index}."
+                )
+
+        return fixes
+
+    def _repair_syntax(self, notebook: NotebookNode, report: QAReport) -> List[str]:
+        """Apply bounded deterministic syntax repairs based on validator evidence."""
+
+        syntax_error = report.evidence.get("syntax_error") or {}
+        if not isinstance(syntax_error, dict):
+            return []
+
+        cell_index = syntax_error.get("cell_index")
+        line_in_cell = syntax_error.get("line_in_cell")
+        message = str(syntax_error.get("message") or "")
+        if not isinstance(cell_index, int) or not isinstance(line_in_cell, int):
+            return []
+        if not (0 <= cell_index < len(notebook.cells)):
+            return []
+
+        cell = notebook.cells[cell_index]
+        if cell.cell_type != "code":
+            return []
+
+        lines = str(cell.source or "").splitlines()
+        target_index = line_in_cell - 1
+        if not (0 <= target_index < len(lines)):
+            return []
+
+        original_line = lines[target_index]
+        updated_line = self._repair_missing_colon(original_line, message)
+        if updated_line == original_line:
+            updated_line = self._repair_unclosed_delimiter(original_line, message)
+
+        if updated_line == original_line:
+            return []
+
+        lines[target_index] = updated_line
+        cell.source = "\n".join(lines)
+        return [
+            f"Applied bounded syntax repair in code cell {cell_index} at line {line_in_cell}."
+        ]
+
+    def _repair_graph_scaffold(
+        self, notebook: NotebookNode, report: QAReport
+    ) -> List[str]:
+        """Append a deterministic runnable graph scaffold when graph structure is incomplete."""
+
+        graph_cell = self._ensure_graph_code_cell(notebook)
+        source = str(graph_cell.source or "")
+        if _GRAPH_SCAFFOLD_MARKER in source:
+            return []
+
+        graph_cell.source = (
+            f"{source.rstrip()}\n\n{_GRAPH_SCAFFOLD_TEMPLATE}".strip()
+            if source.strip()
+            else _GRAPH_SCAFFOLD_TEMPLATE
+        )
+        return [
+            "Appended a deterministic LangGraph scaffold to recover missing graph wiring."
+        ]
+
+    def _repair_missing_colon(self, line: str, message: str) -> str:
+        """Append a trailing colon for obvious block starters when syntax evidence is clear."""
+
+        stripped = line.rstrip()
+        if stripped.endswith(":"):
+            return line
+
+        block_starter = re.match(
+            r"^\s*(if|elif|else|for|while|try|except|finally|with|def|class)\b",
+            stripped,
+        )
+        if not block_starter:
+            return line
+
+        if "expected ':'" in message or "invalid syntax" in message:
+            return f"{stripped}:"
+
+        return line
+
+    def _repair_unclosed_delimiter(self, line: str, message: str) -> str:
+        """Close a single obviously unclosed delimiter on the current source line."""
+
+        match = re.search(r"'([\(\[\{])' was never closed", message)
+        if not match:
+            return line
+
+        opener = match.group(1)
+        closer = {"(": ")", "[": "]", "{": "}"}[opener]
+        if line.count(opener) - line.count(closer) != 1:
+            return line
+        if line.rstrip().endswith(closer):
+            return line
+        return f"{line.rstrip()}{closer}"
+
+    def _ensure_setup_code_cell(self, notebook: NotebookNode) -> NotebookNode:
+        """Return the best setup/import code cell, creating one if necessary."""
+
+        for cell in notebook.cells:
+            if cell.cell_type == "code" and cell.metadata.get("section") == "setup":
+                return cell
+        for cell in notebook.cells:
+            if cell.cell_type == "code":
+                return cell
+
+        cell = nbformat.v4.new_code_cell(source="")
+        cell.metadata["section"] = "setup"
+        notebook.cells.insert(0, cell)
+        return cell
+
+    def _ensure_graph_code_cell(self, notebook: NotebookNode) -> NotebookNode:
+        """Return a graph-section code cell, creating one if necessary."""
+
+        for cell in notebook.cells:
+            if cell.cell_type == "code" and cell.metadata.get("section") == "graph":
+                return cell
+
+        graph_header = nbformat.v4.new_markdown_cell(
+            source="## Graph\n\nRecovered automatically during notebook repair."
+        )
+        graph_header.metadata["section"] = "graph"
+        graph_cell = nbformat.v4.new_code_cell(source="")
+        graph_cell.metadata["section"] = "graph"
+        notebook.cells.extend([graph_header, graph_cell])
+        return graph_cell
+
+    def _merge_langgraph_imports(self, source: str, names_to_add: set[str]) -> str:
+        """Merge LangGraph imports into the setup code without duplicating lines."""
+
+        lines = source.splitlines()
+        import_line_index = None
+        import_names: set[str] = set()
+        for index, line in enumerate(lines):
+            match = re.match(
+                r"^(\s*from\s+langgraph\.graph\s+import\s+)(.+)$",
+                line.strip(),
+            )
+            if not match:
+                continue
+            import_line_index = index
+            names = [
+                item.strip()
+                for item in match.group(2).split(",")
+                if item.strip()
+            ]
+            import_names.update(names)
+            break
+
+        import_names.update(names_to_add)
+        ordered_names = sorted(
+            import_names,
+            key=lambda item: (_LANGGRAPH_IMPORT_ORDER.get(item, 99), item),
+        )
+        import_line = f"from langgraph.graph import {', '.join(ordered_names)}"
+
+        if import_line_index is not None:
+            lines[import_line_index] = import_line
+            return "\n".join(lines).strip()
+
+        insert_at = 0
+        while insert_at < len(lines):
+            stripped = lines[insert_at].strip()
+            if not stripped or stripped.startswith("#") or stripped.startswith("import ") or stripped.startswith("from "):
+                insert_at += 1
+                continue
+            break
+
+        updated_lines = [*lines[:insert_at], import_line, *lines[insert_at:]]
+        return "\n".join(updated_lines).strip()
+
+    def _validate_cells(self, cells: Sequence[CellSpec]) -> List[QAReport]:
+        """Validate cells using the shared notebook validator."""
+
+        with TemporaryDirectory() as temp_dir:
+            notebook = self.notebook_builder.build_notebook(cells)
+            notebook_path = Path(temp_dir) / "repaired.ipynb"
+            self.notebook_builder.write(notebook, notebook_path)
+            return self.validator.validate_all(notebook_path)
+
+    def _clone_cells(self, cells: Sequence[CellSpec]) -> List[CellSpec]:
+        """Clone cell specs so repair attempts do not mutate caller-owned state."""
+
+        return [cell.model_copy(deep=True) for cell in cells]
+
+    def _cells_from_notebook(self, notebook: NotebookNode) -> List[CellSpec]:
+        """Convert an in-memory notebook into CellSpec entries."""
+
+        regenerated_cells: List[CellSpec] = []
+        for cell in notebook.cells:
+            metadata = dict(cell.metadata or {})
+            section = metadata.pop("section", None)
+            source = cell.source if isinstance(cell.source, str) else "".join(cell.source or [])
+            regenerated_cells.append(
+                CellSpec(
+                    cell_type=cell.cell_type,
+                    content=source,
+                    metadata=metadata,
+                    section=section if isinstance(section, str) else None,
                 )
             )
-            code_cell.metadata["section"] = section
+        return regenerated_cells
 
-            nb.cells.extend([header_cell, code_cell])
-            repaired = True
+    def _report_key(self, report: QAReport) -> tuple[str, str, str, str]:
+        """Return a stable key for comparing report severity across attempts."""
 
-        return repaired
+        return (
+            report.rule_id,
+            report.check_name,
+            report.severity,
+            report.message,
+        )
 
-    def _repair_compilation(self, nb: NotebookNode, report: QAReport) -> bool:
-        """Fix compilation issues in the notebook.
+    def _is_non_regressive(
+        self,
+        baseline_reports: Sequence[QAReport],
+        candidate_reports: Sequence[QAReport],
+    ) -> bool:
+        """Accept candidates that improve or safely preserve validation severity."""
 
-        Args:
-            nb: Notebook to repair
-            report: QA report with compilation issues
+        baseline_failed = [report for report in baseline_reports if not report.passed]
+        candidate_failed = [report for report in candidate_reports if not report.passed]
+        if len(candidate_failed) < len(baseline_failed):
+            return True
 
-        Returns:
-            True if any repairs were made
-        """
-        repaired = False
+        if len(candidate_failed) != len(baseline_failed):
+            return False
 
-        # Check for missing StateGraph construction
-        if "No StateGraph construction found" in report.message:
-            # Find the graph section or add it
-            graph_cell_idx = None
-            for idx, cell in enumerate(nb.cells):
-                if cell.metadata.get("section") == "graph":
-                    graph_cell_idx = idx
-                    break
+        baseline_errors = {
+            self._report_key(report)
+            for report in baseline_failed
+            if report.severity == "error"
+        }
+        candidate_errors = {
+            self._report_key(report)
+            for report in candidate_failed
+            if report.severity == "error"
+        }
+        return candidate_errors < baseline_errors
 
-            if graph_cell_idx is not None:
-                cell = nb.cells[graph_cell_idx]
-                if cell.cell_type == "code" and "StateGraph" not in cell.source:
-                    # Add minimal StateGraph construction
-                    graph_template = """
-from langgraph.graph import StateGraph, END
-from typing import TypedDict
+    def _validation_summary(
+        self,
+        baseline_reports: Sequence[QAReport],
+        candidate_reports: Sequence[QAReport],
+        *,
+        accepted: bool,
+        error: str | None = None,
+    ) -> Dict[str, Any]:
+        """Return a compact validation comparison for repair attempt evidence."""
 
-class WorkflowState(TypedDict):
-    messages: list
+        baseline_failed = [report for report in baseline_reports if not report.passed]
+        candidate_failed = [report for report in candidate_reports if not report.passed]
+        baseline_errors = [
+            report.check_name for report in baseline_failed if report.severity == "error"
+        ]
+        candidate_errors = [
+            report.check_name for report in candidate_failed if report.severity == "error"
+        ]
 
-graph = StateGraph(WorkflowState)
-
-def placeholder_node(state: WorkflowState):
-    return state
-
-graph.add_node("start", placeholder_node)
-graph.set_entry_point("start")
-graph.add_edge("start", END)
-graph = graph.compile()
-"""
-                    existing_source = cell.source or ""
-                    if existing_source.strip():
-                        # Preserve existing content and append the graph template
-                        cell.source = existing_source.rstrip() + "\n\n" + graph_template.strip()
-                    else:
-                        # Cell is effectively empty; safe to replace entirely
-                        cell.source = graph_template.strip()
-                    repaired = True
-
-        # Check for missing .compile() call
-        elif "Graph compilation step (.compile()) not found" in report.message:
-            # Find the last graph-related code cell
-            for idx in range(len(nb.cells) - 1, -1, -1):
-                cell = nb.cells[idx]
-                if cell.cell_type == "code" and "StateGraph" in cell.source:
-                    if ".compile()" not in cell.source:
-                        cell.source = cell.source.rstrip() + "\ngraph = graph.compile()"
-                        repaired = True
-                    break
-
-        return repaired
+        summary: Dict[str, Any] = {
+            "baseline_failed_checks": len(baseline_failed),
+            "candidate_failed_checks": len(candidate_failed),
+            "baseline_error_checks": baseline_errors,
+            "candidate_error_checks": candidate_errors,
+            "accepted": accepted,
+        }
+        if error:
+            summary["validation_error"] = error
+        return summary
 
     def should_retry(self, qa_reports: List[QAReport], attempt: int) -> bool:
-        """Determine if repair should be retried.
+        """Determine if repair should be retried."""
 
-        Args:
-            qa_reports: Current QA reports
-            attempt: Current attempt number (0-indexed)
-
-        Returns:
-            True if repair should be retried
-        """
         if attempt >= self.max_attempts:
             return False
 
-        failed_reports = [r for r in qa_reports if not r.passed]
+        failed_reports = [report for report in qa_reports if not report.passed]
         return len(failed_reports) > 0
 
     def get_repair_summary(self, qa_reports: List[QAReport]) -> Dict[str, Any]:
-        """Generate a summary of repair results.
+        """Generate a summary of repair results."""
 
-        Args:
-            qa_reports: Final QA reports after repair attempts
-
-        Returns:
-            Dictionary with repair summary
-        """
-        passed = [r for r in qa_reports if r.passed]
-        failed = [r for r in qa_reports if not r.passed]
+        passed = [report for report in qa_reports if report.passed]
+        failed = [report for report in qa_reports if not report.passed]
 
         return {
             "total_checks": len(qa_reports),
             "passed": len(passed),
             "failed": len(failed),
             "success_rate": len(passed) / len(qa_reports) if qa_reports else 0.0,
-            "failed_checks": [r.check_name for r in failed],
+            "failed_checks": [report.check_name for report in failed],
             "all_passed": len(failed) == 0,
         }
-

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -35,6 +35,7 @@ from langgraph_system_generator.generator.tool_registry import (
     ToolRegistry,
     get_tool_registry,
 )
+from langgraph_system_generator.qa.repair import RepairOutcome
 from langgraph_system_generator.generator.state import (
     ArchitectureSelectionResult,
     CellSpec,
@@ -44,6 +45,7 @@ from langgraph_system_generator.generator.state import (
     GraphDesignResult,
     GraphEdgeSpec,
     GraphNodeSpec,
+    QAReport,
     ToolSpec,
 )
 from langgraph_system_generator.utils.error_handling import GenerationError
@@ -150,6 +152,37 @@ async def test_qa_repair_agent_validate_uses_shared_notebook_validator(monkeypat
 
     assert graph_report.rule_id == "graph_structure"
     assert graph_report.passed is False
+
+
+@pytest.mark.asyncio
+async def test_qa_repair_agent_repair_delegates_to_shared_engine(monkeypatch):
+    monkeypatch.setattr(
+        qa_repair_agent,
+        "ChatOpenAI",
+        make_stub_llm("[]"),
+    )
+    repaired_cells = [CellSpec(cell_type="markdown", content="Updated", metadata={})]
+
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.agents.qa_repair_agent.NotebookRepairAgent.repair_cells",
+        lambda *_args, **_kwargs: RepairOutcome(
+            status="applied",
+            cells=repaired_cells,
+            qa_reports=[],
+            attempted_fixes=["Applied deterministic fix."],
+            persisted=True,
+            message="Repair candidate passed validation and was accepted.",
+            validation_summary={"accepted": True},
+        ),
+    )
+
+    agent = qa_repair_agent.QARepairAgent()
+    result = await agent.repair(
+        [CellSpec(cell_type="markdown", content="Original", metadata={})],
+        [QAReport(check_name="Undefined Names", passed=False, message="boom")],
+    )
+
+    assert result == repaired_cells
 
 
 def test_architecture_registry_preserves_zero_docs_weight_and_filters_unknown_patterns():

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -129,13 +129,7 @@ def test_architecture_registry_includes_builtin_architectures():
 
 
 @pytest.mark.asyncio
-async def test_qa_repair_agent_validate_uses_shared_notebook_validator(monkeypatch):
-    monkeypatch.setattr(
-        qa_repair_agent,
-        "ChatOpenAI",
-        make_stub_llm("[]"),
-    )
-
+async def test_qa_repair_agent_validate_uses_shared_notebook_validator():
     agent = qa_repair_agent.QARepairAgent()
     reports = await agent.validate(
         [
@@ -156,23 +150,22 @@ async def test_qa_repair_agent_validate_uses_shared_notebook_validator(monkeypat
 
 @pytest.mark.asyncio
 async def test_qa_repair_agent_repair_delegates_to_shared_engine(monkeypatch):
-    monkeypatch.setattr(
-        qa_repair_agent,
-        "ChatOpenAI",
-        make_stub_llm("[]"),
-    )
     repaired_cells = [CellSpec(cell_type="markdown", content="Updated", metadata={})]
+    captured_attempt: dict[str, int] = {"value": -1}
 
     monkeypatch.setattr(
         "langgraph_system_generator.generator.agents.qa_repair_agent.NotebookRepairAgent.repair_cells",
-        lambda *_args, **_kwargs: RepairOutcome(
-            status="applied",
-            cells=repaired_cells,
-            qa_reports=[],
-            attempted_fixes=["Applied deterministic fix."],
-            persisted=True,
-            message="Repair candidate passed validation and was accepted.",
-            validation_summary={"accepted": True},
+        lambda _self, _cells, _reports, attempt=0: (
+            captured_attempt.__setitem__("value", attempt)
+            or RepairOutcome(
+                status="applied",
+                cells=repaired_cells,
+                qa_reports=[],
+                attempted_fixes=["Applied deterministic fix."],
+                persisted=True,
+                message="Repair candidate passed validation and was accepted.",
+                validation_summary={"accepted": True},
+            )
         ),
     )
 
@@ -180,9 +173,11 @@ async def test_qa_repair_agent_repair_delegates_to_shared_engine(monkeypatch):
     result = await agent.repair(
         [CellSpec(cell_type="markdown", content="Original", metadata={})],
         [QAReport(check_name="Undefined Names", passed=False, message="boom")],
+        attempt=2,
     )
 
     assert result == repaired_cells
+    assert captured_attempt["value"] == 2
 
 
 def test_architecture_registry_preserves_zero_docs_weight_and_filters_unknown_patterns():
@@ -1687,7 +1682,6 @@ def test_architecture_selector_uses_request_scoped_model_config(monkeypatch):
     [
         (graph_designer, graph_designer.GraphDesigner),
         (toolchain_engineer, toolchain_engineer.ToolchainEngineer),
-        (qa_repair_agent, qa_repair_agent.QARepairAgent),
         (notebook_composer, notebook_composer.NotebookComposer),
     ],
 )
@@ -1720,3 +1714,28 @@ def test_other_agents_use_request_scoped_model_config(
         "base_url": "https://example.test/v1",
         "max_tokens": 512,
     }
+
+
+def test_qa_repair_agent_stays_lazy_about_llm_configuration(monkeypatch):
+    """QARepairAgent should preserve request-scoped config without eagerly constructing an LLM."""
+
+    captured_kwargs = {}
+
+    monkeypatch.setattr(
+        qa_repair_agent,
+        "ChatOpenAI",
+        make_capturing_llm(captured_kwargs),
+    )
+
+    agent = qa_repair_agent.QARepairAgent(
+        model_config=ModelConfig(
+            model="gpt-5.1",
+            temperature=0.3,
+            api_base="https://example.test/v1",
+            max_tokens=512,
+        )
+    )
+
+    assert captured_kwargs == {}
+    assert agent.model_config is not None
+    assert agent.model_config.api_base == "https://example.test/v1"

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -657,6 +657,7 @@ async def test_repair_node_success_refreshes_cells_and_appends_history(monkeypat
     assert len(result["qa_history"]) == len(existing_history) + 1
     assert result["qa_history"][-1].check_name == "Repair Attempt"
     assert result["qa_history"][-1].rule_id == "repair_attempt"
+    assert result["qa_history"][-1].attempt == 2
     assert result["qa_history"][-1].evidence["attempted_fixes"] == [
         "Applied deterministic fix."
     ]
@@ -710,6 +711,7 @@ async def test_repair_node_failure_keeps_cells_and_appends_history(monkeypatch):
     assert result["qa_reports"][0].attempt == 4
     assert len(result["qa_history"]) == len(existing_history) + 1
     assert result["qa_history"][-1].passed is False
+    assert result["qa_history"][-1].attempt == 4
     assert result["repair_attempts"] == 4
     assert result["qa_repair_feedback"].repair_attempts == 4
     assert result["qa_repair_feedback"].rollback_used is True

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -34,6 +34,7 @@ from langgraph_system_generator.generator.state import (
     QARepairFeedback,
     ToolPlanningFeedback,
 )
+from langgraph_system_generator.qa.repair import RepairOutcome
 from langgraph_system_generator.utils.config import GenerationConfig
 
 
@@ -618,12 +619,16 @@ async def test_repair_node_success_refreshes_cells_and_appends_history(monkeypat
     existing_history = [QAReport(check_name="Runtime Check", passed=False, message="boom")]
 
     monkeypatch.setattr(
-        "langgraph_system_generator.generator.nodes.NotebookRepairAgent.repair_notebook",
-        lambda *_args, **_kwargs: (True, updated_reports),
-    )
-    monkeypatch.setattr(
-        "langgraph_system_generator.generator.nodes._cells_from_notebook",
-        lambda *_args, **_kwargs: updated_cells,
+        "langgraph_system_generator.generator.nodes.NotebookRepairAgent.repair_cells",
+        lambda *_args, **_kwargs: RepairOutcome(
+            status="applied",
+            cells=updated_cells,
+            qa_reports=updated_reports,
+            attempted_fixes=["Applied deterministic fix."],
+            persisted=True,
+            message="Repair candidate passed validation and was accepted.",
+            validation_summary={"accepted": True},
+        ),
     )
 
     state = {
@@ -636,12 +641,25 @@ async def test_repair_node_success_refreshes_cells_and_appends_history(monkeypat
     }
     result = await repair_node(state)
 
-    assert result["generated_cells"] == updated_cells
+    managed_cells = [
+        cell for cell in result["generated_cells"] if cell.section != "qa_repair_summary"
+    ]
+    summary_cell = next(
+        cell for cell in result["generated_cells"] if cell.section == "qa_repair_summary"
+    )
+
+    assert managed_cells == updated_cells
+    assert "QA and Repair Summary" in summary_cell.content
+    assert "Applied a non-regressive deterministic repair." in summary_cell.content
     assert result["qa_reports"][0].check_name == "Fix"
     assert result["qa_reports"][0].stage == "static"
     assert result["qa_reports"][0].attempt == 2
     assert len(result["qa_history"]) == len(existing_history) + 1
     assert result["qa_history"][-1].check_name == "Repair Attempt"
+    assert result["qa_history"][-1].rule_id == "repair_attempt"
+    assert result["qa_history"][-1].evidence["attempted_fixes"] == [
+        "Applied deterministic fix."
+    ]
     assert result["repair_attempts"] == 2
     assert result["qa_repair_feedback"].repair_attempts == 2
     assert result["qa_repair_feedback"].unrepaired_failures == []
@@ -654,8 +672,18 @@ async def test_repair_node_failure_keeps_cells_and_appends_history(monkeypatch):
     existing_history = [QAReport(check_name="Runtime Check", passed=False, message="boom")]
 
     monkeypatch.setattr(
-        "langgraph_system_generator.generator.nodes.NotebookRepairAgent.repair_notebook",
-        lambda *_args, **_kwargs: (False, updated_reports),
+        "langgraph_system_generator.generator.nodes.NotebookRepairAgent.repair_cells",
+        lambda *_args, **_kwargs: RepairOutcome(
+            status="rolled_back",
+            cells=initial_cells,
+            qa_reports=updated_reports,
+            attempted_fixes=["Tried deterministic fix."],
+            rollback_used=True,
+            persisted=False,
+            message="Repair candidate was rolled back because it regressed or did not improve validation.",
+            next_steps=["Inspect the QA and Repair Summary cell before retrying."],
+            validation_summary={"accepted": False},
+        ),
     )
 
     state = {
@@ -668,7 +696,15 @@ async def test_repair_node_failure_keeps_cells_and_appends_history(monkeypatch):
     }
     result = await repair_node(state)
 
-    assert result["generated_cells"] == initial_cells
+    managed_cells = [
+        cell for cell in result["generated_cells"] if cell.section != "qa_repair_summary"
+    ]
+    summary_cell = next(
+        cell for cell in result["generated_cells"] if cell.section == "qa_repair_summary"
+    )
+
+    assert managed_cells == initial_cells
+    assert "Rolled back the repair candidate" in summary_cell.content
     assert result["qa_reports"][0].check_name == "Fix"
     assert result["qa_reports"][0].stage == "static"
     assert result["qa_reports"][0].attempt == 4
@@ -676,7 +712,8 @@ async def test_repair_node_failure_keeps_cells_and_appends_history(monkeypatch):
     assert result["qa_history"][-1].passed is False
     assert result["repair_attempts"] == 4
     assert result["qa_repair_feedback"].repair_attempts == 4
-    assert "Repair attempt did not resolve" in result["qa_repair_feedback"].warnings[-1]
+    assert result["qa_repair_feedback"].rollback_used is True
+    assert "rolled back after validation" in result["qa_repair_feedback"].warnings[-1]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_repair.py
+++ b/tests/unit/test_repair.py
@@ -1,14 +1,17 @@
-"""Tests for QA repair agent."""
+"""Tests for the shared QA repair engine."""
 
 from __future__ import annotations
 
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import nbformat
 import pytest
-from nbformat.v4 import new_code_cell, new_notebook
 
-from langgraph_system_generator.generator.state import QAReport
+from langgraph_system_generator.generator.state import CellSpec, QAReport
+from langgraph_system_generator.notebook.composer import (
+    NotebookComposer as NotebookFileComposer,
+)
 from langgraph_system_generator.qa.repair import NotebookRepairAgent
 from langgraph_system_generator.qa.validators import NotebookValidator
 
@@ -16,17 +19,101 @@ from langgraph_system_generator.qa.validators import NotebookValidator
 @pytest.fixture
 def tmp_notebook_path(tmp_path: Path) -> Path:
     """Create a temporary notebook path."""
+
     return tmp_path / "test_notebook.ipynb"
 
 
 @pytest.fixture
 def repair_agent() -> NotebookRepairAgent:
     """Create a repair agent for testing."""
+
     return NotebookRepairAgent(max_attempts=3)
+
+
+def _validate_cells(cells: list[CellSpec]) -> list[QAReport]:
+    """Validate cells using the shared notebook validator path."""
+
+    builder = NotebookFileComposer()
+    validator = NotebookValidator()
+    with TemporaryDirectory() as temp_dir:
+        notebook = builder.build_notebook(cells)
+        notebook_path = Path(temp_dir) / "generated.ipynb"
+        builder.write(notebook, notebook_path)
+        return validator.validate_all(notebook_path)
+
+
+def _valid_graph_cells(*, execution_content: str | None = None) -> list[CellSpec]:
+    """Return a minimal valid notebook cell set for repair-focused tests."""
+
+    return [
+        CellSpec(
+            cell_type="code",
+            content="from langgraph.graph import END, START, StateGraph\nfrom typing import TypedDict",
+            metadata={"section": "setup"},
+            section="setup",
+        ),
+        CellSpec(
+            cell_type="code",
+            content='config = {"configurable": {"thread_id": "demo"}}',
+            metadata={"section": "config"},
+            section="config",
+        ),
+        CellSpec(
+            cell_type="code",
+            content=(
+                "class WorkflowState(TypedDict, total=False):\n"
+                "    messages: list\n\n"
+                "workflow = StateGraph(WorkflowState)\n\n"
+                "def start_node(state: WorkflowState):\n"
+                "    return state\n\n"
+                "workflow.add_node('start', start_node)\n"
+                "workflow.add_edge(START, 'start')\n"
+                "workflow.add_edge('start', END)\n"
+                "graph = workflow.compile()"
+            ),
+            metadata={"section": "graph"},
+            section="graph",
+        ),
+        CellSpec(
+            cell_type="code",
+            content=execution_content or "result = graph.invoke({})\nprint(result)",
+            metadata={"section": "execution"},
+            section="execution",
+        ),
+        CellSpec(
+            cell_type="code",
+            content='output_data = {"result": "ok"}\noutput_data',
+            metadata={"section": "export"},
+            section="export",
+        ),
+        CellSpec(
+            cell_type="markdown",
+            content="Troubleshooting notes.",
+            metadata={"section": "troubleshooting"},
+            section="troubleshooting",
+        ),
+    ]
+
+
+def _joined_code(cells: list[CellSpec]) -> str:
+    """Return concatenated code cell content for easy assertions."""
+
+    return "\n".join(cell.content for cell in cells if cell.cell_type == "code")
+
+
+def _failed_report(reports: list[QAReport], rule_id: str) -> QAReport:
+    """Return the first failing report for the requested rule."""
+
+    return next(
+        report
+        for report in reports
+        if report.rule_id == rule_id and not report.passed
+    )
 
 
 def test_repair_agent_initialization():
     """Test repair agent initialization."""
+
     agent = NotebookRepairAgent(max_attempts=5)
     assert agent.max_attempts == 5
     assert isinstance(agent.validator, NotebookValidator)
@@ -34,204 +121,279 @@ def test_repair_agent_initialization():
 
 def test_repair_agent_default_max_attempts():
     """Test repair agent uses default max attempts."""
+
     agent = NotebookRepairAgent()
     assert agent.max_attempts == NotebookRepairAgent.DEFAULT_MAX_ATTEMPTS
 
 
-def test_repair_placeholders(tmp_notebook_path: Path, repair_agent):
-    """Test repairing placeholders in notebook."""
-    nb = new_notebook()
-    nb.cells.append(new_code_cell(source="# TODO: implement\nx = 1\n# FIXME: broken"))
+def test_repair_cells_removes_placeholders_and_accepts_candidate(repair_agent):
+    """Placeholder cleanup should remove marker content without dropping real code."""
 
-    with tmp_notebook_path.open("w") as f:
-        nbformat.write(nb, f)
+    cells = _valid_graph_cells(
+        execution_content="# TODO: implement\nvalue = 1\n# FIXME: remove placeholder"
+    )
+    reports = _validate_cells(cells)
+    placeholder_report = _failed_report(reports, "placeholder_content")
 
-    # Create a QA report indicating placeholder issue
-    qa_reports = [
-        QAReport(
-            check_name="No Placeholders",
-            passed=False,
-            message="Found placeholders: TODO, FIXME",
-            suggestions=["Remove placeholders"],
-        )
-    ]
+    outcome = repair_agent.repair_cells(cells, [placeholder_report])
 
-    success, new_reports = repair_agent.repair_notebook(tmp_notebook_path, qa_reports)
-
-    # Verify repair was attempted
-    assert success or len(new_reports) > 0
-
-    # Read the repaired notebook
-    with tmp_notebook_path.open("r") as f:
-        repaired_nb = nbformat.read(f, as_version=4)
-
-    # Check that placeholders were removed
-    content = repaired_nb.cells[0].source
-    assert "TODO" not in content
-    assert "FIXME" not in content
-    assert "x = 1" in content  # Code should remain
+    assert outcome.success is True
+    code = _joined_code(outcome.cells)
+    assert "TODO" not in code
+    assert "FIXME" not in code
+    assert "value = 1" in code
+    assert all(report.passed for report in outcome.qa_reports)
 
 
-def test_repair_placeholders_ellipsis(tmp_notebook_path: Path, repair_agent):
-    """Test repairing ellipsis placeholders."""
-    nb = new_notebook()
-    nb.cells.append(new_code_cell(source="def func():\n    ...\n    pass"))
+def test_repair_cells_adds_missing_langgraph_imports(repair_agent):
+    """Import repair should restore missing LangGraph imports in the setup section."""
 
-    with tmp_notebook_path.open("w") as f:
-        nbformat.write(nb, f)
-
-    qa_reports = [
-        QAReport(
-            check_name="No Placeholders",
-            passed=False,
-            message="Found placeholders: ... (1x)",
-            suggestions=["Remove ellipsis"],
-        )
-    ]
-
-    success, new_reports = repair_agent.repair_notebook(tmp_notebook_path, qa_reports)
-
-    # Verify repair was attempted
-    assert success or len(new_reports) > 0
-
-    with tmp_notebook_path.open("r") as f:
-        repaired_nb = nbformat.read(f, as_version=4)
-
-    # Ellipsis line should be removed
-    content = repaired_nb.cells[0].source
-    assert content.count("...") == 0
-
-
-def test_repair_imports(tmp_notebook_path: Path, repair_agent):
-    """Test adding missing imports."""
-    nb = new_notebook()
-    nb.cells.append(new_code_cell(source="x = 1"))
-
-    with tmp_notebook_path.open("w") as f:
-        nbformat.write(nb, f)
-
-    qa_reports = [
-        QAReport(
-            check_name="Required Imports",
-            passed=False,
-            message="Missing required imports: langgraph, StateGraph",
-            suggestions=["Add imports"],
-        )
-    ]
-
-    success, new_reports = repair_agent.repair_notebook(tmp_notebook_path, qa_reports)
-
-    # Verify repair was attempted
-    assert success or len(new_reports) > 0
-
-    with tmp_notebook_path.open("r") as f:
-        repaired_nb = nbformat.read(f, as_version=4)
-
-    content = repaired_nb.cells[0].source
-    assert "StateGraph" in content or "langgraph" in content
-
-
-def test_repair_sections(tmp_notebook_path: Path, repair_agent):
-    """Test adding missing sections."""
-    nb = new_notebook()
-    nb.cells.append(new_code_cell(source="x = 1", metadata={"section": "setup"}))
-
-    with tmp_notebook_path.open("w") as f:
-        nbformat.write(nb, f)
-
-    qa_reports = [
-        QAReport(
-            check_name="Required Sections",
-            passed=False,
-            message="Missing required sections: config, graph",
-            suggestions=["Add missing sections"],
-        )
-    ]
-
-    _success, _new_reports = repair_agent.repair_notebook(tmp_notebook_path, qa_reports)
-
-    with tmp_notebook_path.open("r") as f:
-        repaired_nb = nbformat.read(f, as_version=4)
-
-    sections = {cell.metadata.get("section") for cell in repaired_nb.cells}
-    assert "config" in sections
-    assert "graph" in sections
-
-
-def test_repair_compilation_missing_stategraph(tmp_notebook_path: Path, repair_agent):
-    """Test repairing missing StateGraph construction."""
-    nb = new_notebook()
-    nb.cells.append(new_code_cell(source="x = 1", metadata={"section": "graph"}))
-
-    with tmp_notebook_path.open("w") as f:
-        nbformat.write(nb, f)
-
-    qa_reports = [
-        QAReport(
-            check_name="Graph Compilation",
-            passed=False,
-            message="No StateGraph construction found in notebook",
-            suggestions=["Add StateGraph"],
-        )
-    ]
-
-    _success, _new_reports = repair_agent.repair_notebook(tmp_notebook_path, qa_reports)
-
-    with tmp_notebook_path.open("r") as f:
-        repaired_nb = nbformat.read(f, as_version=4)
-
-    # Find graph section
-    graph_cell = None
-    for cell in repaired_nb.cells:
-        if cell.metadata.get("section") == "graph" and cell.cell_type == "code":
-            graph_cell = cell
-            break
-
-    assert graph_cell is not None
-    # Verify StateGraph was added and existing code was preserved
-    assert "StateGraph" in graph_cell.source
-    assert "x = 1" in graph_cell.source  # Original code should be preserved
-
-
-def test_repair_compilation_missing_compile(tmp_notebook_path: Path, repair_agent):
-    """Test repairing missing .compile() call."""
-    nb = new_notebook()
-    nb.cells.append(
-        new_code_cell(
-            source="from langgraph.graph import StateGraph\ngraph = StateGraph(dict)",
+    cells = [
+        CellSpec(
+            cell_type="code",
+            content="from typing import TypedDict",
+            metadata={"section": "setup"},
+            section="setup",
+        ),
+        CellSpec(
+            cell_type="code",
+            content='config = {"configurable": {"thread_id": "demo"}}',
+            metadata={"section": "config"},
+            section="config",
+        ),
+        CellSpec(
+            cell_type="code",
+            content=(
+                "class WorkflowState(TypedDict, total=False):\n"
+                "    messages: list\n\n"
+                "workflow = StateGraph(WorkflowState)\n\n"
+                "def start_node(state: WorkflowState):\n"
+                "    return state\n\n"
+                "workflow.add_node('start', start_node)\n"
+                "workflow.add_edge(START, 'start')\n"
+                "workflow.add_edge('start', END)\n"
+                "graph = workflow.compile()"
+            ),
             metadata={"section": "graph"},
+            section="graph",
+        ),
+        CellSpec(
+            cell_type="code",
+            content="result = graph.invoke({})\nprint(result)",
+            metadata={"section": "execution"},
+            section="execution",
+        ),
+        CellSpec(
+            cell_type="code",
+            content='output_data = {"result": "ok"}\noutput_data',
+            metadata={"section": "export"},
+            section="export",
+        ),
+        CellSpec(
+            cell_type="markdown",
+            content="Troubleshooting notes.",
+            metadata={"section": "troubleshooting"},
+            section="troubleshooting",
+        ),
+    ]
+    reports = _validate_cells(cells)
+    import_report = _failed_report(reports, "required_import_symbols")
+
+    outcome = repair_agent.repair_cells(cells, reports)
+
+    assert outcome.success is True
+    setup_cell = next(cell for cell in outcome.cells if cell.section == "setup")
+    assert "from langgraph.graph import" in setup_cell.content
+    assert "StateGraph" in setup_cell.content
+    assert "START" in setup_cell.content
+    assert all(report.passed for report in outcome.qa_reports)
+
+
+def test_repair_cells_rebuilds_incomplete_graph_scaffold(repair_agent):
+    """Graph repair should append a deterministic scaffold for incomplete graphs."""
+
+    cells = [
+        CellSpec(
+            cell_type="code",
+            content="from typing import TypedDict",
+            metadata={"section": "setup"},
+            section="setup",
+        ),
+        CellSpec(
+            cell_type="code",
+            content='config = {"configurable": {"thread_id": "demo"}}',
+            metadata={"section": "config"},
+            section="config",
+        ),
+        CellSpec(
+            cell_type="code",
+            content="# TODO: graph scaffold\nworkflow = None",
+            metadata={"section": "graph"},
+            section="graph",
+        ),
+        CellSpec(
+            cell_type="code",
+            content="print('ready')",
+            metadata={"section": "execution"},
+            section="execution",
+        ),
+        CellSpec(
+            cell_type="code",
+            content='output_data = {"result": "ok"}\noutput_data',
+            metadata={"section": "export"},
+            section="export",
+        ),
+        CellSpec(
+            cell_type="markdown",
+            content="Troubleshooting notes.",
+            metadata={"section": "troubleshooting"},
+            section="troubleshooting",
+        ),
+    ]
+    reports = _validate_cells(cells)
+
+    outcome = repair_agent.repair_cells(cells, reports)
+
+    assert outcome.success is True
+    code = _joined_code(outcome.cells)
+    assert "Recovered deterministic graph scaffold" in code
+    assert "graph = recovered_workflow.compile()" in code
+    assert all(report.passed for report in outcome.qa_reports)
+
+
+def test_repair_cells_fixes_undefined_name_typos(repair_agent):
+    """Undefined-name repair should use validator suggestions for bounded typo fixes."""
+
+    cells = _valid_graph_cells(execution_content="result = grpah.invoke({})\nprint(result)")
+    reports = _validate_cells(cells)
+    undefined_report = _failed_report(reports, "undefined_names")
+
+    outcome = repair_agent.repair_cells(cells, [undefined_report])
+
+    assert outcome.success is True
+    code = _joined_code(outcome.cells)
+    assert "grpah" not in code
+    assert "graph.invoke({})" in code
+    assert all(report.passed for report in outcome.qa_reports)
+
+
+@pytest.mark.parametrize(
+    ("execution_content", "expected_fragment"),
+    [
+        ("if True\n    print(graph)", "if True:"),
+        ("print(1 + 2", "print(1 + 2)"),
+    ],
+)
+def test_repair_cells_applies_bounded_syntax_fixes(
+    repair_agent,
+    execution_content,
+    expected_fragment,
+):
+    """Syntax repair should handle unambiguous missing-colon and delimiter cases."""
+
+    cells = _valid_graph_cells(execution_content=execution_content)
+    reports = _validate_cells(cells)
+    syntax_report = _failed_report(reports, "python_syntax")
+
+    outcome = repair_agent.repair_cells(cells, [syntax_report])
+
+    assert outcome.success is True
+    code = _joined_code(outcome.cells)
+    assert expected_fragment in code
+    assert all(report.passed for report in outcome.qa_reports)
+
+
+def test_repair_cells_rolls_back_regressive_candidates(monkeypatch, repair_agent):
+    """A regressive repair candidate should be rejected and rolled back."""
+
+    cells = _valid_graph_cells(execution_content="result = grpah.invoke({})\nprint(result)")
+    baseline_reports = _validate_cells(cells)
+    regressive_reports = [
+        QAReport(
+            check_name="Python Syntax",
+            passed=False,
+            message="Syntax error in notebook code: invalid syntax at line 4",
+            rule_id="python_syntax",
+            severity="error",
+            category="syntax",
+            repairable=True,
+            suggestions=["Fix Python syntax errors before attempting execution."],
         )
+    ]
+    validate_calls = {"count": 0}
+
+    def fake_validate(_cells):
+        validate_calls["count"] += 1
+        return baseline_reports if validate_calls["count"] == 1 else regressive_reports
+
+    monkeypatch.setattr(repair_agent, "_validate_cells", fake_validate)
+    monkeypatch.setattr(
+        repair_agent,
+        "_apply_repairs",
+        lambda _notebook, _failed_reports: ["Applied synthetic deterministic fix."],
     )
 
-    with tmp_notebook_path.open("w") as f:
-        nbformat.write(nb, f)
+    outcome = repair_agent.repair_cells(cells, baseline_reports)
 
-    qa_reports = [
-        QAReport(
-            check_name="Graph Compilation",
-            passed=False,
-            message="Graph compilation step (.compile()) not found",
-            suggestions=["Add .compile()"],
-        )
-    ]
+    assert outcome.status == "rolled_back"
+    assert outcome.rollback_used is True
+    assert outcome.persisted is False
+    assert outcome.cells == cells
+    assert outcome.qa_reports == baseline_reports
+    assert outcome.validation_summary["accepted"] is False
 
-    _success, _new_reports = repair_agent.repair_notebook(tmp_notebook_path, qa_reports)
 
-    with tmp_notebook_path.open("r") as f:
-        repaired_nb = nbformat.read(f, as_version=4)
+def test_repair_cells_skips_unhandled_failures_without_claiming_success(repair_agent):
+    """Unhandled failures should be surfaced as skipped, not as successful repairs."""
 
-    content = repaired_nb.cells[0].source
-    assert ".compile()" in content
+    cells = _valid_graph_cells()
+    runtime_report = QAReport(
+        check_name="Runtime Check",
+        passed=False,
+        message="Runtime validation unavailable in this environment.",
+        rule_id="runtime_check",
+        severity="error",
+        category="runtime",
+        repairable=False,
+        suggestions=["Install a healthy notebook execution environment before retrying."],
+    )
+
+    outcome = repair_agent.repair_cells(cells, [runtime_report])
+
+    assert outcome.status == "skipped"
+    assert outcome.success is False
+    assert outcome.rollback_used is False
+    assert outcome.attempted_fixes == []
+    assert "No safe deterministic repair matched" in outcome.message
+    assert outcome.next_steps
+
+
+def test_repair_notebook_persists_accepted_repairs(tmp_notebook_path: Path, repair_agent):
+    """The legacy path adapter should write accepted in-memory repairs back to disk."""
+
+    builder = NotebookFileComposer()
+    cells = _valid_graph_cells(execution_content="result = grpah.invoke({})\nprint(result)")
+    notebook = builder.build_notebook(cells)
+    builder.write(notebook, tmp_notebook_path)
+    reports = repair_agent.validator.validate_all(tmp_notebook_path)
+
+    success, new_reports = repair_agent.repair_notebook(tmp_notebook_path, reports)
+
+    assert success is True
+    assert all(report.passed for report in new_reports)
+    with tmp_notebook_path.open("r", encoding="utf-8") as handle:
+        repaired_notebook = nbformat.read(handle, as_version=4)
+    code = "\n".join(cell.source for cell in repaired_notebook.cells if cell.cell_type == "code")
+    assert "grpah" not in code
+    assert "graph.invoke({})" in code
 
 
 def test_repair_notebook_all_passing(tmp_notebook_path: Path, repair_agent):
-    """Test repair when all checks pass (no repair needed)."""
-    nb = new_notebook()
-    nb.cells.append(new_code_cell(source="x = 1"))
+    """Repair should return success immediately when the caller reports no failures."""
 
-    with tmp_notebook_path.open("w") as f:
-        nbformat.write(nb, f)
-
+    builder = NotebookFileComposer()
+    notebook = builder.build_notebook(_valid_graph_cells())
+    builder.write(notebook, tmp_notebook_path)
     qa_reports = [
         QAReport(
             check_name="Test Check",
@@ -243,37 +405,26 @@ def test_repair_notebook_all_passing(tmp_notebook_path: Path, repair_agent):
 
     success, new_reports = repair_agent.repair_notebook(tmp_notebook_path, qa_reports)
 
-    # Should succeed immediately since no repairs needed
-    assert success
+    assert success is True
     assert new_reports == qa_reports
 
 
 def test_repair_notebook_max_attempts(tmp_notebook_path: Path):
     """Test repair respects max attempts."""
+
     agent = NotebookRepairAgent(max_attempts=2)
+    builder = NotebookFileComposer()
+    notebook = builder.build_notebook(_valid_graph_cells(execution_content="result = grpah.invoke({})"))
+    builder.write(notebook, tmp_notebook_path)
+    reports = agent.validator.validate_all(tmp_notebook_path)
 
-    nb = new_notebook()
-    nb.cells.append(new_code_cell(source="# TODO: implement"))
-
-    with tmp_notebook_path.open("w") as f:
-        nbformat.write(nb, f)
-
-    qa_reports = [
-        QAReport(
-            check_name="No Placeholders",
-            passed=False,
-            message="Found placeholders: TODO",
-            suggestions=["Remove TODO"],
-        )
-    ]
-
-    # Test with attempt at max
-    success, _ = agent.repair_notebook(tmp_notebook_path, qa_reports, attempt=2)
-    assert not success  # Should fail since at max attempts
+    success, _ = agent.repair_notebook(tmp_notebook_path, reports, attempt=2)
+    assert not success
 
 
 def test_repair_notebook_invalid_path(repair_agent):
     """Test repair with invalid notebook path."""
+
     qa_reports = [
         QAReport(
             check_name="Test",
@@ -284,7 +435,8 @@ def test_repair_notebook_invalid_path(repair_agent):
     ]
 
     success, new_reports = repair_agent.repair_notebook(
-        "/nonexistent/notebook.ipynb", qa_reports
+        "/nonexistent/notebook.ipynb",
+        qa_reports,
     )
 
     assert not success
@@ -293,6 +445,7 @@ def test_repair_notebook_invalid_path(repair_agent):
 
 def test_should_retry_within_limits(repair_agent):
     """Test should_retry returns True when within limits."""
+
     qa_reports = [
         QAReport(
             check_name="Test",
@@ -309,6 +462,7 @@ def test_should_retry_within_limits(repair_agent):
 
 def test_should_retry_at_max(repair_agent):
     """Test should_retry returns False at max attempts."""
+
     qa_reports = [
         QAReport(
             check_name="Test",
@@ -324,6 +478,7 @@ def test_should_retry_at_max(repair_agent):
 
 def test_should_retry_all_passing(repair_agent):
     """Test should_retry returns False when all checks pass."""
+
     qa_reports = [
         QAReport(
             check_name="Test",
@@ -338,6 +493,7 @@ def test_should_retry_all_passing(repair_agent):
 
 def test_get_repair_summary_all_passed(repair_agent):
     """Test repair summary with all checks passing."""
+
     qa_reports = [
         QAReport(check_name="Check1", passed=True, message="OK", suggestions=[]),
         QAReport(check_name="Check2", passed=True, message="OK", suggestions=[]),
@@ -355,6 +511,7 @@ def test_get_repair_summary_all_passed(repair_agent):
 
 def test_get_repair_summary_mixed_results(repair_agent):
     """Test repair summary with mixed results."""
+
     qa_reports = [
         QAReport(check_name="Check1", passed=True, message="OK", suggestions=[]),
         QAReport(check_name="Check2", passed=False, message="Error", suggestions=[]),
@@ -369,51 +526,3 @@ def test_get_repair_summary_mixed_results(repair_agent):
     assert summary["success_rate"] == pytest.approx(0.333, rel=0.01)
     assert summary["failed_checks"] == ["Check2", "Check3"]
     assert summary["all_passed"] is False
-
-
-def test_get_repair_summary_empty(repair_agent):
-    """Test repair summary with no reports."""
-    summary = repair_agent.get_repair_summary([])
-
-    assert summary["total_checks"] == 0
-    assert summary["passed"] == 0
-    assert summary["failed"] == 0
-    assert summary["success_rate"] == 0.0
-    assert summary["all_passed"] is True  # Vacuously true
-
-
-def test_integration_repair_cycle(tmp_notebook_path: Path, repair_agent):
-    """Test complete repair cycle with validation."""
-    # Create a notebook with multiple issues
-    nb = new_notebook()
-    nb.cells.append(
-        new_code_cell(
-            source="# TODO: implement\nx = 1",
-            metadata={"section": "setup"},
-        )
-    )
-
-    with tmp_notebook_path.open("w") as f:
-        nbformat.write(nb, f)
-
-    # Run initial validation
-    validator = NotebookValidator()
-    initial_reports = validator.validate_all(tmp_notebook_path)
-
-    # Some checks should fail
-    failed = [r for r in initial_reports if not r.passed]
-    assert len(failed) > 0
-
-    # Attempt repair
-    success, repaired_reports = repair_agent.repair_notebook(
-        tmp_notebook_path, initial_reports
-    )
-
-    # Check that some issues were fixed
-    repaired_failed = [r for r in repaired_reports if not r.passed]
-    assert len(repaired_failed) < len(failed)
-
-    # Get summary
-    summary = repair_agent.get_repair_summary(repaired_reports)
-    assert summary["total_checks"] > 0
-    assert summary["passed"] > 0

--- a/tests/unit/test_repair.py
+++ b/tests/unit/test_repair.py
@@ -145,6 +145,33 @@ def test_repair_cells_removes_placeholders_and_accepts_candidate(repair_agent):
     assert all(report.passed for report in outcome.qa_reports)
 
 
+def test_repair_placeholders_preserves_identifiers_and_literals(repair_agent):
+    """Placeholder cleanup should not mutate identifiers or literals that only contain marker text."""
+
+    notebook = nbformat.v4.new_notebook(
+        cells=[
+            nbformat.v4.new_code_cell(
+                source=(
+                    'method_TODO = 1\n'
+                    'payload = {"TODO": "keep"}\n'
+                    "value = method_TODO  # TODO: refine after smoke test\n"
+                    "# FIXME: remove placeholder"
+                )
+            )
+        ]
+    )
+    notebook.cells[0].metadata["section"] = "execution"
+
+    fixes = repair_agent._repair_placeholders(notebook)
+
+    repaired_source = str(notebook.cells[0].source)
+    assert fixes
+    assert "method_TODO = 1" in repaired_source
+    assert 'payload = {"TODO": "keep"}' in repaired_source
+    assert "# TODO" not in repaired_source
+    assert "# FIXME" not in repaired_source
+
+
 def test_repair_cells_adds_missing_langgraph_imports(repair_agent):
     """Import repair should restore missing LangGraph imports in the setup section."""
 
@@ -261,6 +288,54 @@ def test_repair_cells_rebuilds_incomplete_graph_scaffold(repair_agent):
     assert all(report.passed for report in outcome.qa_reports)
 
 
+def test_repair_sections_inserts_setup_at_start(repair_agent):
+    """Recovered setup sections should be inserted before dependent notebook cells."""
+
+    notebook = NotebookFileComposer().build_notebook(
+        [
+            CellSpec(
+                cell_type="markdown",
+                content="## Graph",
+                metadata={"section": "graph"},
+                section="graph",
+            ),
+            CellSpec(
+                cell_type="code",
+                content="graph = None",
+                metadata={"section": "graph"},
+                section="graph",
+            ),
+        ]
+    )
+    report = QAReport(
+        check_name="Required Sections",
+        passed=False,
+        message="Missing required sections: setup",
+        rule_id="required_sections",
+        severity="error",
+        category="structure",
+        repairable=True,
+        evidence={"missing_sections": ["setup"]},
+    )
+
+    fixes = repair_agent._repair_sections(notebook, report)
+
+    assert fixes == ["Added missing 'setup' section with deterministic fallback content."]
+    setup_indexes = [
+        index
+        for index, cell in enumerate(notebook.cells)
+        if cell.metadata.get("section") == "setup"
+    ]
+    graph_indexes = [
+        index
+        for index, cell in enumerate(notebook.cells)
+        if cell.metadata.get("section") == "graph"
+    ]
+    assert len(setup_indexes) >= 2
+    assert graph_indexes
+    assert max(setup_indexes[:2]) < min(graph_indexes)
+
+
 def test_repair_cells_fixes_undefined_name_typos(repair_agent):
     """Undefined-name repair should use validator suggestions for bounded typo fixes."""
 
@@ -275,6 +350,30 @@ def test_repair_cells_fixes_undefined_name_typos(repair_agent):
     assert "grpah" not in code
     assert "graph.invoke({})" in code
     assert all(report.passed for report in outcome.qa_reports)
+
+
+def test_repair_cells_fixes_undefined_name_typos_with_interleaved_markdown(repair_agent):
+    """Undefined-name repair should map validator code-cell indexes back to notebook cells."""
+
+    cells = _valid_graph_cells(execution_content="result = grpah.invoke({})\nprint(result)")
+    cells.insert(
+        3,
+        CellSpec(
+            cell_type="markdown",
+            content="Execution follows below.",
+            metadata={"section": "notes"},
+            section="notes",
+        ),
+    )
+    reports = _validate_cells(cells)
+    undefined_report = _failed_report(reports, "undefined_names")
+
+    outcome = repair_agent.repair_cells(cells, [undefined_report])
+
+    assert outcome.success is True
+    execution_cell = next(cell for cell in outcome.cells if cell.section == "execution")
+    assert "grpah" not in execution_cell.content
+    assert "graph.invoke({})" in execution_cell.content
 
 
 @pytest.mark.parametrize(
@@ -356,6 +455,7 @@ def test_repair_cells_skips_unhandled_failures_without_claiming_success(repair_a
         category="runtime",
         repairable=False,
         suggestions=["Install a healthy notebook execution environment before retrying."],
+        stage="runtime",
     )
 
     outcome = repair_agent.repair_cells(cells, [runtime_report])
@@ -366,6 +466,26 @@ def test_repair_cells_skips_unhandled_failures_without_claiming_success(repair_a
     assert outcome.attempted_fixes == []
     assert "No safe deterministic repair matched" in outcome.message
     assert outcome.next_steps
+    assert any(report.check_name == "Runtime Check" for report in outcome.qa_reports)
+    assert any(report.stage == "runtime" for report in outcome.qa_reports if not report.passed)
+
+
+def test_cells_from_notebook_preserves_list_source_line_boundaries(repair_agent):
+    """List-backed notebook sources should round-trip with intact line boundaries."""
+
+    notebook = nbformat.v4.new_notebook(
+        cells=[
+            nbformat.v4.new_code_cell(source=["value = 1", "print(value)"]),
+            nbformat.v4.new_markdown_cell(source=["## Summary", "Line two"]),
+        ]
+    )
+    notebook.cells[0].metadata["section"] = "execution"
+    notebook.cells[1].metadata["section"] = "summary"
+
+    regenerated = repair_agent._cells_from_notebook(notebook)
+
+    assert regenerated[0].content == "value = 1\nprint(value)"
+    assert regenerated[1].content == "## Summary\nLine two"
 
 
 def test_repair_notebook_persists_accepted_repairs(tmp_notebook_path: Path, repair_agent):


### PR DESCRIPTION
## Summary
- replace the split QA repair flow with a shared deterministic in-memory repair engine
- make `QARepairAgent.repair()` and `repair_node` use the shared repair outcome contract with validation and rollback
- surface repair outcomes in notebook-visible `QA and Repair Summary` cells plus richer `qa_history` evidence

## Testing
- python -m pytest tests/unit/test_repair.py tests/unit/test_generator_agents.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py tests/unit/test_validators.py -q
- python -m pytest tests/unit -q
- python -m pytest --asyncio-mode=auto -q
- python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

Closes #174
Closes #176
