### PR TITLE
Complete QARepairAgent registry and regressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,23 @@ aligned when changing notebook assembly behavior:
 - surface deterministic fallbacks through visible notebook comments plus
   `notebook_composition_feedback` instead of silently dropping into placeholders
 
+### QARepairAgent-specific expectations
+
+The canonical QA/repair engine lives under `src/langgraph_system_generator/qa/`.
+`generator/agents/qa_repair_agent.py` should stay a runtime-facing facade over
+that shared engine, not a second repair implementation.
+
+- register validation rules and deterministic repair routines through
+  `src/langgraph_system_generator/qa/registry.py`
+- load internal QA/repair extensions with `QA_REPAIR_PLUGIN_MODULES`; plugin
+  modules must expose `register_qa_repair_plugins(registry)`
+- keep `qa_reports`, `qa_history`, `repair_attempts`, and
+  `qa_repair_feedback` stable for CLI/API/manifest consumers
+- validate repair candidates in memory first, persist only non-regressive
+  results, and keep rollback/no-op outcomes visible in `qa_history`
+- prefer bounded deterministic repairs over free-form rewrites, especially in
+  stub mode and CI-facing tests
+
 ### Minimal runtime-agent skeleton
 
 Use the existing agents as the style reference.

--- a/docs/wiki/Architecture-Deep-Dive.md
+++ b/docs/wiki/Architecture-Deep-Dive.md
@@ -322,7 +322,9 @@ mode it is recorded as non-blocking runtime evidence.
 **Input**: Notebook + Failed QA reports  
 **Output**: Repaired notebook
 
-If QA fails, attempts to repair the notebook:
+If QA fails, the shared QA/repair engine applies registered deterministic repair
+routines in memory, revalidates the candidate notebook, and persists the repair
+only when validation is non-regressive:
 
 ```python
 {
@@ -333,19 +335,26 @@ If QA fails, attempts to repair the notebook:
   "qa_history": [
     # ... prior static/runtime reports ...,
     {"check_name": "Repair Attempt", "stage": "repair", "passed": false}
-  ]
+  ],
+  "qa_repair_feedback": {
+    "repair_attempts": 1,
+    "rollback_used": true,
+    "unrepaired_failures": ["Python Syntax: invalid syntax"],
+    "next_steps": ["Inspect the QA and Repair Summary cell before retrying."]
+  }
 }
 ```
 
 **Repair Strategy**:
 1. Identify specific failures
-2. Generate targeted fixes
-3. Apply fixes to notebook
-4. Re-run QA validation
-5. Repeat up to `MAX_REPAIR_ATTEMPTS` (default: 3)
+2. Select matching routines from `QARepairRegistry`
+3. Apply fixes to an in-memory notebook candidate
+4. Re-run QA validation and accept only non-regressive candidates
+5. Record rollback/no-op outcomes in `qa_history` and `qa_repair_feedback`
 
 **Component**: `NotebookRepairAgent`  
-**LLM-Powered**: Yes (live mode only)
+**LLM-Powered**: No; repair is deterministic and registry-backed in both stub
+and live-compatible paths
 
 #### 10. Package Outputs
 **Input**: Final notebook  
@@ -440,7 +449,7 @@ Each pipeline stage has a dedicated agent:
 | `GraphDesigner` | Design workflow structure | Live mode |
 | `ToolchainEngineer` | Plan required tools | Live mode |
 | `NotebookComposer` | Generate notebook cells | Live mode |
-| `QARepairAgent` | Fix validation failures | Live mode |
+| `QARepairAgent` | Orchestrate deterministic QA repairs | No |
 
 ### Support Components
 
@@ -450,6 +459,7 @@ Each pipeline stage has a dedicated agent:
 | `VectorStoreManager` | FAISS index management |
 | `DocumentCache` | Cached documentation storage |
 | `NotebookValidator` | Static & runtime validation |
+| `QARepairRegistry` | Internal validator and repair routine registry |
 | `NotebookExporter` | Multi-format export |
 | `PatternLibrary` | Reusable pattern templates |
 
@@ -573,19 +583,20 @@ All patterns are:
 |-------|------|-------------|
 | `json_structure` | Static | Valid notebook JSON |
 | `required_sections` | Static | All sections present |
-| `no_placeholders` | Static | No TODO/placeholder text |
-| `imports_present` | Static | Required imports included |
-| `graph_compiles` | Runtime | Code syntax validation |
+| `placeholder_content` | Static | No TODO/placeholder text |
+| `required_import_symbols` | Static | Required imports included |
+| `python_syntax` | Static | Code syntax validation |
+| `graph_structure` | Static | Parsed graph construction and terminal path validation |
 
 ### Repair Strategies
 
 When QA fails, the repair agent:
 
 1. **Analyzes failures**: Categorizes error types
-2. **Generates fixes**: Creates targeted repairs
-3. **Applies patches**: Updates specific cells
-4. **Validates**: Re-runs QA checks
-5. **Iterates**: Repeats if needed (max 3 attempts)
+2. **Selects routines**: Uses `QARepairRegistry` to find matching deterministic fixes
+3. **Applies candidates**: Updates in-memory notebook cells first
+4. **Validates**: Re-runs QA checks before accepting the candidate
+5. **Rolls back safely**: Keeps the original cells if the candidate regresses
 
 ### Best-Effort Fallback
 
@@ -656,6 +667,9 @@ class Settings(BaseSettings):
     max_repair_attempts: int = 3
     default_budget_tokens: int = 100000
     graph_designer_plugin_modules: list[str] = []
+    notebook_composer_plugin_modules: list[str] = []
+    toolchain_engineer_plugin_modules: list[str] = []
+    qa_repair_plugin_modules: list[str] = []
     
     # LangSmith
     langsmith_project: Optional[str] = None
@@ -703,21 +717,35 @@ workflow.add_edge("custom_analysis", "rag_retrieval")
 app = workflow.compile()
 ```
 
-### Custom Validators
+### Internal QA/Repair Plugins
 
-Add validation checks:
+Register internal validation rules or repair routines without editing the core
+QA modules by setting `QA_REPAIR_PLUGIN_MODULES` to one or more dotted module
+paths. Each module should expose `register_qa_repair_plugins(registry)`:
 
 ```python
-from langgraph_system_generator.qa.validators import NotebookValidator
+from langgraph_system_generator.qa.registry import RepairRoutineRegistration
+from langgraph_system_generator.qa.validators import QAValidationRule
 
-class CustomValidator(NotebookValidator):
-    def check_custom_requirement(self, notebook_path):
-        # Your validation logic
-        return QAReport(
-            check_name="custom_check",
-            passed=True,
-            message="Custom check passed"
+
+class CustomRule(QAValidationRule):
+    rule_id = "custom_rule"
+    check_name = "Custom Rule"
+    category = "custom"
+
+    def validate(self, context):
+        return self.passed_report("Custom rule passed.")
+
+
+def register_qa_repair_plugins(registry):
+    registry.register_validator(CustomRule())
+    registry.register_repair_routine(
+        RepairRoutineRegistration(
+            routine_id="custom_repair",
+            handled_rule_ids=("custom_rule",),
+            handler=lambda agent, notebook, report: [],
         )
+    )
 ```
 
 ## Performance Characteristics

--- a/docs/wiki/CLI-and-API-Reference.md
+++ b/docs/wiki/CLI-and-API-Reference.md
@@ -124,6 +124,12 @@ The CLI respects these environment variables:
 | `DEFAULT_BUDGET_TOKENS` | Token budget | `100000` |
 | `LNF_OUTPUT_BASE` | Base output directory | `.` |
 | `GRAPH_DESIGNER_PLUGIN_MODULES` | Extra graph designer registry modules | None |
+| `QA_REPAIR_PLUGIN_MODULES` | Extra QA/repair registry modules | None |
+
+`QA_REPAIR_PLUGIN_MODULES` is an internal extension hook. Provide a JSON array
+or comma-separated list of dotted module paths; each module must expose
+`register_qa_repair_plugins(registry)` and may register validator rules or
+deterministic repair routines without adding new CLI/API request fields.
 
 ### Exit Codes
 

--- a/src/langgraph_system_generator/qa/__init__.py
+++ b/src/langgraph_system_generator/qa/__init__.py
@@ -1,7 +1,18 @@
 """QA and repair tooling for notebook validation and fixing."""
 
+from langgraph_system_generator.qa.registry import (
+    QARepairRegistry,
+    RepairRoutineRegistration,
+    get_qa_repair_registry,
+)
 from langgraph_system_generator.qa.repair import NotebookRepairAgent
 from langgraph_system_generator.qa.validators import NotebookValidator
 
-__all__ = ["NotebookValidator", "NotebookRepairAgent"]
+__all__ = [
+    "NotebookValidator",
+    "NotebookRepairAgent",
+    "QARepairRegistry",
+    "RepairRoutineRegistration",
+    "get_qa_repair_registry",
+]
 

--- a/src/langgraph_system_generator/qa/registry.py
+++ b/src/langgraph_system_generator/qa/registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, List, Sequence
+from typing import Callable, Iterable, List, Protocol, Sequence
 
 from nbformat import NotebookNode
 
@@ -21,7 +21,47 @@ from langgraph_system_generator.qa.validators import (
 )
 from langgraph_system_generator.utils.config import settings
 
-RepairRoutineCallable = Callable[[Any, NotebookNode, QAReport], List[str]]
+
+class SupportsRepairRoutineHandler(Protocol):
+    """Structural typing contract for deterministic repair handlers."""
+
+    def _repair_placeholders(self, notebook: NotebookNode) -> List[str]: ...
+
+    def _repair_sections(
+        self,
+        notebook: NotebookNode,
+        report: QAReport,
+    ) -> List[str]: ...
+
+    def _repair_imports(
+        self,
+        notebook: NotebookNode,
+        report: QAReport,
+    ) -> List[str]: ...
+
+    def _repair_undefined_names(
+        self,
+        notebook: NotebookNode,
+        report: QAReport,
+    ) -> List[str]: ...
+
+    def _repair_syntax(
+        self,
+        notebook: NotebookNode,
+        report: QAReport,
+    ) -> List[str]: ...
+
+    def _repair_graph_scaffold(
+        self,
+        notebook: NotebookNode,
+        report: QAReport,
+    ) -> List[str]: ...
+
+
+RepairRoutineCallable = Callable[
+    [SupportsRepairRoutineHandler, NotebookNode, QAReport],
+    List[str],
+]
 
 
 @dataclass(frozen=True)
@@ -80,7 +120,12 @@ class QARepairRegistry:
             else build_default_validator_registry()
         )
         self._repair_routines: dict[str, RepairRoutineRegistration] = {}
-        for routine in repair_routines or build_default_repair_routines():
+        routines = (
+            build_default_repair_routines()
+            if repair_routines is None
+            else repair_routines
+        )
+        for routine in routines:
             self.register_repair_routine(routine)
 
     def clone(self) -> "QARepairRegistry":
@@ -217,7 +262,7 @@ def build_default_repair_routines() -> List[RepairRoutineRegistration]:
 
 
 def get_qa_repair_registry(
-    plugin_modules: Sequence[str] | None = None,
+    plugin_modules: Sequence[str] | str | None = None,
 ) -> QARepairRegistry:
     """Build the QA/repair registry and load configured internal plugins."""
 
@@ -231,7 +276,7 @@ def get_qa_repair_registry(
 
 def _load_plugin_modules(
     registry: QARepairRegistry,
-    plugin_modules: Sequence[str] | None,
+    plugin_modules: Sequence[str] | str | None,
 ) -> None:
     """Load QA/repair plugin modules into the registry."""
 
@@ -261,13 +306,17 @@ def _load_plugin_modules(
             ) from exc
 
 
-def _normalize_plugin_modules(plugin_modules: Sequence[str] | None) -> List[str]:
+def _normalize_plugin_modules(
+    plugin_modules: Sequence[str] | str | None,
+) -> List[str]:
     """Return de-duplicated plugin module names."""
 
+    if isinstance(plugin_modules, str):
+        plugin_modules = [plugin_modules]
     normalized: List[str] = []
-    for raw_module in plugin_modules or []:
-        module_name = str(raw_module).strip()
-        if module_name and module_name not in normalized:
-            normalized.append(module_name)
+    for raw_item in plugin_modules or []:
+        for raw_module in str(raw_item).split(","):
+            module_name = raw_module.strip()
+            if module_name and module_name not in normalized:
+                normalized.append(module_name)
     return normalized
-

--- a/src/langgraph_system_generator/qa/registry.py
+++ b/src/langgraph_system_generator/qa/registry.py
@@ -1,0 +1,273 @@
+"""Internal registry for QA validation rules and deterministic repair routines."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, List, Sequence
+
+from nbformat import NotebookNode
+
+from langgraph_system_generator.generator.state import QAReport
+from langgraph_system_generator.qa.validators import (
+    GraphStructureRule,
+    PlaceholderRule,
+    PythonSyntaxRule,
+    QAValidationRule,
+    RequiredImportsRule,
+    RequiredSectionsRule,
+    UndefinedNameRule,
+    ValidatorRegistry,
+)
+from langgraph_system_generator.utils.config import settings
+
+RepairRoutineCallable = Callable[[Any, NotebookNode, QAReport], List[str]]
+
+
+@dataclass(frozen=True)
+class RepairRoutineRegistration:
+    """Registered deterministic repair routine metadata."""
+
+    routine_id: str
+    handled_rule_ids: Sequence[str]
+    handler: RepairRoutineCallable
+    description: str = ""
+    handled_check_names: Sequence[str] = ()
+
+    def normalized(self) -> "RepairRoutineRegistration":
+        """Return a normalized registration with validated identifiers."""
+
+        routine_id = self.routine_id.strip()
+        handled_rule_ids = tuple(
+            dict.fromkeys(rule_id.strip() for rule_id in self.handled_rule_ids if rule_id.strip())
+        )
+        handled_check_names = tuple(
+            dict.fromkeys(
+                check_name.strip()
+                for check_name in self.handled_check_names
+                if check_name.strip()
+            )
+        )
+        if not routine_id:
+            raise ValueError("Repair routine registrations require a non-empty routine_id.")
+        if not handled_rule_ids and not handled_check_names:
+            raise ValueError(
+                f"Repair routine '{routine_id}' must handle at least one rule id or check name."
+            )
+        if not callable(self.handler):
+            raise ValueError(f"Repair routine '{routine_id}' handler must be callable.")
+        return RepairRoutineRegistration(
+            routine_id=routine_id,
+            handled_rule_ids=handled_rule_ids,
+            handler=self.handler,
+            description=self.description.strip(),
+            handled_check_names=handled_check_names,
+        )
+
+
+class QARepairRegistry:
+    """Registry for internal QA validation rules and repair routines."""
+
+    def __init__(
+        self,
+        *,
+        validator_registry: ValidatorRegistry | None = None,
+        repair_routines: Iterable[RepairRoutineRegistration] | None = None,
+    ):
+        self._validator_registry = (
+            validator_registry.clone()
+            if validator_registry is not None
+            else build_default_validator_registry()
+        )
+        self._repair_routines: dict[str, RepairRoutineRegistration] = {}
+        for routine in repair_routines or build_default_repair_routines():
+            self.register_repair_routine(routine)
+
+    def clone(self) -> "QARepairRegistry":
+        """Return a shallow clone that preserves rule/routine state."""
+
+        return QARepairRegistry(
+            validator_registry=self._validator_registry,
+            repair_routines=list(self._repair_routines.values()),
+        )
+
+    def validator_registry(self) -> ValidatorRegistry:
+        """Return a clone of the validator-rule registry."""
+
+        return self._validator_registry.clone()
+
+    def register_validator(self, rule: QAValidationRule) -> QAValidationRule:
+        """Register or replace a validator rule."""
+
+        self._validator_registry.register(rule)
+        return rule
+
+    def disable_validator(self, rule_id: str) -> bool:
+        """Disable a validator rule by id, returning whether a rule was removed."""
+
+        return self._validator_registry.disable(rule_id)
+
+    def registered_validator_ids(self) -> List[str]:
+        """Return registered validator rule ids in execution order."""
+
+        return self._validator_registry.rule_ids()
+
+    def register_repair_routine(
+        self,
+        registration: RepairRoutineRegistration,
+    ) -> RepairRoutineRegistration:
+        """Register or replace a deterministic repair routine."""
+
+        normalized = registration.normalized()
+        self._repair_routines[normalized.routine_id] = normalized
+        return normalized
+
+    def disable_repair_routine(self, routine_id: str) -> bool:
+        """Disable a repair routine by id, returning whether one was removed."""
+
+        return self._repair_routines.pop(routine_id.strip(), None) is not None
+
+    def registered_repair_routine_ids(self) -> List[str]:
+        """Return registered repair routine ids in dispatch order."""
+
+        return list(self._repair_routines)
+
+    def repair_routines_for(self, report: QAReport) -> List[RepairRoutineRegistration]:
+        """Return repair routines that can handle the supplied QA report."""
+
+        matches: List[RepairRoutineRegistration] = []
+        for routine in self._repair_routines.values():
+            if report.rule_id in routine.handled_rule_ids:
+                matches.append(routine)
+                continue
+            if report.check_name in routine.handled_check_names:
+                matches.append(routine)
+        return matches
+
+
+def build_default_validator_registry() -> ValidatorRegistry:
+    """Create the default ordered validation registry."""
+
+    return ValidatorRegistry(
+        [
+            PlaceholderRule(
+                [
+                    "TODO",
+                    "FIXME",
+                    "PLACEHOLDER",
+                    "...",
+                    "# Your code here",
+                    "pass  # implement",
+                ]
+            ),
+            RequiredSectionsRule(["setup", "config", "graph", "execution"]),
+            RequiredImportsRule(["langgraph", "StateGraph", "END"]),
+            PythonSyntaxRule(),
+            UndefinedNameRule(),
+            GraphStructureRule(),
+        ]
+    )
+
+
+def build_default_repair_routines() -> List[RepairRoutineRegistration]:
+    """Create the default repair routine registrations."""
+
+    return [
+        RepairRoutineRegistration(
+            routine_id="placeholder_cleanup",
+            handled_rule_ids=("placeholder_content",),
+            handled_check_names=("No Placeholders",),
+            handler=lambda agent, notebook, _report: agent._repair_placeholders(notebook),
+            description="Remove deterministic placeholder markers from code cells.",
+        ),
+        RepairRoutineRegistration(
+            routine_id="required_sections",
+            handled_rule_ids=("required_sections",),
+            handled_check_names=("Required Sections",),
+            handler=lambda agent, notebook, report: agent._repair_sections(notebook, report),
+            description="Add deterministic fallback cells for missing required sections.",
+        ),
+        RepairRoutineRegistration(
+            routine_id="required_import_symbols",
+            handled_rule_ids=("required_import_symbols",),
+            handled_check_names=("Required Imports",),
+            handler=lambda agent, notebook, report: agent._repair_imports(notebook, report),
+            description="Merge missing LangGraph imports into the setup section.",
+        ),
+        RepairRoutineRegistration(
+            routine_id="undefined_name_typo",
+            handled_rule_ids=("undefined_names",),
+            handler=lambda agent, notebook, report: agent._repair_undefined_names(notebook, report),
+            description="Apply validator-provided close-match symbol replacements.",
+        ),
+        RepairRoutineRegistration(
+            routine_id="bounded_syntax",
+            handled_rule_ids=("python_syntax",),
+            handler=lambda agent, notebook, report: agent._repair_syntax(notebook, report),
+            description="Apply bounded deterministic syntax fixes.",
+        ),
+        RepairRoutineRegistration(
+            routine_id="graph_scaffold",
+            handled_rule_ids=("graph_structure",),
+            handled_check_names=("Graph Compilation",),
+            handler=lambda agent, notebook, report: agent._repair_graph_scaffold(notebook, report),
+            description="Append deterministic LangGraph scaffold when graph wiring is incomplete.",
+        ),
+    ]
+
+
+def get_qa_repair_registry(
+    plugin_modules: Sequence[str] | None = None,
+) -> QARepairRegistry:
+    """Build the QA/repair registry and load configured internal plugins."""
+
+    registry = QARepairRegistry()
+    _load_plugin_modules(
+        registry,
+        settings.qa_repair_plugin_modules if plugin_modules is None else plugin_modules,
+    )
+    return registry
+
+
+def _load_plugin_modules(
+    registry: QARepairRegistry,
+    plugin_modules: Sequence[str] | None,
+) -> None:
+    """Load QA/repair plugin modules into the registry."""
+
+    for module_name in _normalize_plugin_modules(plugin_modules):
+        try:
+            module = importlib.import_module(module_name)
+        except Exception as exc:  # pragma: no cover - exercised by plugin tests
+            raise ValueError(
+                f"Failed to import QA/repair plugin module '{module_name}': "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+
+        entrypoint = getattr(module, "register_qa_repair_plugins", None)
+        if not callable(entrypoint):
+            raise ValueError(
+                f"QA/repair plugin module '{module_name}' must define "
+                "register_qa_repair_plugins(registry)."
+            )
+
+        try:
+            entrypoint(registry)
+        except Exception as exc:
+            raise ValueError(
+                f"QA/repair plugin module '{module_name}' failed while running "
+                "register_qa_repair_plugins(registry): "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+
+
+def _normalize_plugin_modules(plugin_modules: Sequence[str] | None) -> List[str]:
+    """Return de-duplicated plugin module names."""
+
+    normalized: List[str] = []
+    for raw_module in plugin_modules or []:
+        module_name = str(raw_module).strip()
+        if module_name and module_name not in normalized:
+            normalized.append(module_name)
+    return normalized
+

--- a/src/langgraph_system_generator/qa/repair.py
+++ b/src/langgraph_system_generator/qa/repair.py
@@ -15,6 +15,10 @@ from langgraph_system_generator.generator.state import CellSpec, QAReport
 from langgraph_system_generator.notebook.composer import (
     NotebookComposer as NotebookFileComposer,
 )
+from langgraph_system_generator.qa.registry import (
+    QARepairRegistry,
+    get_qa_repair_registry,
+)
 from langgraph_system_generator.qa.validators import NotebookValidator
 
 _GRAPH_SCAFFOLD_MARKER = "# Recovered deterministic graph scaffold"
@@ -76,14 +80,19 @@ class NotebookRepairAgent:
 
     DEFAULT_MAX_ATTEMPTS = 3
 
-    def __init__(self, max_attempts: int = DEFAULT_MAX_ATTEMPTS):
+    def __init__(
+        self,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+        registry: QARepairRegistry | None = None,
+    ):
         """Initialize repair agent.
 
         Args:
             max_attempts: Maximum number of repair attempts before giving up
         """
         self.max_attempts = max_attempts
-        self.validator = NotebookValidator()
+        self.registry = registry.clone() if registry is not None else get_qa_repair_registry()
+        self.validator = NotebookValidator(registry=self.registry)
         self.notebook_builder = NotebookFileComposer()
 
     def repair_cells(
@@ -243,18 +252,8 @@ class NotebookRepairAgent:
 
         attempted_fixes: List[str] = []
         for report in failed_reports:
-            if report.rule_id == "placeholder_content" or report.check_name == "No Placeholders":
-                attempted_fixes.extend(self._repair_placeholders(notebook))
-            elif report.rule_id == "required_sections" or report.check_name == "Required Sections":
-                attempted_fixes.extend(self._repair_sections(notebook, report))
-            elif report.rule_id == "required_import_symbols" or report.check_name == "Required Imports":
-                attempted_fixes.extend(self._repair_imports(notebook, report))
-            elif report.rule_id == "undefined_names":
-                attempted_fixes.extend(self._repair_undefined_names(notebook, report))
-            elif report.rule_id == "python_syntax":
-                attempted_fixes.extend(self._repair_syntax(notebook, report))
-            elif report.rule_id == "graph_structure" or report.check_name == "Graph Compilation":
-                attempted_fixes.extend(self._repair_graph_scaffold(notebook, report))
+            for routine in self.registry.repair_routines_for(report):
+                attempted_fixes.extend(routine.handler(self, notebook, report))
 
         return list(dict.fromkeys(fix for fix in attempted_fixes if fix.strip()))
 

--- a/src/langgraph_system_generator/qa/validators.py
+++ b/src/langgraph_system_generator/qa/validators.py
@@ -9,7 +9,7 @@ import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 import nbformat
 from nbformat import NotebookNode
@@ -743,10 +743,20 @@ class ValidatorRegistry:
 
         self._rules[rule.rule_id] = rule
 
+    def disable(self, rule_id: str) -> bool:
+        """Disable a validation rule by id."""
+
+        return self._rules.pop(rule_id.strip(), None) is not None
+
     def get(self, rule_id: str) -> QAValidationRule:
         """Return a registered validation rule."""
 
         return self._rules[rule_id]
+
+    def rule_ids(self) -> List[str]:
+        """Return registered validation rule ids in execution order."""
+
+        return list(self._rules)
 
     def rules(self) -> List[QAValidationRule]:
         """Return the ordered list of registered validation rules."""
@@ -773,8 +783,21 @@ class NotebookValidator:
     REQUIRED_SECTIONS = ["setup", "config", "graph", "execution"]
     REQUIRED_IMPORTS = ["langgraph", "StateGraph", "END"]
 
-    def __init__(self, registry: ValidatorRegistry | None = None):
-        self.registry = registry.clone() if registry else self._build_default_registry()
+    def __init__(self, registry: ValidatorRegistry | Any | None = None):
+        if registry is None:
+            from langgraph_system_generator.qa.registry import get_qa_repair_registry
+
+            self.registry = get_qa_repair_registry().validator_registry()
+        elif hasattr(registry, "validator_registry") and callable(
+            registry.validator_registry
+        ):
+            self.registry = registry.validator_registry()
+        elif isinstance(registry, ValidatorRegistry):
+            self.registry = registry.clone()
+        else:
+            raise TypeError(
+                "NotebookValidator registry must be a ValidatorRegistry or QARepairRegistry."
+            )
 
     def _build_default_registry(self) -> ValidatorRegistry:
         """Create the default ordered validation registry."""

--- a/src/langgraph_system_generator/qa/validators.py
+++ b/src/langgraph_system_generator/qa/validators.py
@@ -9,7 +9,7 @@ import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence
+from typing import Dict, Iterable, List, Optional, Protocol, Sequence, runtime_checkable
 
 import nbformat
 from nbformat import NotebookNode
@@ -769,6 +769,13 @@ class ValidatorRegistry:
         return ValidatorRegistry(self.rules())
 
 
+@runtime_checkable
+class SupportsValidatorRegistry(Protocol):
+    """Structural typing contract for objects that can provide a validator registry."""
+
+    def validator_registry(self) -> ValidatorRegistry: ...
+
+
 class NotebookValidator:
     """Validates generated notebooks for quality and correctness."""
 
@@ -783,35 +790,23 @@ class NotebookValidator:
     REQUIRED_SECTIONS = ["setup", "config", "graph", "execution"]
     REQUIRED_IMPORTS = ["langgraph", "StateGraph", "END"]
 
-    def __init__(self, registry: ValidatorRegistry | Any | None = None):
+    def __init__(
+        self,
+        registry: ValidatorRegistry | SupportsValidatorRegistry | None = None,
+    ):
         if registry is None:
             from langgraph_system_generator.qa.registry import get_qa_repair_registry
 
             self.registry = get_qa_repair_registry().validator_registry()
-        elif hasattr(registry, "validator_registry") and callable(
-            registry.validator_registry
-        ):
-            self.registry = registry.validator_registry()
         elif isinstance(registry, ValidatorRegistry):
             self.registry = registry.clone()
+        elif isinstance(registry, SupportsValidatorRegistry):
+            self.registry = registry.validator_registry()
         else:
             raise TypeError(
-                "NotebookValidator registry must be a ValidatorRegistry or QARepairRegistry."
+                "NotebookValidator registry must be a ValidatorRegistry or implement "
+                "validator_registry()."
             )
-
-    def _build_default_registry(self) -> ValidatorRegistry:
-        """Create the default ordered validation registry."""
-
-        return ValidatorRegistry(
-            [
-                PlaceholderRule(self.PLACEHOLDER_PATTERNS),
-                RequiredSectionsRule(self.REQUIRED_SECTIONS),
-                RequiredImportsRule(self.REQUIRED_IMPORTS),
-                PythonSyntaxRule(),
-                UndefinedNameRule(),
-                GraphStructureRule(),
-            ]
-        )
 
     def _load_notebook(self, notebook_path: str | Path) -> NotebookNode:
         """Load a notebook from disk as v4."""

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -1,5 +1,8 @@
 """Additional tests for generator graph nodes with synthetic state inputs."""
 
+import sys
+import types
+
 import pytest
 
 from langgraph_system_generator.generator.agents import (
@@ -34,6 +37,11 @@ from langgraph_system_generator.generator.state import (
     QARepairFeedback,
     ToolPlanningFeedback,
 )
+from langgraph_system_generator.qa.registry import RepairRoutineRegistration
+from langgraph_system_generator.qa.validators import (
+    NotebookValidationContext,
+    QAValidationRule,
+)
 from langgraph_system_generator.qa.repair import RepairOutcome
 from langgraph_system_generator.utils.config import GenerationConfig
 
@@ -56,6 +64,71 @@ def make_stub_llm(content: str):
             return DummyResponse(self._content)
 
     return StubLLM
+
+
+class NodePluginMarkerRule(QAValidationRule):
+    """Synthetic plugin validator used by node integration tests."""
+
+    rule_id = "node_plugin_marker"
+    check_name = "Node Plugin Marker"
+    category = "custom"
+    failure_severity = "error"
+    repairable = True
+
+    def validate(self, context: NotebookValidationContext) -> QAReport:
+        content = "\n".join(str(cell.source or "") for cell in context.notebook.cells)
+        if "NODE_PLUGIN_BROKEN" in content:
+            return self.failed_report("Node plugin marker needs repair.")
+        return self.passed_report("Node plugin marker is absent.")
+
+
+def _valid_generated_cells(*, execution_content: str | None = None):
+    """Return a minimal valid generated cell set for node integration tests."""
+
+    return [
+        CellSpec(
+            cell_type="code",
+            content="from langgraph.graph import END, START, StateGraph\nfrom typing import TypedDict",
+            metadata={"section": "setup"},
+            section="setup",
+        ),
+        CellSpec(
+            cell_type="code",
+            content='config = {"configurable": {"thread_id": "demo"}}',
+            metadata={"section": "config"},
+            section="config",
+        ),
+        CellSpec(
+            cell_type="code",
+            content=(
+                "class WorkflowState(TypedDict, total=False):\n"
+                "    messages: list\n\n"
+                "workflow = StateGraph(WorkflowState)\n\n"
+                "def start_node(state: WorkflowState):\n"
+                "    return state\n\n"
+                "workflow.add_node('start', start_node)\n"
+                "workflow.add_edge(START, 'start')\n"
+                "workflow.add_edge('start', END)\n"
+                "graph = workflow.compile()"
+            ),
+            metadata={"section": "graph"},
+            section="graph",
+        ),
+        CellSpec(
+            cell_type="code",
+            content=execution_content or "result = graph.invoke({})\nprint(result)",
+            metadata={"section": "execution"},
+            section="execution",
+        ),
+    ]
+
+
+def _install_qa_plugin(module_name: str, register_func) -> None:
+    """Install an in-memory QA/repair plugin module."""
+
+    module = types.ModuleType(module_name)
+    module.register_qa_repair_plugins = register_func
+    sys.modules[module_name] = module
 
 
 @pytest.mark.asyncio
@@ -467,6 +540,35 @@ async def test_static_qa_node_surfaces_blocking_feedback(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_static_qa_node_uses_plugin_validators(monkeypatch):
+    module_name = "test_nodes_qa_plugin_validator"
+
+    def register(registry):
+        registry.register_validator(NodePluginMarkerRule())
+
+    _install_qa_plugin(module_name, register)
+    monkeypatch.setattr(
+        "langgraph_system_generator.qa.registry.settings.qa_repair_plugin_modules",
+        [module_name],
+    )
+
+    result = await static_qa_node(
+        {
+            "generated_cells": _valid_generated_cells(
+                execution_content='marker = "NODE_PLUGIN_BROKEN"\nprint(marker)'
+            ),
+            "qa_reports": [],
+            "repair_attempts": 0,
+        }
+    )
+
+    assert any(
+        report.rule_id == "node_plugin_marker" and not report.passed
+        for report in result["qa_reports"]
+    )
+
+
+@pytest.mark.asyncio
 async def test_runtime_qa_node_message_empty_cells():
     result = await runtime_qa_node(
         {
@@ -716,6 +818,72 @@ async def test_repair_node_failure_keeps_cells_and_appends_history(monkeypatch):
     assert result["qa_repair_feedback"].repair_attempts == 4
     assert result["qa_repair_feedback"].rollback_used is True
     assert "rolled back after validation" in result["qa_repair_feedback"].warnings[-1]
+
+
+@pytest.mark.asyncio
+async def test_repair_node_uses_plugin_repair_routines(monkeypatch):
+    module_name = "test_nodes_qa_plugin_repair"
+
+    def repair_marker(_agent, notebook, _report):
+        fixes = []
+        for cell in notebook.cells:
+            if cell.cell_type != "code":
+                continue
+            source = str(cell.source or "")
+            updated = source.replace("NODE_PLUGIN_BROKEN", "NODE_PLUGIN_REPAIRED")
+            if updated != source:
+                cell.source = updated
+                fixes.append("Repaired node plugin marker.")
+        return fixes
+
+    def register(registry):
+        registry.register_validator(NodePluginMarkerRule())
+        registry.register_repair_routine(
+            RepairRoutineRegistration(
+                routine_id="node_plugin_marker_repair",
+                handled_rule_ids=("node_plugin_marker",),
+                handler=repair_marker,
+            )
+        )
+
+    _install_qa_plugin(module_name, register)
+    monkeypatch.setattr(
+        "langgraph_system_generator.qa.registry.settings.qa_repair_plugin_modules",
+        [module_name],
+    )
+    cells = _valid_generated_cells(
+        execution_content='marker = "NODE_PLUGIN_BROKEN"\nprint(marker)'
+    )
+    report = QAReport(
+        check_name="Node Plugin Marker",
+        passed=False,
+        message="Node plugin marker needs repair.",
+        rule_id="node_plugin_marker",
+        severity="error",
+        category="custom",
+        repairable=True,
+    )
+
+    result = await repair_node(
+        {
+            "generated_cells": cells,
+            "qa_reports": [report],
+            "qa_history": [],
+            "repair_attempts": 0,
+        }
+    )
+
+    code = "\n".join(
+        cell.content
+        for cell in result["generated_cells"]
+        if cell.cell_type == "code"
+    )
+    assert "NODE_PLUGIN_BROKEN" not in code
+    assert "NODE_PLUGIN_REPAIRED" in code
+    assert result["qa_history"][-1].evidence["attempted_fixes"] == [
+        "Repaired node plugin marker."
+    ]
+    assert result["qa_repair_feedback"].unrepaired_failures == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_qa_repair_registry.py
+++ b/tests/unit/test_qa_repair_registry.py
@@ -1,0 +1,265 @@
+"""Tests for the internal QA/repair registry and plugin loader."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from langgraph_system_generator.generator.state import CellSpec, QAReport
+from langgraph_system_generator.notebook.composer import (
+    NotebookComposer as NotebookFileComposer,
+)
+from langgraph_system_generator.qa.registry import (
+    QARepairRegistry,
+    RepairRoutineRegistration,
+    get_qa_repair_registry,
+)
+from langgraph_system_generator.qa.repair import NotebookRepairAgent
+from langgraph_system_generator.qa.validators import (
+    NotebookValidationContext,
+    NotebookValidator,
+    QAValidationRule,
+)
+
+
+class CustomMarkerRule(QAValidationRule):
+    """Fail when a synthetic marker remains in notebook content."""
+
+    rule_id = "custom_marker"
+    check_name = "Custom Marker"
+    category = "custom"
+    failure_severity = "error"
+    repairable = True
+
+    def validate(self, context: NotebookValidationContext) -> QAReport:
+        content = "\n".join(str(cell.source or "") for cell in context.notebook.cells)
+        if "BROKEN_PLUGIN_MARKER" in content:
+            return self.failed_report(
+                "Custom marker was not repaired.",
+                evidence={"marker": "BROKEN_PLUGIN_MARKER"},
+            )
+        return self.passed_report("Custom marker is absent.")
+
+
+def _valid_graph_cells(*, execution_content: str | None = None) -> list[CellSpec]:
+    """Return a minimal valid notebook cell set for registry tests."""
+
+    return [
+        CellSpec(
+            cell_type="code",
+            content="from langgraph.graph import END, START, StateGraph\nfrom typing import TypedDict",
+            metadata={"section": "setup"},
+            section="setup",
+        ),
+        CellSpec(
+            cell_type="code",
+            content='config = {"configurable": {"thread_id": "demo"}}',
+            metadata={"section": "config"},
+            section="config",
+        ),
+        CellSpec(
+            cell_type="code",
+            content=(
+                "class WorkflowState(TypedDict, total=False):\n"
+                "    messages: list\n\n"
+                "workflow = StateGraph(WorkflowState)\n\n"
+                "def start_node(state: WorkflowState):\n"
+                "    return state\n\n"
+                "workflow.add_node('start', start_node)\n"
+                "workflow.add_edge(START, 'start')\n"
+                "workflow.add_edge('start', END)\n"
+                "graph = workflow.compile()"
+            ),
+            metadata={"section": "graph"},
+            section="graph",
+        ),
+        CellSpec(
+            cell_type="code",
+            content=execution_content or "result = graph.invoke({})\nprint(result)",
+            metadata={"section": "execution"},
+            section="execution",
+        ),
+    ]
+
+
+def _validate_cells(cells: list[CellSpec], validator: NotebookValidator) -> list[QAReport]:
+    """Validate cells through the notebook file path used by production nodes."""
+
+    builder = NotebookFileComposer()
+    with TemporaryDirectory() as temp_dir:
+        notebook = builder.build_notebook(cells)
+        notebook_path = Path(temp_dir) / "generated.ipynb"
+        builder.write(notebook, notebook_path)
+        return validator.validate_all(notebook_path)
+
+
+def _custom_repair_handler(_agent, notebook, _report) -> list[str]:
+    """Replace a synthetic marker in code cells."""
+
+    fixes: list[str] = []
+    for cell in notebook.cells:
+        if cell.cell_type != "code":
+            continue
+        source = str(cell.source or "")
+        updated = source.replace("BROKEN_PLUGIN_MARKER", "REPAIRED_PLUGIN_MARKER")
+        if updated != source:
+            cell.source = updated
+            fixes.append("Repaired custom plugin marker.")
+    return fixes
+
+
+def _install_plugin_module(name: str, register_func) -> None:
+    """Install an in-memory plugin module for loader tests."""
+
+    module = types.ModuleType(name)
+    module.register_qa_repair_plugins = register_func
+    sys.modules[name] = module
+
+
+def test_default_registry_contains_builtin_validators_and_repairs():
+    registry = get_qa_repair_registry(plugin_modules=())
+
+    assert registry.registered_validator_ids() == [
+        "placeholder_content",
+        "required_sections",
+        "required_import_symbols",
+        "python_syntax",
+        "undefined_names",
+        "graph_structure",
+    ]
+    assert registry.registered_repair_routine_ids() == [
+        "placeholder_cleanup",
+        "required_sections",
+        "required_import_symbols",
+        "undefined_name_typo",
+        "bounded_syntax",
+        "graph_scaffold",
+    ]
+
+
+def test_custom_validator_injection_works():
+    registry = get_qa_repair_registry(plugin_modules=())
+    registry.register_validator(CustomMarkerRule())
+    validator = NotebookValidator(registry=registry)
+    cells = _valid_graph_cells(
+        execution_content='marker = "BROKEN_PLUGIN_MARKER"\nprint(marker)'
+    )
+
+    reports = _validate_cells(cells, validator)
+
+    assert any(
+        report.rule_id == "custom_marker" and not report.passed
+        for report in reports
+    )
+
+
+def test_disabling_validator_removes_it_from_validate_all():
+    registry = get_qa_repair_registry(plugin_modules=())
+    assert registry.disable_validator("placeholder_content") is True
+    validator = NotebookValidator(registry=registry)
+    cells = _valid_graph_cells(execution_content="# TODO: normally flagged\nprint('ok')")
+
+    reports = _validate_cells(cells, validator)
+
+    assert "placeholder_content" not in {report.rule_id for report in reports}
+
+
+def test_custom_repair_routine_injection_works():
+    registry = get_qa_repair_registry(plugin_modules=())
+    registry.register_validator(CustomMarkerRule())
+    registry.register_repair_routine(
+        RepairRoutineRegistration(
+            routine_id="custom_marker_repair",
+            handled_rule_ids=("custom_marker",),
+            handler=_custom_repair_handler,
+        )
+    )
+    agent = NotebookRepairAgent(registry=registry)
+    cells = _valid_graph_cells(
+        execution_content='marker = "BROKEN_PLUGIN_MARKER"\nprint(marker)'
+    )
+    reports = _validate_cells(cells, agent.validator)
+
+    outcome = agent.repair_cells(cells, reports)
+
+    assert outcome.success is True
+    assert "Repaired custom plugin marker." in outcome.attempted_fixes
+    assert "BROKEN_PLUGIN_MARKER" not in "\n".join(cell.content for cell in outcome.cells)
+    assert any(report.rule_id == "custom_marker" and report.passed for report in outcome.qa_reports)
+
+
+def test_plugin_module_loading_registers_custom_extensions(monkeypatch):
+    module_name = "test_qa_repair_plugin"
+
+    def register(registry: QARepairRegistry) -> None:
+        registry.register_validator(CustomMarkerRule())
+        registry.register_repair_routine(
+            RepairRoutineRegistration(
+                routine_id="plugin_marker_repair",
+                handled_rule_ids=("custom_marker",),
+                handler=_custom_repair_handler,
+            )
+        )
+
+    _install_plugin_module(module_name, register)
+    monkeypatch.setattr(
+        "langgraph_system_generator.qa.registry.settings.qa_repair_plugin_modules",
+        [module_name],
+    )
+
+    registry = get_qa_repair_registry()
+
+    assert "custom_marker" in registry.registered_validator_ids()
+    assert "plugin_marker_repair" in registry.registered_repair_routine_ids()
+
+
+def test_plugin_module_without_entrypoint_raises_actionable_value_error(monkeypatch):
+    module_name = "test_qa_repair_plugin_without_entrypoint"
+    sys.modules[module_name] = types.ModuleType(module_name)
+
+    try:
+        get_qa_repair_registry(plugin_modules=(module_name,))
+    except ValueError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("Expected plugin loader to reject missing entrypoint.")
+
+    assert module_name in message
+    assert "register_qa_repair_plugins" in message
+
+
+def test_plugin_module_hook_failure_raises_actionable_value_error():
+    module_name = "test_qa_repair_plugin_hook_failure"
+
+    def register(_registry: QARepairRegistry) -> None:
+        raise RuntimeError("boom")
+
+    _install_plugin_module(module_name, register)
+
+    try:
+        get_qa_repair_registry(plugin_modules=(module_name,))
+    except ValueError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("Expected plugin loader to wrap hook failures.")
+
+    assert module_name in message
+    assert "boom" in message
+    assert "register_qa_repair_plugins" in message
+
+
+def test_missing_plugin_module_raises_actionable_value_error():
+    module_name = "test_qa_repair_plugin_does_not_exist"
+
+    try:
+        get_qa_repair_registry(plugin_modules=(module_name,))
+    except ValueError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("Expected plugin loader to wrap import failures.")
+
+    assert module_name in message
+    assert "Failed to import QA/repair plugin module" in message
+

--- a/tests/unit/test_qa_repair_registry.py
+++ b/tests/unit/test_qa_repair_registry.py
@@ -139,6 +139,16 @@ def test_default_registry_contains_builtin_validators_and_repairs():
     ]
 
 
+def test_explicit_empty_repair_routines_are_preserved():
+    registry = QARepairRegistry(repair_routines=())
+    clone = registry.clone()
+    agent = NotebookRepairAgent(registry=registry)
+
+    assert registry.registered_repair_routine_ids() == []
+    assert clone.registered_repair_routine_ids() == []
+    assert agent.registry.registered_repair_routine_ids() == []
+
+
 def test_custom_validator_injection_works():
     registry = get_qa_repair_registry(plugin_modules=())
     registry.register_validator(CustomMarkerRule())
@@ -215,6 +225,33 @@ def test_plugin_module_loading_registers_custom_extensions(monkeypatch):
     assert "plugin_marker_repair" in registry.registered_repair_routine_ids()
 
 
+def test_plugin_module_loading_accepts_comma_separated_module_strings():
+    module_one = "test_qa_repair_plugin_one"
+    module_two = "test_qa_repair_plugin_two"
+
+    def register_one(registry: QARepairRegistry) -> None:
+        registry.register_validator(CustomMarkerRule())
+
+    def register_two(registry: QARepairRegistry) -> None:
+        registry.register_repair_routine(
+            RepairRoutineRegistration(
+                routine_id="plugin_marker_repair",
+                handled_rule_ids=("custom_marker",),
+                handler=_custom_repair_handler,
+            )
+        )
+
+    _install_plugin_module(module_one, register_one)
+    _install_plugin_module(module_two, register_two)
+
+    registry = get_qa_repair_registry(
+        plugin_modules=f"{module_one}, {module_two}"
+    )
+
+    assert "custom_marker" in registry.registered_validator_ids()
+    assert "plugin_marker_repair" in registry.registered_repair_routine_ids()
+
+
 def test_plugin_module_without_entrypoint_raises_actionable_value_error(monkeypatch):
     module_name = "test_qa_repair_plugin_without_entrypoint"
     sys.modules[module_name] = types.ModuleType(module_name)
@@ -262,4 +299,3 @@ def test_missing_plugin_module_raises_actionable_value_error():
 
     assert module_name in message
     assert "Failed to import QA/repair plugin module" in message
-

--- a/tests/unit/test_qa_repair_regressions.py
+++ b/tests/unit/test_qa_repair_regressions.py
@@ -1,0 +1,302 @@
+"""Regression suite for deterministic QA repair behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from langgraph_system_generator.generator.state import CellSpec, QAReport
+from langgraph_system_generator.notebook.composer import (
+    NotebookComposer as NotebookFileComposer,
+)
+from langgraph_system_generator.qa.repair import NotebookRepairAgent
+from langgraph_system_generator.qa.validators import NotebookValidator
+
+
+def _valid_graph_cells(*, execution_content: str | None = None) -> list[CellSpec]:
+    """Return a minimal valid notebook cell set for repair regression tests."""
+
+    return [
+        CellSpec(
+            cell_type="code",
+            content="from langgraph.graph import END, START, StateGraph\nfrom typing import TypedDict",
+            metadata={"section": "setup"},
+            section="setup",
+        ),
+        CellSpec(
+            cell_type="code",
+            content='config = {"configurable": {"thread_id": "demo"}}',
+            metadata={"section": "config"},
+            section="config",
+        ),
+        CellSpec(
+            cell_type="code",
+            content=(
+                "class WorkflowState(TypedDict, total=False):\n"
+                "    messages: list\n\n"
+                "workflow = StateGraph(WorkflowState)\n\n"
+                "def start_node(state: WorkflowState):\n"
+                "    return state\n\n"
+                "workflow.add_node('start', start_node)\n"
+                "workflow.add_edge(START, 'start')\n"
+                "workflow.add_edge('start', END)\n"
+                "graph = workflow.compile()"
+            ),
+            metadata={"section": "graph"},
+            section="graph",
+        ),
+        CellSpec(
+            cell_type="code",
+            content=execution_content or "result = graph.invoke({})\nprint(result)",
+            metadata={"section": "execution"},
+            section="execution",
+        ),
+        CellSpec(
+            cell_type="code",
+            content='output_data = {"result": "ok"}\noutput_data',
+            metadata={"section": "export"},
+            section="export",
+        ),
+        CellSpec(
+            cell_type="markdown",
+            content="Troubleshooting notes.",
+            metadata={"section": "troubleshooting"},
+            section="troubleshooting",
+        ),
+    ]
+
+
+def _validate_cells(cells: list[CellSpec]) -> list[QAReport]:
+    """Validate cells using the same file-backed path as generator nodes."""
+
+    builder = NotebookFileComposer()
+    validator = NotebookValidator()
+    with TemporaryDirectory() as temp_dir:
+        notebook = builder.build_notebook(cells)
+        notebook_path = Path(temp_dir) / "generated.ipynb"
+        builder.write(notebook, notebook_path)
+        return validator.validate_all(notebook_path)
+
+
+def _joined_code(cells: list[CellSpec]) -> str:
+    """Return all code cell content joined for assertions."""
+
+    return "\n".join(cell.content for cell in cells if cell.cell_type == "code")
+
+
+def _failed_report(reports: list[QAReport], rule_id: str) -> QAReport:
+    """Return the first failed report for a rule."""
+
+    return next(
+        report
+        for report in reports
+        if report.rule_id == rule_id and not report.passed
+    )
+
+
+@pytest.fixture
+def repair_agent() -> NotebookRepairAgent:
+    """Create a repair agent for regression tests."""
+
+    return NotebookRepairAgent()
+
+
+def test_regression_placeholder_cleanup_removes_visible_scaffold(repair_agent):
+    cells = _valid_graph_cells(execution_content="# TODO: fill in\nvalue = 1\nvalue")
+    reports = _validate_cells(cells)
+
+    outcome = repair_agent.repair_cells(cells, reports)
+
+    assert outcome.success is True
+    assert "TODO" not in _joined_code(outcome.cells)
+    assert "value = 1" in _joined_code(outcome.cells)
+
+
+def test_regression_missing_langgraph_imports_are_consolidated(repair_agent):
+    cells = _valid_graph_cells()
+    cells[0] = CellSpec(
+        cell_type="code",
+        content="from typing import TypedDict",
+        metadata={"section": "setup"},
+        section="setup",
+    )
+    reports = _validate_cells(cells)
+
+    outcome = repair_agent.repair_cells(cells, reports)
+
+    assert outcome.success is True
+    setup = next(cell for cell in outcome.cells if cell.section == "setup")
+    assert "from langgraph.graph import" in setup.content
+    assert "END" in setup.content
+    assert "START" in setup.content
+    assert "StateGraph" in setup.content
+
+
+def test_regression_missing_setup_section_is_inserted_before_graph(repair_agent):
+    cells = _valid_graph_cells()[1:]
+    cells[1] = CellSpec(
+        cell_type="code",
+        content=(
+            "from langgraph.graph import END, START, StateGraph\n"
+            "from typing import TypedDict\n\n"
+            f"{cells[1].content}"
+        ),
+        metadata={"section": "graph"},
+        section="graph",
+    )
+    notebook = NotebookFileComposer().build_notebook(
+        cells,
+        ensure_minimum_sections=False,
+    )
+    report = QAReport(
+        check_name="Required Sections",
+        passed=False,
+        message="Missing required sections: setup",
+        rule_id="required_sections",
+        severity="error",
+        category="structure",
+        repairable=True,
+        evidence={"missing_sections": ["setup"]},
+    )
+
+    fixes = repair_agent._repair_sections(notebook, report)
+    setup_indexes = [
+        index
+        for index, cell in enumerate(notebook.cells)
+        if cell.metadata.get("section") == "setup"
+    ]
+    graph_indexes = [
+        index
+        for index, cell in enumerate(notebook.cells)
+        if cell.metadata.get("section") == "graph"
+    ]
+    assert fixes == ["Added missing 'setup' section with deterministic fallback content."]
+    assert setup_indexes
+    assert graph_indexes
+    assert max(setup_indexes[:2]) < min(graph_indexes)
+
+
+def test_regression_incomplete_graph_scaffold_is_recovered(repair_agent):
+    cells = _valid_graph_cells()
+    cells[2] = CellSpec(
+        cell_type="code",
+        content="workflow = None",
+        metadata={"section": "graph"},
+        section="graph",
+    )
+    reports = _validate_cells(cells)
+
+    outcome = repair_agent.repair_cells(cells, reports)
+
+    assert outcome.success is True
+    assert "Recovered deterministic graph scaffold" in _joined_code(outcome.cells)
+    assert "graph = recovered_workflow.compile()" in _joined_code(outcome.cells)
+
+
+def test_regression_undefined_name_typo_uses_validator_suggestion(repair_agent):
+    cells = _valid_graph_cells(execution_content="result = grpah.invoke({})\nprint(result)")
+    reports = _validate_cells(cells)
+
+    outcome = repair_agent.repair_cells(cells, [_failed_report(reports, "undefined_names")])
+
+    assert outcome.success is True
+    assert "grpah" not in _joined_code(outcome.cells)
+    assert "graph.invoke({})" in _joined_code(outcome.cells)
+
+
+def test_regression_interleaved_markdown_does_not_break_typo_repair(repair_agent):
+    cells = _valid_graph_cells(execution_content="result = grpah.invoke({})\nprint(result)")
+    cells.insert(
+        3,
+        CellSpec(
+            cell_type="markdown",
+            content="Execution notes live between code cells.",
+            metadata={"section": "notes"},
+            section="notes",
+        ),
+    )
+    reports = _validate_cells(cells)
+
+    outcome = repair_agent.repair_cells(cells, [_failed_report(reports, "undefined_names")])
+
+    assert outcome.success is True
+    execution = next(cell for cell in outcome.cells if cell.section == "execution")
+    assert "grpah" not in execution.content
+    assert "graph.invoke({})" in execution.content
+
+
+def test_regression_missing_colon_syntax_repair_is_bounded(repair_agent):
+    cells = _valid_graph_cells(execution_content="if True\n    print(graph)")
+    reports = _validate_cells(cells)
+
+    outcome = repair_agent.repair_cells(cells, [_failed_report(reports, "python_syntax")])
+
+    assert outcome.success is True
+    assert "if True:" in _joined_code(outcome.cells)
+
+
+def test_regression_unclosed_delimiter_syntax_repair_is_bounded(repair_agent):
+    cells = _valid_graph_cells(execution_content="print(1 + 2")
+    reports = _validate_cells(cells)
+
+    outcome = repair_agent.repair_cells(cells, [_failed_report(reports, "python_syntax")])
+
+    assert outcome.success is True
+    assert "print(1 + 2)" in _joined_code(outcome.cells)
+
+
+def test_regression_regressive_candidate_rolls_back(monkeypatch, repair_agent):
+    cells = _valid_graph_cells(execution_content="result = grpah.invoke({})\nprint(result)")
+    baseline_reports = _validate_cells(cells)
+    regressive_reports = [
+        QAReport(
+            check_name="Python Syntax",
+            passed=False,
+            message="Syntax error in notebook code: invalid syntax at line 4",
+            rule_id="python_syntax",
+            severity="error",
+            category="syntax",
+            repairable=True,
+        )
+    ]
+    validate_calls = {"count": 0}
+
+    def fake_validate(_cells):
+        validate_calls["count"] += 1
+        return baseline_reports if validate_calls["count"] == 1 else regressive_reports
+
+    monkeypatch.setattr(repair_agent, "_validate_cells", fake_validate)
+    monkeypatch.setattr(
+        repair_agent,
+        "_apply_repairs",
+        lambda _notebook, _failed_reports: ["Applied synthetic repair."],
+    )
+
+    outcome = repair_agent.repair_cells(cells, baseline_reports)
+
+    assert outcome.status == "rolled_back"
+    assert outcome.rollback_used is True
+    assert outcome.cells == cells
+
+
+def test_regression_unhandled_runtime_failure_remains_visible(repair_agent):
+    cells = _valid_graph_cells()
+    runtime_report = QAReport(
+        check_name="Runtime Check",
+        passed=False,
+        message="Runtime validation failed: external dependency unavailable.",
+        rule_id="runtime_smoke_test",
+        severity="error",
+        category="runtime",
+        repairable=False,
+        stage="runtime",
+    )
+
+    outcome = repair_agent.repair_cells(cells, [runtime_report])
+
+    assert outcome.status == "skipped"
+    assert outcome.success is False
+    assert any(report.rule_id == "runtime_smoke_test" for report in outcome.qa_reports)
+    assert "No safe deterministic repair matched" in outcome.message


### PR DESCRIPTION
## Summary
- Adds an internal QARepairRegistry for validator rules and deterministic repair routines.
- Makes NotebookValidator and NotebookRepairAgent consume the shared QA/repair registry, including QA_REPAIR_PLUGIN_MODULES plugins via register_qa_repair_plugins(registry).
- Adds registry/plugin tests, a 10-case QA repair regression suite, and node integration coverage for plugin validators and repair routines.
- Updates AGENTS.md and wiki docs for the registry, plugin entrypoint, and QA_REPAIR_PLUGIN_MODULES.

## Verification
- PYTHONPATH=./src python -m pytest tests/unit/test_repair.py tests/unit/test_validators.py tests/unit/test_qa_repair_registry.py tests/unit/test_qa_repair_regressions.py tests/unit/test_generator_agents.py tests/unit/test_generator_nodes.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py tests/unit/test_config.py -q
- PYTHONPATH=./src python -m pytest tests/unit -q
- PYTHONPATH=./src python -m pytest --asyncio-mode=auto -q
- python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

Closes #177
Closes #178
Closes #173