### PR TITLE
Fix failing main actions

### DIFF
--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -35,7 +35,7 @@ jobs:
           ref: main
           fetch-depth: 0
       - name: Update diagram
-        uses: githubocto/repo-visualizer@0.11.0
+        uses: githubocto/repo-visualizer@0.9.1
         with:
           excluded_paths: "ignore,.github"
           root_path: "src/"

--- a/.github/workflows/wiki-from-code.yml
+++ b/.github/workflows/wiki-from-code.yml
@@ -45,19 +45,20 @@ jobs:
       - name: Get author e-mail (enterprise)
         id: pr_author
         env:
-          GH_TOKEN: ${{ secrets.ENTERPRISE_READ_TOKEN }}   # PAT or App token with read:org
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
         run: |
           # Handle both push and pull_request events
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             login="${{ github.event.pull_request.user.login }}"
             org="${{ github.repository_owner }}"
 
-            # Single-line GraphQL avoids the UNKNOWN_CHAR error
+            # Single-line GraphQL avoids the UNKNOWN_CHAR error. Some tokens do
+            # not have read:org, so fall back to the commit author when needed.
             email=$(gh api graphql \
                 -f query='query($login:String!,$org:String!){user(login:$login){organizationVerifiedDomainEmails(login:$org)}}' \
                 -f login="$login" \
                 -f org="$org" \
-                --jq '.data.user.organizationVerifiedDomainEmails[0]')
+                --jq '.data.user.organizationVerifiedDomainEmails[0]' 2>/dev/null || true)
 
             # Fallback to HEAD-commit author e-mail if nothing came back
             if [ -z "$email" ] || [ "$email" = "null" ]; then
@@ -84,9 +85,20 @@ jobs:
           AUTHOR_EMAIL:   ${{ steps.pr_author.outputs.email }}
           REPO_LANG:      ${{ github.event.repository.language }}
           REPO_SIZE:      ${{ steps.repo_size.outputs.size }}
-          REFRESH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
-          GH_PAT:         ${{ secrets.ENTERPRISE_READ_TOKEN }}
+          REFRESH_TOKEN:  ${{ github.token }}
+          GH_PAT:         ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN_FALLBACK: ${{ github.token }}
         run: |
+          if [ -z "${ADAPTS_API_KEY:-}" ]; then
+            echo "::warning::ADAPTS_API_KEY is not configured; skipping Adapts wiki generation."
+            exit 0
+          fi
+
+          if [ -z "${GH_PAT:-}" ]; then
+            echo "::warning::GH_PAT is not configured; falling back to the workflow token."
+            export GH_PAT="${GITHUB_TOKEN_FALLBACK}"
+          fi
+
           python <<'PY'
           import os, json
           from adaptsapi.generate_docs import post, PayloadValidationError

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -117,7 +117,6 @@ class NotebookComposer:
         normalized = "\n    ".join(lines).strip()
         return normalized or fallback
 
-<<<<<<< Updated upstream
     @staticmethod
     def _merge_string_lists(*values: Any) -> List[str]:
         """Merge list-or-scalar string inputs into an ordered unique list."""
@@ -130,22 +129,11 @@ class NotebookComposer:
 
         return normalize_provider_env_var(value)
 
-=======
-<<<<<<< ours
-=======
->>>>>>> Stashed changes
     @staticmethod
     def _package_import_probe(package_name: str) -> str:
         """Return the import probe used to detect whether a package is installed."""
 
-<<<<<<< Updated upstream
         return package_import_probe(package_name)
-=======
-        return _PACKAGE_IMPORT_PROBES.get(
-            package_name,
-            package_name.replace("-", "_").replace(".", "_"),
-        )
->>>>>>> Stashed changes
 
     def _resolve_max_iterations(self, workflow_design: Dict[str, Any]) -> int:
         """Resolve the iteration limit embedded into notebook cells."""
@@ -181,7 +169,6 @@ class NotebookComposer:
             )
         )
 
-<<<<<<< Updated upstream
     @staticmethod
     def _merge_feedback(
         target: NotebookCompositionFeedback,
@@ -198,8 +185,6 @@ class NotebookComposer:
                 target.warnings.append(warning)
         target.fallback_events.extend(source.fallback_events)
 
-=======
->>>>>>> Stashed changes
     def _fallback_banner(self, label: str, reason: str) -> str:
         """Return a visible notebook-facing warning comment for fallback code."""
 
@@ -213,43 +198,6 @@ class NotebookComposer:
             f"# Reason: {safe_reason}\n\n"
         )
 
-<<<<<<< Updated upstream
-=======
-    def _add_dependency_candidate(
-        self,
-        plan: NotebookDependencyPlan,
-        selected_packages: List[str],
-        selected_families: Dict[str, str],
-        package_name: str,
-        *,
-        family: str | None = None,
-        requested_by: str | None = None,
-    ) -> None:
-        """Add a dependency candidate while deduplicating and resolving conflicts."""
-
-        normalized_package = str(package_name or "").strip()
-        if not normalized_package:
-            return
-
-        dependency_family = family or _PACKAGE_FAMILIES.get(normalized_package)
-        if dependency_family:
-            chosen = selected_families.get(dependency_family)
-            if chosen and chosen != normalized_package:
-                detail = (
-                    f"Kept '{chosen}' instead of '{normalized_package}' "
-                    f"for dependency family '{dependency_family}'."
-                )
-                if requested_by:
-                    detail += f" Requested by {requested_by}."
-                if detail not in plan.conflicts_resolved:
-                    plan.conflicts_resolved.append(detail)
-                return
-            selected_families[dependency_family] = normalized_package
-
-        if normalized_package not in selected_packages:
-            selected_packages.append(normalized_package)
-
->>>>>>> Stashed changes
     def _plan_dependencies(
         self,
         tools: List[Dict[str, Any]],
@@ -263,7 +211,6 @@ class NotebookComposer:
                 "Generated notebooks assume a Jupyter or Colab-style environment with pip available.",
             ]
         )
-<<<<<<< Updated upstream
         accumulator = DependencyAccumulator(runtime_notes=list(plan.runtime_notes))
 
         for package_name in ["langgraph", "langchain-core", "langchain-openai"]:
@@ -357,118 +304,6 @@ class NotebookComposer:
             return result
         return await asyncio.to_thread(self.llm.invoke, messages)
 
-=======
-        selected_packages: List[str] = []
-        selected_families: Dict[str, str] = {}
-
-        for package_name in ["langgraph", "langchain-core", "langchain-openai"]:
-            self._add_dependency_candidate(
-                plan,
-                selected_packages,
-                selected_families,
-                package_name,
-            )
-
-        for tool in tools:
-            category = self._normalize_inline_text(tool.get("category", ""), "").lower()
-            tool_configuration = tool.get("configuration")
-            if not isinstance(tool_configuration, dict):
-                tool_configuration = {}
-            requested_packages = tool_configuration.get("packages", [])
-            if isinstance(requested_packages, str):
-                requested_packages = [requested_packages]
-            if not isinstance(requested_packages, list):
-                requested_packages = []
-            for package_name in requested_packages:
-                self._add_dependency_candidate(
-                    plan,
-                    selected_packages,
-                    selected_families,
-                    str(package_name),
-                    requested_by=self._normalize_inline_text(tool.get("name", ""), "tool"),
-                )
-
-            inferred_packages: List[tuple[str, str | None]] = []
-            if "search" in category:
-                inferred_packages.append(("langchain-community", None))
-            if any(token in category for token in {"file", "document", "pdf"}):
-                inferred_packages.append(("pypdf", "pdf_parser"))
-            if "api" in category:
-                inferred_packages.append(("requests", None))
-
-            for package_name, family in inferred_packages:
-                self._add_dependency_candidate(
-                    plan,
-                    selected_packages,
-                    selected_families,
-                    package_name,
-                    family=family,
-                    requested_by=self._normalize_inline_text(tool.get("name", ""), "tool"),
-                )
-
-        if "langchain-openai" in selected_packages and "OPENAI_API_KEY" not in plan.provider_env_vars:
-            plan.provider_env_vars.append("OPENAI_API_KEY")
-
-        plan.packages = selected_packages
-        if selected_packages:
-            plan.install_commands = [
-                "python -m pip install -q " + " ".join(selected_packages)
-            ]
-        return plan
-
-    def _section_builders(
-        self,
-        context: _NotebookCompositionContext,
-    ) -> List[tuple[str, Any]]:
-        """Return the ordered internal section builders for notebook composition."""
-
-        resolved_max_iterations = context.feedback.resolved_max_iterations or 1
-        return [
-            (
-                "intro",
-                lambda: self._create_intro_cells(
-                    context.notebook_plan,
-                    context.architecture.get("justification"),
-                    context.workflow_design.get("graph_exports"),
-                ),
-            ),
-            ("install", lambda: self._create_install_cells(context.dependency_plan)),
-            (
-                "config",
-                lambda: self._create_config_cells(
-                    context.dependency_plan,
-                    context.feedback,
-                ),
-            ),
-            ("state", lambda: self._create_state_cells(context.workflow_design)),
-            (
-                "tools",
-                lambda: self._create_tool_cells(context.tools, context.feedback)
-                if context.tools
-                else [],
-            ),
-            (
-                "nodes",
-                lambda: self._create_node_cells(
-                    context.workflow_design,
-                    context.feedback,
-                ),
-            ),
-            (
-                "graph",
-                lambda: self._create_graph_cells(
-                    context.workflow_design,
-                    resolved_max_iterations,
-                ),
-            ),
-            (
-                "execution",
-                lambda: self._create_execution_cells(context.workflow_design),
-            ),
-        ]
-
->>>>>>> theirs
->>>>>>> Stashed changes
     async def compose_notebook(
         self,
         notebook_plan: NotebookPlan,


### PR DESCRIPTION
## Summary
- remove committed merge-conflict markers from notebook composer
- pin repo visualizer to an existing action tag
- make wiki generation use the existing GH_PAT secret and skip gracefully when ADAPTS_API_KEY is absent

## Verification
- python -m py_compile src\\langgraph_system_generator\\generator\\agents\\notebook_composer.py
- workflow YAML parse for diagram.yml and wiki-from-code.yml
- flake8 src tests --count --select=E9,F63,F7,F82 --show-source --statistics
- python -m pytest tests\\unit\\test_generator_notebook_composer.py --asyncio-mode=auto -q
- python -m pytest tests\\unit\\test_generator_agents.py --asyncio-mode=auto -q
- python -m pytest tests\\unit --asyncio-mode=auto -q

## Notes
The Adapts wiki workflow still needs ADAPTS_API_KEY configured to actually generate wiki docs; this PR keeps main green by warning and skipping when that external-service key is missing.