### PR TITLE
Prepare 1.0 release readiness

### DIFF
--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Open diagram update PR
         uses: peter-evans/create-pull-request@v8.1.1
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ github.token }}
           commit-message: "Update repo visualization diagram"
           title: "Update repo visualization diagram"
           body: |

--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -46,10 +46,24 @@ jobs:
           commit_message: "Repo visualization diagram"
           should_push: false
 
+      - name: Check diagram PR token
+        id: diagram-token
+        shell: bash
+        env:
+          DIAGRAM_PR_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          if [ -n "$DIAGRAM_PR_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping diagram PR creation because secrets.GH_PAT is not configured. Configure a PAT with repo/workflow scopes so automation PRs trigger required checks."
+          fi
+
       - name: Open diagram update PR
+        if: steps.diagram-token.outputs.available == 'true'
         uses: peter-evans/create-pull-request@v8.1.1
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GH_PAT }}
           commit-message: "Update repo visualization diagram"
           title: "Update repo visualization diagram"
           body: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable release changes are tracked in this file.
+
+## 1.0.0 - 2026-05-04
+
+### Added
+- Release-readiness tracker for the 1.0 CLI/API/package contract.
+- Root MIT license file for GitHub and package metadata discovery.
+- Isolated packaging smoke coverage for minimal, API, and full extras.
+- Local-only 1.0 release evaluation gate for deterministic LangGraph generator checks.
+
+### Changed
+- Package metadata now reports `1.0.0` and Production/Stable status.
+- The Create diagram workflow uses the repository `GITHUB_TOKEN` path for update PRs.
+- Public docs and MemoryBank context describe the project as the 1.0 release baseline instead of Alpha.
+
+### Notes
+- Deep Agents remains experimental and opt-in through `agent_type="deepagents"`.
+- The FastAPI SSE implementation remains scoped to single-server operation for 1.0.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 LangGraph Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -353,6 +353,17 @@ ruff check src/ tests/
 mypy src/
 ```
 
+Release-readiness checks:
+
+```bash
+# Local deterministic LangGraph release evaluation, no LangSmith upload
+python scripts/run_release_eval.py --no-upload
+
+# Isolated install matrix smoke tests for the documented package extras
+RUN_PACKAGING_SMOKE=1 PACKAGING_SMOKE_SCENARIOS=minimal,api python -m pytest tests/integration/test_packaging_install_smoke.py -q
+RUN_PACKAGING_SMOKE=1 PACKAGING_SMOKE_SCENARIOS=full python -m pytest tests/integration/test_packaging_install_smoke.py -q
+```
+
 When editing docs only, the narrowest useful validation is:
 
 ```bash
@@ -376,3 +387,5 @@ More docs:
 - [Colab Usage](docs/wiki/Colab-Usage.md)
 - [Development Guide](docs/dev.md)
 - [Repository Visualizations](docs/diagrams/README.md)
+- [Changelog](CHANGELOG.md)
+- [License](LICENSE)

--- a/docs/CI_CD_WORKFLOWS.md
+++ b/docs/CI_CD_WORKFLOWS.md
@@ -57,7 +57,8 @@ All workflows follow security best practices:
 
 **File**: `.github/workflows/diagram.yml`
 
-**Purpose**: Auto-generates and commits repository visualization diagram
+**Purpose**: Auto-generates the legacy top-level repository visualization diagram
+and opens an update pull request
 
 **Triggers**:
 - Push to `main` branch
@@ -67,12 +68,20 @@ All workflows follow security best practices:
 - **Depends on CodeQL**: Job waits for security scan to pass
 - Action pinned to `@0.9.1`, the latest published `githubocto/repo-visualizer`
   tag currently used by the workflow (previously used unpinned `@main`)
-- Minimal permissions: `contents: write` only for diagram job
+- Minimal permissions: `contents: write` and `pull-requests: write` only for
+  the diagram job
+- Uses the workflow `GITHUB_TOKEN` path for create-pull-request instead of a
+  repository-specific `GH_PAT` secret
 
 **Workflow**:
 1. Run CodeQL security analysis
 2. Generate repo visualization (only if CodeQL passes)
-3. Commit diagram to repository
+3. Open or update an `automation/repo-visualization-diagram` pull request with
+   `diagram.svg`
+
+The docs-owned Mermaid/DOT/JSON/Figma repository architecture bundle under
+`docs/diagrams/repo-architecture-visualizer/` is refreshed locally through the
+`repo-architecture-visualizer` skill, not this GitHub Actions workflow.
 
 ### GitHub Pages Documentation
 

--- a/docs/CI_CD_WORKFLOWS.md
+++ b/docs/CI_CD_WORKFLOWS.md
@@ -70,14 +70,21 @@ and opens an update pull request
   tag currently used by the workflow (previously used unpinned `@main`)
 - Minimal permissions: `contents: write` and `pull-requests: write` only for
   the diagram job
-- Uses the workflow `GITHUB_TOKEN` path for create-pull-request instead of a
-  repository-specific `GH_PAT` secret
+- Uses `secrets.GH_PAT` for create-pull-request so automation PRs can trigger
+  normal pull request checks under branch protection
+- Skips PR creation with a workflow notice if `secrets.GH_PAT` is not
+  configured, rather than failing the whole workflow
 
 **Workflow**:
 1. Run CodeQL security analysis
 2. Generate repo visualization (only if CodeQL passes)
-3. Open or update an `automation/repo-visualization-diagram` pull request with
-   `diagram.svg`
+3. If `secrets.GH_PAT` is configured, open or update an
+   `automation/repo-visualization-diagram` pull request with `diagram.svg`
+
+`GH_PAT` must be a repository automation token with enough scope to push the
+automation branch and open/update pull requests. The default `GITHUB_TOKEN` is
+not used for this step because PRs created with it do not trigger the same
+pull request checks required for protected-branch merging.
 
 The docs-owned Mermaid/DOT/JSON/Figma repository architecture bundle under
 `docs/diagrams/repo-architecture-visualizer/` is refreshed locally through the

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -9,6 +9,7 @@
 2. **Install dependencies**
    ```bash
    pip install -r requirements.txt
+   pip install -e ".[full,dev]"
    ```
 
 3. **Configure environment**
@@ -18,6 +19,14 @@
 4. **Run tests**
    ```bash
    python -m pytest
+   ```
+
+   Release-readiness gates:
+
+   ```bash
+   python scripts/run_release_eval.py --no-upload
+   RUN_PACKAGING_SMOKE=1 PACKAGING_SMOKE_SCENARIOS=minimal,api python -m pytest tests/integration/test_packaging_install_smoke.py -q
+   RUN_PACKAGING_SMOKE=1 PACKAGING_SMOKE_SCENARIOS=full python -m pytest tests/integration/test_packaging_install_smoke.py -q
    ```
 
 5. **Import the package**
@@ -34,3 +43,11 @@
   `LNF_LOG_LEVEL=DEBUG` when running uvicorn to surface detailed traces.
 - Logs are formatted consistently as ISO timestamps with level, logger name, and
   message to simplify grepping and log aggregation.
+
+## Release metadata
+
+- The root `LICENSE` file is the MIT license source used by GitHub and package
+  metadata.
+- `CHANGELOG.md` records release-facing changes.
+- `setup.py` and `src/langgraph_system_generator/__init__.py` must carry the
+  same package version before tagging a release.

--- a/docs/wiki/Developer-Onboarding.md
+++ b/docs/wiki/Developer-Onboarding.md
@@ -87,6 +87,18 @@ mypy src/
 The repository also ships a dedicated documentation workflow so pull requests
 surface missing coverage early.
 
+Release-readiness checks:
+
+```bash
+python scripts/run_release_eval.py --no-upload
+RUN_PACKAGING_SMOKE=1 PACKAGING_SMOKE_SCENARIOS=minimal,api python -m pytest tests/integration/test_packaging_install_smoke.py -q
+RUN_PACKAGING_SMOKE=1 PACKAGING_SMOKE_SCENARIOS=full python -m pytest tests/integration/test_packaging_install_smoke.py -q
+```
+
+The release evaluation gate is local-only by default. Use LangSmith tracing or
+upload workflows separately when credentials and a release candidate baseline
+are available.
+
 ## Logging And Tracing
 
 For local debugging:

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -44,6 +44,11 @@ pip install -e ".[full]"
 pip install -e ".[full,dev]"
 ```
 
+The `lnf` console entry point is registered by the core install so `lnf --help`
+works in minimal environments. Generating notebook artifacts requires the
+`full` extra; minimal installs fail with an actionable `".[full]"` hint instead
+of an import traceback.
+
 If you are using this repository directly, `pip install -r requirements.txt` is
 also supported and installs the broad dependency set used by CI.
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -83,7 +83,7 @@ LangGraph System Generator excels at:
 
 ### Project Status
 
-LangGraph System Generator is in active development (Alpha). It includes:
+LangGraph System Generator is in its 1.0 release baseline. It includes:
 
 - ✅ Complete generation pipeline (Prompt → Requirements → RAG → Architecture → Plan → Generate → QA/Repair → Export)
 - ✅ Three core patterns with comprehensive examples

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -114,7 +114,7 @@ This wiki provides comprehensive coverage of:
 
 ## Version
 
-This documentation targets the current **LangGraph System Generator Alpha** release. For the exact version, see the main project README or package metadata.
+This documentation targets the current **LangGraph System Generator 1.0** release. For the exact version, see the main project README or package metadata.
 
 ## License
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -7,6 +7,9 @@
 - Current documentation work includes the docs-owned
   `docs/diagrams/repo-architecture-visualizer/2026-04-30/` bundle for
   package/module/env relationship snapshots.
+- Current release work is preparing the 1.0.0 readiness branch with packaging
+  smoke tests, release metadata, local LangGraph evaluation gates, and workflow
+  cleanup before opening the final release PR.
 
 ## Recent Changes Reflected in the Codebase
 
@@ -21,11 +24,21 @@
   manifest/API fields.
 - `docs/diagrams/README.md` now indexes both the hand-maintained generator
   stage/state map and the generated repo architecture visualizer bundle.
+- The 1.0 readiness branch adds a root MIT license, changelog, stable package
+  metadata, isolated install smoke tests, and `scripts/run_release_eval.py` for
+  local-only release evaluation.
+- Release-readiness issue triage closed stale completed RequirementsAnalyst,
+  pattern/example, cross-cutting, and duplicate CYOA items; remaining open
+  issues are explicit post-1.0/residual work unless #258 is still waiting for
+  the release PR merge.
 
 ## Immediate Next Steps
 
 - Keep public docs, examples, and onboarding copy aligned with the current
   CLI/API contract.
+- Keep the 1.0 release tracker (#256) aligned with packaging, workflow,
+  evaluation, metadata, issue-triage, and PR progress until the `v1.0.0`
+  release is published.
 - Keep maintainer visualization docs aligned when generator stages, package
   boundaries, module relationships, or environment-variable usage changes.
 - Preserve parity between CLI-driven, API-driven, and web-driven artifact
@@ -45,3 +58,11 @@
   live mode treats runtime support gaps as real failures.
 - The SSE implementation is appropriate for single-server development, but not a
   distributed production event bus.
+- Packaging smoke tests are opt-in through `RUN_PACKAGING_SMOKE=1` because they
+  create isolated virtual environments and the full-extra path is slow.
+- The local release evaluation gate defaults to no upload; LangSmith can remain
+  a separate explicit release-candidate comparison step when credentials are
+  available.
+- The current release-readiness branch verification baseline is `python -m
+  pytest --asyncio-mode=auto` with 625 passing tests and 4 skipped tests, plus
+  the CI fatal-error flake8 gate.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -14,17 +14,28 @@
 - Maintainer repository visualizations are checked in under `docs/diagrams/`,
   including the generator stage/state map and the generated
   repo-architecture-visualizer package/module/env bundle.
+- Release-readiness packaging smoke coverage now validates the minimal, API,
+  and full extras install paths in isolated virtual environments when opted in.
+- The local 1.0 release evaluation gate validates deterministic architecture
+  selection, graph design, notebook composition, QA/repair, and example
+  inventory surfaces without requiring LangSmith upload.
+- The release-readiness branch has a green full local verification baseline:
+  `python -m pytest --asyncio-mode=auto` reports 625 passed and 4 skipped, and
+  the CI fatal-error flake8 gate reports 0 findings.
+- Stale completed release-plan issues were closed with evidence, reducing the
+  open issue inventory from 49 to 26 while keeping true residual items open.
 
 ## What Is Still Incomplete
 
-- Public docs and onboarding copy have historically lagged behind the runtime
-  contract and should be kept synchronized with CLI/API behavior.
 - Experimental Deep Agents support is opt-in through `agent_type="deepagents"`
   and keeps the optional SDK out of core imports.
+- The 1.0 release is not tagged yet; #258 should close through the release PR
+  merge, and #256 remains the canonical tracker until `v1.0.0` is published.
 
 ## Current Status
 
-- The package metadata in `setup.py` marks the project as alpha.
+- The package metadata in `setup.py` now uses the 1.0.0 Production/Stable
+  release baseline on the release-readiness branch.
 - The repository already contains substantial scaffolding for CLI, API, RAG,
   notebook export, QA/repair, registry-backed planning, and pattern generation
   workflows.
@@ -32,6 +43,10 @@
   maintained alongside public onboarding docs.
 - Repository architecture diagrams are discoverable through public docs,
   contributor guidance, and MemoryBank context.
+- Release metadata now includes a root MIT license, changelog, and 1.0.0 package
+  version/classifier updates on the release-readiness branch.
+- The release-readiness branch fixes the Create diagram workflow token path to
+  use `github.token` instead of an unavailable `GH_PAT` secret.
 
 ## Known Issues and Limitations
 
@@ -41,3 +56,9 @@
   unavailable, which keeps generation running but may reduce quality.
 - The SSE/job model uses in-memory queues and is not yet designed for
   distributed multi-server coordination.
+- Full-extra packaging smoke tests are intentionally opt-in because they install
+  the broad notebook/RAG/export dependency set into a fresh virtual
+  environment.
+- Router fallback/general routing (#60), iterative requirements refinement
+  (#202), and the remaining CYOA notebook cell issues are tracked as residual
+  follow-up work rather than closed stale items.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -45,8 +45,9 @@
   contributor guidance, and MemoryBank context.
 - Release metadata now includes a root MIT license, changelog, and 1.0.0 package
   version/classifier updates on the release-readiness branch.
-- The release-readiness branch fixes the Create diagram workflow token path to
-  use `github.token` instead of an unavailable `GH_PAT` secret.
+- The release-readiness branch fixes the Create diagram workflow so it uses a
+  configured `GH_PAT` automation token for PR creation and skips cleanly with a
+  notice when that secret is unavailable.
 
 ## Known Issues and Limitations
 

--- a/memory-bank/tasks/TASK002-1-0-release-readiness.md
+++ b/memory-bank/tasks/TASK002-1-0-release-readiness.md
@@ -1,0 +1,69 @@
+# TASK002 - 1.0 Release Readiness Implementation
+
+**Status:** In Progress
+**Added:** 2026-05-04
+**Updated:** 2026-05-04
+
+## Original Request
+
+Implement the 1.0 release readiness plan: update the canonical release tracker,
+close the stale draft PR, fix the diagram workflow token path, resolve packaging
+issue #258 with TDD-backed install smokes, add a local LangGraph evaluation
+gate, update release metadata/docs/MemoryBank, triage stale issues, verify the
+release branch, and open one PR into `main`.
+
+## Thought Process
+
+The release is defined as CLI/API/package stability rather than distributed
+production hosting. The highest-risk release blockers are packaging correctness,
+workflow health, and final verification. Code changes should stay narrow and
+test-first.
+
+## Implementation Plan
+
+- Create an isolated `codex/1.0-release-readiness` worktree branch from current
+  `origin/main`.
+- Update #256 as the 1.0 tracker and close #288 if it still has no file delta.
+- Add failing release metadata and packaging smoke tests.
+- Fix `.github/workflows/diagram.yml` to use the workflow token path.
+- Update package version/classifier, root license, changelog, and public docs.
+- Add a local deterministic release evaluation dataset/script.
+- Run targeted and full verification, then push and open a release PR.
+
+## Progress Tracking
+
+**Overall Status:** In Progress - 90%
+
+### Subtasks
+
+| ID | Description | Status | Updated | Notes |
+|----|-------------|--------|---------|-------|
+| 2.1 | Create release branch/worktree | Complete | 2026-05-04 | Worktree created under `.codex/worktrees/1.0-release-readiness`. |
+| 2.2 | Update #256 and close #288 | Complete | 2026-05-04 | #256 retitled/body-updated; #288 closed as stale/superseded. |
+| 2.3 | Add packaging smoke tests and fix #258 path | Complete | 2026-05-04 | Minimal/API/full isolated smokes pass when opted in. |
+| 2.4 | Add release metadata and diagram workflow fix | Complete | 2026-05-04 | Version, classifier, license, changelog, and workflow token updated. |
+| 2.5 | Add local release evaluation gate | Complete | 2026-05-04 | Dataset and `scripts/run_release_eval.py` added; targeted test passes. |
+| 2.6 | Triage stale issues with evidence | Complete | 2026-05-04 | Closed stale completed and duplicate issues; kept true residuals open with audit comments. |
+| 2.7 | Run final verification and open PR | In Progress | 2026-05-04 | Full pytest and flake8 fatal-error gate pass; publication pending. |
+
+## Progress Log
+
+### 2026-05-04
+
+- Created the release-readiness worktree branch from current `origin/main`.
+- Updated #256 to track 1.0 release readiness and closed stale draft PR #288.
+- Added release metadata tests and verified they failed before version/workflow
+  changes.
+- Added packaging smoke tests and verified the minimal install failure before
+  fixing the CLI's non-ASCII traceback path.
+- Fixed full-extra packaging import drift by removing an accidental runtime
+  `pytest` import from the router pattern module.
+- Added local release evaluation data/script and fixed the Deep Agents fallback
+  graph so the evaluation gate has a real terminal branch.
+- Closed stale completed RequirementsAnalyst, pattern/example, cross-cutting,
+  and duplicate CYOA issues with evidence; left router fallback (#60) and
+  iterative requirements refinement (#202) open as real residuals.
+- Verified the branch with `python -m pytest tests/unit -q`, `python -m pytest
+  tests/patterns -v`, `python -m pytest tests/integration -q`, full `python -m
+  pytest --asyncio-mode=auto` (625 passed, 4 skipped), CI fatal-error flake8,
+  opt-in packaging smokes, and the local release evaluation gate.

--- a/memory-bank/tasks/_index.md
+++ b/memory-bank/tasks/_index.md
@@ -1,5 +1,9 @@
 # Tasks Index
 
+## In Progress
+
+- [TASK002 - 1.0 release readiness implementation](TASK002-1-0-release-readiness.md)
+
 ## Completed
 
 - [TASK001 - Repo architecture visualizer docs sync](TASK001-repo-architecture-visualizer-docs-sync.md)
@@ -9,5 +13,7 @@
 - Present task files:
   - `_index.md`
   - `TASK001-repo-architecture-visualizer-docs-sync.md`
+  - `TASK002-1-0-release-readiness.md`
 - Task-level Memory Bank tracking has started with the documentation and
-  visualization sync for the checked-in repo architecture bundle.
+  visualization sync for the checked-in repo architecture bundle and the 1.0
+  release-readiness branch.

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -20,6 +20,18 @@
   - copy `.env.example` to `.env`
   - run `python -m pytest`
 - The `lnf` console entry point defined in `setup.py` is available only after the package has been installed.
+- Release-readiness packaging checks live in
+  `tests/integration/test_packaging_install_smoke.py` and are opt-in with
+  `RUN_PACKAGING_SMOKE=1`.
+- The local deterministic release evaluation script is
+  `scripts/run_release_eval.py`; it writes a JSON report and defaults to
+  no-upload behavior for CI/release PR use.
+- The current full release-readiness verification command is `python -m pytest
+  --asyncio-mode=auto`; the latest branch run reported 625 passed and 4 skipped.
+- The CI fatal-error lint gate is `python -m flake8 . --count
+  --select=E9,F63,F7,F82 --show-source --statistics`; the broader
+  `--exit-zero` flake8 statistics command is informational and still reports
+  pre-existing style findings.
 
 ## Configuration Model
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 testpaths = tests
 asyncio_mode = auto
+markers =
+    packaging_smoke: isolated install smoke tests for release packaging checks

--- a/scripts/run_release_eval.py
+++ b/scripts/run_release_eval.py
@@ -1,0 +1,149 @@
+"""Run the local deterministic 1.0 release evaluation gate."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from langgraph_system_generator.cli import _build_stub_result, _serialize  # noqa: E402
+
+
+DEFAULT_DATASET = REPO_ROOT / "tests" / "evaluation" / "release_1_0_eval_cases.json"
+DEFAULT_OUTPUT = REPO_ROOT / "output" / "release-evaluation" / "release_1_0_eval_report.json"
+
+
+def _load_dataset(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _edge_count(workflow_design: dict[str, Any]) -> int:
+    return len(workflow_design.get("edges") or []) + len(
+        workflow_design.get("conditional_edges") or []
+    )
+
+
+def _check_generator_case(case: dict[str, Any]) -> list[str]:
+    result = _serialize(
+        _build_stub_result(case["prompt"], agent_type=case.get("agent_type"))
+    )
+    failures: list[str] = []
+
+    expected_architecture = case.get("expected_architecture")
+    if expected_architecture and result.get("architecture_type") != expected_architecture:
+        failures.append(
+            f"expected architecture {expected_architecture!r}, got {result.get('architecture_type')!r}"
+        )
+
+    if "graph_design" in case["surfaces"]:
+        workflow_design = result.get("workflow_design") or {}
+        if not workflow_design.get("nodes"):
+            failures.append("workflow_design has no nodes")
+        if _edge_count(workflow_design) == 0:
+            failures.append("workflow_design has no edges or conditional_edges")
+
+    if "notebook_composition" in case["surfaces"]:
+        generated_cells = result.get("generated_cells") or []
+        min_cell_count = int(case.get("min_cell_count") or 0)
+        if len(generated_cells) < min_cell_count:
+            failures.append(
+                f"expected at least {min_cell_count} generated cells, got {len(generated_cells)}"
+            )
+        if not (result.get("notebook_plan") or {}).get("sections"):
+            failures.append("notebook_plan has no sections")
+
+    if "qa_repair" in case["surfaces"]:
+        qa_repair_feedback = result.get("qa_repair_feedback") or {}
+        if qa_repair_feedback.get("unrepaired_failures"):
+            failures.append("qa_repair_feedback contains unrepaired failures")
+        if result.get("generation_complete") is not True:
+            failures.append("generation_complete is not true")
+
+    return failures
+
+
+def _check_examples_case(case: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    for relative_path in case.get("expected_examples") or []:
+        if not (REPO_ROOT / relative_path).exists():
+            failures.append(f"missing example {relative_path}")
+    return failures
+
+
+def run_evaluation(dataset: dict[str, Any], *, upload_enabled: bool) -> dict[str, Any]:
+    case_results = []
+    for case in dataset["cases"]:
+        failures: list[str] = []
+        if any(surface != "examples" for surface in case["surfaces"]):
+            failures.extend(_check_generator_case(case))
+        if "examples" in case["surfaces"]:
+            failures.extend(_check_examples_case(case))
+
+        case_results.append(
+            {
+                "id": case["id"],
+                "surfaces": case["surfaces"],
+                "status": "passed" if not failures else "failed",
+                "failures": failures,
+            }
+        )
+
+    failed = sum(1 for case in case_results if case["status"] == "failed")
+    return {
+        "dataset": dataset["name"],
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "upload": "requested" if upload_enabled else "disabled",
+        "summary": {
+            "total": len(case_results),
+            "passed": len(case_results) - failed,
+            "failed": failed,
+        },
+        "cases": case_results,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the local 1.0 release evaluation gate.")
+    parser.add_argument("--dataset", type=Path, default=DEFAULT_DATASET)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--no-upload",
+        action="store_true",
+        default=False,
+        help="Keep evaluation local-only. This is the default for CI and release PRs.",
+    )
+    parser.add_argument(
+        "--upload-langsmith",
+        action="store_true",
+        help="Mark that a LangSmith upload was requested by the caller.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    upload_enabled = bool(args.upload_langsmith and not args.no_upload)
+    dataset = _load_dataset(args.dataset)
+    report = run_evaluation(dataset, upload_enabled=upload_enabled)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(
+        "Release evaluation: "
+        f"{report['summary']['passed']}/{report['summary']['total']} passed; "
+        f"upload={report['upload']}; report={args.output}"
+    )
+    return 0 if report["summary"]["failed"] == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ DEV_DEPENDENCIES = [
 
 setup(
     name="langgraph-system-generator",
-    version="0.1.1",
+    version="1.0.0",
     description="LangGraph Notebook Foundry scaffolding",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -82,7 +82,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Intended Audience :: Developers",
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Topic :: Software Development :: Libraries",
     ],
 )

--- a/src/langgraph_system_generator/__init__.py
+++ b/src/langgraph_system_generator/__init__.py
@@ -1,5 +1,5 @@
 """LangGraph Notebook Foundry package scaffold."""
 
 __all__ = ["__version__"]
-__version__ = "0.1.1"
+__version__ = "1.0.0"
 

--- a/src/langgraph_system_generator/api/server.py
+++ b/src/langgraph_system_generator/api/server.py
@@ -15,6 +15,7 @@ from fastapi.responses import FileResponse, HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, ConfigDict, Field
 
+from langgraph_system_generator import __version__
 from langgraph_system_generator.constants import _BASE_OUTPUT, resolve_under_base
 from langgraph_system_generator.cli import (
     GenerationArtifacts,
@@ -50,7 +51,7 @@ async def _lifespan(app_: FastAPI):  # noqa: ARG001
 
 app = FastAPI(
     title="LangGraph Notebook Foundry API",
-    version="0.1.1",
+    version=__version__,
     lifespan=_lifespan,
 )
 

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -1547,17 +1547,17 @@ def _run_generate(args: argparse.Namespace) -> int:
             )
         )
     except GenerationError as exc:
-        print(f"✗ Failed to generate artifacts: {exc}")
+        print(f"ERROR: Failed to generate artifacts: {exc}")
         if exc.hint:
             print(f"  Hint: {exc.hint}")
         return 1
     except OptionalDependencyError as exc:
-        print(f"✗ Failed to generate artifacts: {exc}")
+        print(f"ERROR: Failed to generate artifacts: {exc}")
         if exc.hint:
             print(f"  Hint: {exc.hint}")
         return 1
 
-    print(f"✓ Generated artifacts in {artifacts['output_dir']}")
+    print(f"Generated artifacts in {artifacts['output_dir']}")
     print(f"  Manifest: {artifacts['manifest_path']}")
     if artifacts["manifest"].get("plan_path"):
         print(f"  Plan: {artifacts['manifest']['plan_path']}")
@@ -1591,7 +1591,7 @@ def _run_build_index(args: argparse.Namespace) -> int:
                 chunk_overlap=args.chunk_overlap,
             )
         )
-        print(f"✓ Vector index written to {path}")
+        print(f"Vector index written to {path}")
         return 0
     except (
         FileNotFoundError,
@@ -1599,7 +1599,7 @@ def _run_build_index(args: argparse.Namespace) -> int:
         RuntimeError,
         ValueError,
     ) as exc:  # pragma: no cover - defensive
-        print(f"✗ Failed to build index: {exc}")
+        print(f"ERROR: Failed to build index: {exc}")
         return 1
 
 

--- a/src/langgraph_system_generator/generator/graph_design_registry.py
+++ b/src/langgraph_system_generator/generator/graph_design_registry.py
@@ -240,7 +240,13 @@ def _build_deepagents_fallback(*_args, **_kwargs) -> dict[str, Any]:
             },
         ],
         "edges": [],
-        "conditional_edges": [],
+        "conditional_edges": [
+            {
+                "from": "deep_agent",
+                "condition": "Finish once the Deep Agents harness returns a final response",
+                "branches": {"complete": "END"},
+            }
+        ],
         "entry_point": "deep_agent",
         "checkpointing": True,
     }

--- a/src/langgraph_system_generator/patterns/router.py
+++ b/src/langgraph_system_generator/patterns/router.py
@@ -1,9 +1,6 @@
 """Router pattern generator aligned with current LangGraph graph APIs."""
 
 from __future__ import annotations
-import pytest
-import ast
-
 
 from typing import Dict, List, Optional, Union
 

--- a/tests/evaluation/release_1_0_eval_cases.json
+++ b/tests/evaluation/release_1_0_eval_cases.json
@@ -1,0 +1,51 @@
+{
+  "name": "langgraph-system-generator-1.0-local-evaluation",
+  "description": "Deterministic local release gate for core generator trajectory surfaces.",
+  "cases": [
+    {
+      "id": "router_stub",
+      "prompt": "Create a router-based customer support assistant",
+      "expected_architecture": "router",
+      "min_cell_count": 6,
+      "surfaces": ["architecture_selection", "graph_design", "notebook_composition", "qa_repair"]
+    },
+    {
+      "id": "subagents_stub",
+      "prompt": "Create a supervisor team that delegates research and writing to subagents",
+      "expected_architecture": "subagents",
+      "min_cell_count": 6,
+      "surfaces": ["architecture_selection", "graph_design", "notebook_composition", "qa_repair"]
+    },
+    {
+      "id": "autoagent_stub",
+      "prompt": "Create an AutoAgent planner executor critic assistant",
+      "expected_architecture": "autoagent",
+      "agent_type": "autoagent",
+      "min_cell_count": 6,
+      "surfaces": ["architecture_selection", "graph_design", "notebook_composition", "qa_repair"]
+    },
+    {
+      "id": "deepagents_stub",
+      "prompt": "Create a Deep Agents research assistant",
+      "expected_architecture": "deepagents",
+      "agent_type": "deepagents",
+      "min_cell_count": 6,
+      "surfaces": ["architecture_selection", "graph_design", "notebook_composition", "qa_repair"]
+    },
+    {
+      "id": "examples_inventory",
+      "prompt": "Verify release example coverage",
+      "expected_architecture": "router",
+      "min_cell_count": 0,
+      "expected_examples": [
+        "examples/router_pattern_example.py",
+        "examples/subagents_pattern_example.py",
+        "examples/deepagents_pattern_example.py",
+        "examples/human_approval_pattern.py",
+        "examples/llm_judge_example.py",
+        "examples/llm_compiler_example.py"
+      ],
+      "surfaces": ["examples"]
+    }
+  ]
+}

--- a/tests/integration/test_packaging_install_smoke.py
+++ b/tests/integration/test_packaging_install_smoke.py
@@ -1,0 +1,173 @@
+"""Opt-in isolated install smoke tests for the documented packaging matrix."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import venv
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+pytestmark = pytest.mark.packaging_smoke
+
+
+def _smoke_enabled() -> bool:
+    return os.getenv("RUN_PACKAGING_SMOKE") == "1"
+
+
+def _scenario_enabled(name: str) -> bool:
+    scenarios = os.getenv("PACKAGING_SMOKE_SCENARIOS", "minimal,api,full")
+    return name in {item.strip() for item in scenarios.split(",") if item.strip()}
+
+
+def _python_exe(venv_dir: Path) -> Path:
+    if sys.platform.startswith("win"):
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _script_exe(venv_dir: Path, script_name: str) -> Path:
+    if sys.platform.startswith("win"):
+        return venv_dir / "Scripts" / f"{script_name}.exe"
+    return venv_dir / "bin" / script_name
+
+
+def _run(
+    command: list[str | os.PathLike[str]],
+    *,
+    cwd: Path | None = None,
+    timeout: int = 240,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(part) for part in command],
+        cwd=str(cwd or REPO_ROOT),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def _create_venv(tmp_path: Path) -> Path:
+    venv_dir = tmp_path / "venv"
+    venv.EnvBuilder(with_pip=True).create(venv_dir)
+    return venv_dir
+
+
+def _install_repo(venv_dir: Path, spec: str) -> None:
+    python = _python_exe(venv_dir)
+    result = _run(
+        [python, "-m", "pip", "install", "--disable-pip-version-check", spec],
+        timeout=900,
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def _assert_package_version(venv_dir: Path) -> None:
+    python = _python_exe(venv_dir)
+    result = _run(
+        [
+            python,
+            "-c",
+            "import langgraph_system_generator as pkg; assert pkg.__version__ == '1.0.0', pkg.__version__",
+        ]
+    )
+    assert result.returncode == 0, result.stdout
+
+
+@pytest.mark.skipif(not _smoke_enabled(), reason="set RUN_PACKAGING_SMOKE=1")
+def test_minimal_install_exposes_cli_help_and_friendly_full_extra_error(tmp_path: Path) -> None:
+    if not _scenario_enabled("minimal"):
+        pytest.skip("minimal packaging smoke scenario disabled")
+
+    venv_dir = _create_venv(tmp_path)
+    _install_repo(venv_dir, str(REPO_ROOT))
+    _assert_package_version(venv_dir)
+
+    lnf = _script_exe(venv_dir, "lnf")
+    help_result = _run([lnf, "--help"])
+    assert help_result.returncode == 0, help_result.stdout
+    assert "LangGraph Notebook Foundry CLI" in help_result.stdout
+
+    api_import = _run(
+        [
+            _python_exe(venv_dir),
+            "-c",
+            "import langgraph_system_generator.api as api; assert api.__all__ == ['app']",
+        ]
+    )
+    assert api_import.returncode == 0, api_import.stdout
+
+    generate_result = _run(
+        [
+            lnf,
+            "generate",
+            "Create a router-based assistant",
+            "--mode",
+            "stub",
+            "--output",
+            "minimal-output",
+            "--formats",
+            "ipynb",
+        ],
+        cwd=tmp_path,
+    )
+    assert generate_result.returncode == 1
+    assert '".[full]"' in generate_result.stdout
+    assert "Traceback" not in generate_result.stdout
+
+
+@pytest.mark.skipif(not _smoke_enabled(), reason="set RUN_PACKAGING_SMOKE=1")
+def test_api_extra_exposes_fastapi_app_without_full_extra(tmp_path: Path) -> None:
+    if not _scenario_enabled("api"):
+        pytest.skip("api packaging smoke scenario disabled")
+
+    venv_dir = _create_venv(tmp_path)
+    _install_repo(venv_dir, f"{REPO_ROOT}[api]")
+    _assert_package_version(venv_dir)
+
+    result = _run(
+        [
+            _python_exe(venv_dir),
+            "-c",
+            "from langgraph_system_generator.api import app; assert app.title == 'LangGraph Notebook Foundry API'",
+        ]
+    )
+    assert result.returncode == 0, result.stdout
+
+
+@pytest.mark.skipif(not _smoke_enabled(), reason="set RUN_PACKAGING_SMOKE=1")
+def test_full_extra_can_generate_stub_notebook(tmp_path: Path) -> None:
+    if not _scenario_enabled("full"):
+        pytest.skip("full packaging smoke scenario disabled")
+
+    venv_dir = _create_venv(tmp_path)
+    _install_repo(venv_dir, f"{REPO_ROOT}[full]")
+    _assert_package_version(venv_dir)
+
+    output_dir = tmp_path / "full-output"
+    lnf = _script_exe(venv_dir, "lnf")
+    result = _run(
+        [
+            lnf,
+            "generate",
+            "Create a router-based assistant",
+            "--mode",
+            "stub",
+            "--output",
+            "full-output",
+            "--formats",
+            "ipynb",
+        ],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stdout
+    assert (output_dir / "notebook.ipynb").exists()
+    assert (output_dir / "manifest.json").exists()

--- a/tests/integration/test_packaging_install_smoke.py
+++ b/tests/integration/test_packaging_install_smoke.py
@@ -64,7 +64,7 @@ def _create_venv(tmp_path: Path) -> Path:
 def _install_repo(venv_dir: Path, spec: str) -> None:
     python = _python_exe(venv_dir)
     result = _run(
-        [python, "-m", "pip", "install", "--disable-pip-version-check", spec],
+        [python, "-m", "pip", "install", "--disable-pip-version-check", "-e", spec],
         timeout=900,
     )
     assert result.returncode == 0, result.stdout

--- a/tests/unit/test_release_evaluation_gate.py
+++ b/tests/unit/test_release_evaluation_gate.py
@@ -1,0 +1,75 @@
+"""Tests for the local 1.0 release evaluation gate."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_release_evaluation_dataset_covers_core_generator_surfaces() -> None:
+    dataset_path = REPO_ROOT / "tests" / "evaluation" / "release_1_0_eval_cases.json"
+    assert dataset_path.exists()
+
+    payload = json.loads(dataset_path.read_text(encoding="utf-8"))
+    cases = payload["cases"]
+    surfaces = {surface for case in cases for surface in case["surfaces"]}
+
+    assert "architecture_selection" in surfaces
+    assert "graph_design" in surfaces
+    assert "notebook_composition" in surfaces
+    assert "qa_repair" in surfaces
+    assert "examples" in surfaces
+
+
+def test_release_evaluation_gate_runs_locally_without_upload(tmp_path: Path) -> None:
+    output_path = tmp_path / "release-eval-report.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/run_release_eval.py",
+            "--no-upload",
+            "--output",
+            str(output_path),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stdout
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report["upload"] == "disabled"
+    assert report["summary"]["failed"] == 0
+    assert report["summary"]["total"] >= 5
+
+
+def test_release_evaluation_gate_can_mark_langsmith_upload_requested(tmp_path: Path) -> None:
+    output_path = tmp_path / "release-eval-report.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/run_release_eval.py",
+            "--upload-langsmith",
+            "--output",
+            str(output_path),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stdout
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report["upload"] == "requested"
+    assert report["summary"]["failed"] == 0

--- a/tests/unit/test_release_readiness_metadata.py
+++ b/tests/unit/test_release_readiness_metadata.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+import re
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+ALPHA_RELEASE_STATUS = re.compile(
+    r"(?:project|release|development)\s+status\s*[:=-]\s*alpha"
+    r"|\balpha\s+(?:baseline|release|status)\b"
+    r"|\bdevelopment status :: 3 - alpha\b",
+    re.IGNORECASE,
+)
 
 
 def _read(path: str) -> str:
@@ -48,12 +55,13 @@ def test_public_docs_no_longer_describe_release_as_alpha() -> None:
     for path in checked_paths:
         content = _read(path)
         assert "0.1.1" not in content
-        assert "Alpha" not in content
-        assert "alpha" not in content
+        assert ALPHA_RELEASE_STATUS.search(content) is None
 
 
-def test_diagram_workflow_uses_default_github_token_for_pr_creation() -> None:
+def test_diagram_workflow_uses_pr_token_that_can_trigger_checks() -> None:
     workflow = _read(".github/workflows/diagram.yml")
 
-    assert "token: ${{ github.token }}" in workflow
-    assert "secrets.GH_PAT" not in workflow
+    assert "token: ${{ secrets.GH_PAT }}" in workflow
+    assert "token: ${{ github.token }}" not in workflow
+    assert "steps.diagram-token.outputs.available == 'true'" in workflow
+    assert "Skipping diagram PR creation because secrets.GH_PAT is not configured" in workflow

--- a/tests/unit/test_release_readiness_metadata.py
+++ b/tests/unit/test_release_readiness_metadata.py
@@ -1,0 +1,59 @@
+"""Release-readiness metadata and workflow contract tests."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _setup_call_keywords() -> dict[str, ast.AST]:
+    tree = ast.parse(_read("setup.py"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "setup":
+            return {keyword.arg: keyword.value for keyword in node.keywords}
+    raise AssertionError("setup.py does not call setup()")
+
+
+def test_package_metadata_is_ready_for_1_0_release() -> None:
+    keywords = _setup_call_keywords()
+
+    assert ast.literal_eval(keywords["version"]) == "1.0.0"
+    assert ast.literal_eval(keywords["license"]) == "MIT"
+    assert (REPO_ROOT / "LICENSE").exists()
+    assert (REPO_ROOT / "CHANGELOG.md").exists()
+
+    classifiers = ast.literal_eval(keywords["classifiers"])
+    assert "Development Status :: 5 - Production/Stable" in classifiers
+    assert "Development Status :: 3 - Alpha" not in classifiers
+
+    init_version = _read("src/langgraph_system_generator/__init__.py")
+    assert '__version__ = "1.0.0"' in init_version
+
+
+def test_public_docs_no_longer_describe_release_as_alpha() -> None:
+    checked_paths = [
+        "README.md",
+        "docs/wiki/README.md",
+        "docs/wiki/Home.md",
+        "memory-bank/progress.md",
+    ]
+
+    for path in checked_paths:
+        content = _read(path)
+        assert "0.1.1" not in content
+        assert "Alpha" not in content
+        assert "alpha" not in content
+
+
+def test_diagram_workflow_uses_default_github_token_for_pr_creation() -> None:
+    workflow = _read(".github/workflows/diagram.yml")
+
+    assert "token: ${{ github.token }}" in workflow
+    assert "secrets.GH_PAT" not in workflow


### PR DESCRIPTION
## Summary
- prepares the repository for the 1.0.0 release baseline with stable package metadata, root MIT license, changelog, and public docs/MemoryBank updates
- fixes the Create diagram workflow PR token handling: use `secrets.GH_PAT` when configured so automation PRs can trigger required checks, and skip PR creation with a notice when the secret is absent
- resolves the #258 packaging matrix with opt-in isolated editable-install smoke tests for minimal/API/full extras and CLI optional-dependency output that avoids Windows console tracebacks
- adds a local deterministic 1.0 LangGraph evaluation gate covering architecture selection, graph design, notebook composition, QA/repair, and examples inventory
- keeps real residuals open with audit comments while closing stale completed/duplicate issues with evidence

Closes #258.

## Review follow-up
- Addressed and resolved the workflow-token review thread.
- Addressed and resolved the editable packaging smoke review thread.
- Addressed and resolved the brittle alpha-doc assertion review thread.

## Verification
- `python -m pytest tests/unit/test_documentation_coverage.py tests/unit/test_release_readiness_metadata.py -q` -> 8 passed
- `RUN_PACKAGING_SMOKE=1 PACKAGING_SMOKE_SCENARIOS=minimal,api python -m pytest tests/integration/test_packaging_install_smoke.py -q` -> 2 passed, 1 skipped
- `RUN_PACKAGING_SMOKE=1 PACKAGING_SMOKE_SCENARIOS=full python -m pytest tests/integration/test_packaging_install_smoke.py -q` -> 1 passed, 2 skipped
- `python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` -> 0
- Previous full branch verification before review follow-up: `python -m pytest --asyncio-mode=auto` -> 625 passed, 4 skipped
- Previous local release eval: `python scripts/run_release_eval.py --no-upload --output output/release-evaluation/release_1_0_eval_report.json` -> 5/5 passed