### PR TITLE
Fix diagram workflow PAT checkout auth

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["python"]
+        language: ["actions", "javascript-typescript", "python"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -33,19 +33,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 0
-      - name: Update diagram
-        uses: githubocto/repo-visualizer@0.9.1
-        with:
-          excluded_paths: "ignore,.github"
-          root_path: "src/"
-          commit_message: "Repo visualization diagram"
-          should_push: false
-
       - name: Check diagram PR token
         id: diagram-token
         shell: bash
@@ -56,8 +43,26 @@ jobs:
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping diagram PR creation because secrets.GH_PAT is not configured. Configure a PAT with repo/workflow scopes so automation PRs trigger required checks."
+            echo "::notice::Skipping diagram refresh because secrets.GH_PAT is not configured. Configure a PAT with repo/workflow scopes so automation PRs trigger required checks."
           fi
+
+      - name: Checkout code
+        if: steps.diagram-token.outputs.available == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+          persist-credentials: true
+
+      - name: Update diagram
+        if: steps.diagram-token.outputs.available == 'true'
+        uses: githubocto/repo-visualizer@0.9.1
+        with:
+          excluded_paths: "ignore,.github"
+          root_path: "src/"
+          commit_message: "Repo visualization diagram"
+          should_push: false
 
       - name: Open diagram update PR
         if: steps.diagram-token.outputs.available == 'true'

--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -30,8 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: codeql
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Check diagram PR token
         id: diagram-token

--- a/docs/CI_CD_WORKFLOWS.md
+++ b/docs/CI_CD_WORKFLOWS.md
@@ -17,7 +17,8 @@ All workflows follow security best practices:
 
 **File**: `.github/workflows/codeql.yml`
 
-**Purpose**: Automated security scanning for Python code
+**Purpose**: Automated security scanning for Python, JavaScript/TypeScript, and
+GitHub Actions workflow code
 
 **Triggers**:
 - Push to `main` branch
@@ -29,6 +30,8 @@ All workflows follow security best practices:
 - Extended security queries
 - Security and quality analysis
 - Weekly scheduled CodeQL static code analysis
+- Matrix coverage for `actions`, `javascript-typescript`, and `python`, matching
+  the active default-branch ruleset required status checks
 
 **Permissions**:
 - `contents: read` - Repository checkout

--- a/docs/CI_CD_WORKFLOWS.md
+++ b/docs/CI_CD_WORKFLOWS.md
@@ -68,8 +68,8 @@ and opens an update pull request
 - **Depends on CodeQL**: Job waits for security scan to pass
 - Action pinned to `@0.9.1`, the latest published `githubocto/repo-visualizer`
   tag currently used by the workflow (previously used unpinned `@main`)
-- Minimal permissions: `contents: write` and `pull-requests: write` only for
-  the diagram job
+- Minimal `GITHUB_TOKEN` permissions: the diagram job keeps `contents: read`
+  because branch and pull request writes use the explicit automation token
 - Checks `secrets.GH_PAT` before checkout, then uses that token for checkout
   and create-pull-request so automation PRs can trigger normal pull request
   checks under branch protection

--- a/docs/CI_CD_WORKFLOWS.md
+++ b/docs/CI_CD_WORKFLOWS.md
@@ -70,21 +70,23 @@ and opens an update pull request
   tag currently used by the workflow (previously used unpinned `@main`)
 - Minimal permissions: `contents: write` and `pull-requests: write` only for
   the diagram job
-- Uses `secrets.GH_PAT` for create-pull-request so automation PRs can trigger
-  normal pull request checks under branch protection
-- Skips PR creation with a workflow notice if `secrets.GH_PAT` is not
-  configured, rather than failing the whole workflow
+- Checks `secrets.GH_PAT` before checkout, then uses that token for checkout
+  and create-pull-request so automation PRs can trigger normal pull request
+  checks under branch protection
+- Skips checkout, diagram generation, and PR creation with a workflow notice if
+  `secrets.GH_PAT` is not configured, rather than failing the whole workflow
 
 **Workflow**:
 1. Run CodeQL security analysis
-2. Generate repo visualization (only if CodeQL passes)
-3. If `secrets.GH_PAT` is configured, open or update an
-   `automation/repo-visualization-diagram` pull request with `diagram.svg`
+2. Check whether `secrets.GH_PAT` is configured
+3. If the token is available, checkout `main`, generate repo visualization, and
+   open or update an `automation/repo-visualization-diagram` pull request with
+   `diagram.svg`
 
-`GH_PAT` must be a repository automation token with enough scope to push the
-automation branch and open/update pull requests. The default `GITHUB_TOKEN` is
-not used for this step because PRs created with it do not trigger the same
-pull request checks required for protected-branch merging.
+`GH_PAT` must be a repository automation token with enough scope to checkout
+the repository, push the automation branch, and open/update pull requests. The
+default `GITHUB_TOKEN` is not used for this path because PRs created with it do
+not trigger the same pull request checks required for protected-branch merging.
 
 The docs-owned Mermaid/DOT/JSON/Figma repository architecture bundle under
 `docs/diagrams/repo-architecture-visualizer/` is refreshed locally through the

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -31,6 +31,9 @@
   pattern/example, cross-cutting, and duplicate CYOA items; remaining open
   issues are explicit post-1.0/residual work unless #258 is still waiting for
   the release PR merge.
+- After PR #305 merged, the `Create diagram` workflow still failed while
+  creating the automation PR because checkout did not persist the configured
+  `GH_PAT` credentials for later git fetch/push operations.
 
 ## Immediate Next Steps
 
@@ -39,6 +42,8 @@
 - Keep the 1.0 release tracker (#256) aligned with packaging, workflow,
   evaluation, metadata, issue-triage, and PR progress until the `v1.0.0`
   release is published.
+- Land the follow-up `Create diagram` authentication hotfix and verify the next
+  `main` workflow run is green before tagging `v1.0.0`.
 - Keep maintainer visualization docs aligned when generator stages, package
   boundaries, module relationships, or environment-variable usage changes.
 - Preserve parity between CLI-driven, API-driven, and web-driven artifact

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -34,6 +34,9 @@
 - After PR #305 merged, the `Create diagram` workflow still failed while
   creating the automation PR because checkout did not persist the configured
   `GH_PAT` credentials for later git fetch/push operations.
+- The active default-branch ruleset requires CodeQL contexts for `actions`,
+  `javascript-typescript`, and `python`; the reusable CodeQL workflow must keep
+  that matrix aligned or otherwise green PR checks can still remain unmergeable.
 
 ## Immediate Next Steps
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -48,6 +48,8 @@
 - A follow-up `Create diagram` hotfix branch checks `GH_PAT` before checkout,
   uses that token for checkout and pull-request creation, and skips cleanly
   with a notice when the secret is unavailable.
+- The same hotfix branch aligns the reusable CodeQL matrix with the active
+  ruleset-required contexts: `actions`, `javascript-typescript`, and `python`.
 
 ## Known Issues and Limitations
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -45,9 +45,9 @@
   contributor guidance, and MemoryBank context.
 - Release metadata now includes a root MIT license, changelog, and 1.0.0 package
   version/classifier updates on the release-readiness branch.
-- The release-readiness branch fixes the Create diagram workflow so it uses a
-  configured `GH_PAT` automation token for PR creation and skips cleanly with a
-  notice when that secret is unavailable.
+- A follow-up `Create diagram` hotfix branch checks `GH_PAT` before checkout,
+  uses that token for checkout and pull-request creation, and skips cleanly
+  with a notice when the secret is unavailable.
 
 ## Known Issues and Limitations
 
@@ -63,3 +63,5 @@
 - Router fallback/general routing (#60), iterative requirements refinement
   (#202), and the remaining CYOA notebook cell issues are tracked as residual
   follow-up work rather than closed stale items.
+- The `Create diagram` workflow must pass on `main` after the authentication
+  hotfix merges before the `v1.0.0` release is tagged.

--- a/tests/unit/test_release_readiness_metadata.py
+++ b/tests/unit/test_release_readiness_metadata.py
@@ -75,7 +75,13 @@ def test_diagram_workflow_authenticates_checkout_before_diagram_generation() -> 
     update_index = workflow.index("- name: Update diagram")
 
     assert token_check_index < checkout_index < update_index
-    assert "if: steps.diagram-token.outputs.available == 'true'\n        uses: actions/checkout@v4" in workflow
-    assert "token: ${{ secrets.GH_PAT }}" in workflow
+    assert "if: steps.diagram-token.outputs.available == 'true'" in workflow
+    assert "uses: actions/checkout@v4" in workflow
     assert "persist-credentials: true" in workflow
-    assert "Skipping diagram refresh because secrets.GH_PAT is not configured" in workflow
+
+
+def test_diagram_workflow_does_not_grant_unused_github_token_write_permissions() -> None:
+    workflow = _read(".github/workflows/diagram.yml")
+
+    assert "contents: write" not in workflow
+    assert "pull-requests: write" not in workflow

--- a/tests/unit/test_release_readiness_metadata.py
+++ b/tests/unit/test_release_readiness_metadata.py
@@ -64,4 +64,18 @@ def test_diagram_workflow_uses_pr_token_that_can_trigger_checks() -> None:
     assert "token: ${{ secrets.GH_PAT }}" in workflow
     assert "token: ${{ github.token }}" not in workflow
     assert "steps.diagram-token.outputs.available == 'true'" in workflow
-    assert "Skipping diagram PR creation because secrets.GH_PAT is not configured" in workflow
+    assert "Skipping diagram refresh because secrets.GH_PAT is not configured" in workflow
+
+
+def test_diagram_workflow_authenticates_checkout_before_diagram_generation() -> None:
+    workflow = _read(".github/workflows/diagram.yml")
+
+    token_check_index = workflow.index("- name: Check diagram PR token")
+    checkout_index = workflow.index("- name: Checkout code")
+    update_index = workflow.index("- name: Update diagram")
+
+    assert token_check_index < checkout_index < update_index
+    assert "if: steps.diagram-token.outputs.available == 'true'\n        uses: actions/checkout@v4" in workflow
+    assert "token: ${{ secrets.GH_PAT }}" in workflow
+    assert "persist-credentials: true" in workflow
+    assert "Skipping diagram refresh because secrets.GH_PAT is not configured" in workflow

--- a/tests/unit/test_release_readiness_metadata.py
+++ b/tests/unit/test_release_readiness_metadata.py
@@ -85,3 +85,10 @@ def test_diagram_workflow_does_not_grant_unused_github_token_write_permissions()
 
     assert "contents: write" not in workflow
     assert "pull-requests: write" not in workflow
+
+
+def test_codeql_workflow_covers_ruleset_required_languages() -> None:
+    workflow = _read(".github/workflows/codeql.yml")
+
+    for language in ("actions", "javascript-typescript", "python"):
+        assert f'"{language}"' in workflow


### PR DESCRIPTION
## Summary
- gate the Create diagram job on `secrets.GH_PAT` before checkout/generation
- persist the PAT through `actions/checkout` so create-pull-request can fetch/push the automation branch
- update CI docs and MemoryBank release context for the follow-up hotfix

## Tests
- `python -m pytest tests/unit/test_release_readiness_metadata.py -q`
- `python -m pytest tests/unit/test_documentation_coverage.py -q`
- `python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`

## Release note
After this merges, the next `Create diagram` run on `main` must pass before tagging `v1.0.0`.