### PR TITLE
Fix strict architecture selection and QA advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,15 +188,17 @@ Successful generations can include:
 The manifest includes advisory fields such as `requirements_feedback`,
 `architecture_feedback`, `graph_design_feedback`, `graph_exports`,
 `tool_planning_feedback`, `notebook_composition_feedback`,
-`notebook_dependency_plan`, and `qa_repair_feedback`. These are response/output
-fields, not new request fields.
+`notebook_dependency_plan`, `qa_repair_feedback`, `qa_reports`, and
+`qa_summary`. These are response/output fields, not new request fields.
 
 Use `manifest.json` as the primary summary for:
 
 - the selected architecture and generation mode
 - export success or failure per artifact
 - warning surfaces and fallback paths
-- repair attempt history and next-step hints
+- repair attempt history, QA findings, and next-step hints
+- exact QA advisory details, severity classification, and whether artifacts
+  remain usable
 - artifact paths that can be downloaded through `GET /artifacts`
 
 ## API And Web UI

--- a/docs/wiki/Architecture-Deep-Dive.md
+++ b/docs/wiki/Architecture-Deep-Dive.md
@@ -299,7 +299,9 @@ Validates notebook structure without execution:
 
 Validates the generated notebook by executing the built notebook artifact. In
 `live` mode, missing notebook runtime support is a real gate failure; in `stub`
-mode it is recorded as non-blocking runtime evidence.
+mode it is recorded as non-blocking runtime evidence. Failed `error` reports are
+blocking; failed `warning` and `info` reports are advisory and can still package
+usable artifacts.
 
 ```python
 {
@@ -315,7 +317,20 @@ mode it is recorded as non-blocking runtime evidence.
         "execution": {"executed_cells": 4}
       }
     }
-  ]
+  ],
+  "qa_summary": {
+    "status": "passed",
+    "artifacts_usable": true,
+    "counts": {
+      "total": 4,
+      "passed": 4,
+      "failed": 0,
+      "blocking": 0,
+      "non_blocking": 0,
+      "informational": 0
+    },
+    "findings": []
+  }
 }
 ```
 
@@ -323,12 +338,14 @@ mode it is recorded as non-blocking runtime evidence.
 `execute_notebook`)
 
 #### 9. Repair Loop
-**Input**: Notebook + Failed QA reports  
+**Input**: Notebook + Blocking failed QA reports
 **Output**: Repaired notebook
 
-If QA fails, the shared QA/repair engine applies registered deterministic repair
-routines in memory, revalidates the candidate notebook, and persists the repair
-only when validation is non-regressive:
+If blocking QA fails, the shared QA/repair engine applies registered
+deterministic repair routines in memory, revalidates the candidate notebook, and
+persists the repair only when validation is non-regressive. Advisory-only
+failures bypass repair and package successfully with exact details in
+`qa_summary`:
 
 ```python
 {
@@ -345,12 +362,36 @@ only when validation is non-regressive:
     "rollback_used": true,
     "unrepaired_failures": ["Python Syntax: invalid syntax"],
     "next_steps": ["Inspect the QA and Repair Summary cell before retrying."]
+  },
+  "qa_summary": {
+    "status": "blocking_failed",
+    "artifacts_usable": false,
+    "counts": {
+      "total": 1,
+      "passed": 0,
+      "failed": 1,
+      "blocking": 1,
+      "non_blocking": 0,
+      "informational": 0
+    },
+    "findings": [
+      {
+        "stage": "static",
+        "check_name": "Python Syntax",
+        "rule_id": "python_syntax",
+        "severity": "error",
+        "message": "invalid syntax",
+        "suggestions": ["Inspect the generated code cell."],
+        "repairable": true,
+        "attempt": 1
+      }
+    ]
   }
 }
 ```
 
 **Repair Strategy**:
-1. Identify specific failures
+1. Identify specific blocking failures
 2. Select matching routines from `QARepairRegistry`
 3. Apply fixes to an in-memory notebook candidate
 4. Re-run QA validation and accept only non-regressive candidates
@@ -431,6 +472,7 @@ class GeneratorState(TypedDict):
     qa_history: List[QAReport]
     repair_attempts: int
     qa_repair_feedback: QARepairFeedback
+    qa_summary: Dict[str, Any]
     
     # Output
     artifacts_manifest: Dict[str, str]
@@ -444,7 +486,7 @@ class GeneratorState(TypedDict):
 - **Advisory Graph Feedback**: `graph_design_feedback` captures validation and fallback details while `graph_exports` stores Mermaid/schema bundles for manifests and notebook overview cells
 - **Advisory Tool Feedback**: `tool_planning_feedback` records fallback, validation, environment, and dependency warnings while `tools_plan` remains the downstream list
 - **Notebook Composition Feedback**: `notebook_composition_feedback` and `notebook_dependency_plan` explain fallback and dependency decisions without replacing `generated_cells`
-- **QA History**: `qa_reports` is the current snapshot; `qa_history` preserves attempt-by-attempt evidence across static QA, runtime QA, and repair
+- **QA Reports and Summary**: `qa_reports` is the current snapshot; `qa_summary` classifies failed reports as blocking, non-blocking, or informational; `qa_history` preserves attempt-by-attempt evidence across static QA, runtime QA, and repair
 - **Last-write-wins cells**: `generated_cells` intentionally has no reducer, so each repair pass replaces prior cells
 - **Immutability**: State updates create new state versions (LangGraph managed)
 - **Type Safety**: TypedDict provides IDE autocomplete and validation
@@ -607,9 +649,9 @@ Agents outputs, so offline fallback notebooks do not auto-install `deepagents`.
 
 ### Repair Strategies
 
-When QA fails, the repair agent:
+When blocking QA fails, the repair agent:
 
-1. **Analyzes failures**: Categorizes error types
+1. **Analyzes failures**: Categorizes blocking error types
 2. **Selects routines**: Uses `QARepairRegistry` to find matching deterministic fixes
 3. **Applies candidates**: Updates in-memory notebook cells first
 4. **Validates**: Re-runs QA checks before accepting the candidate
@@ -619,7 +661,7 @@ When QA fails, the repair agent:
 
 If repair fails after max attempts:
 - Packages best available version
-- Includes QA reports in manifest
+- Includes QA reports and QA summary in manifest
 - Logs warnings for manual review
 
 ## Export System

--- a/docs/wiki/CLI-and-API-Reference.md
+++ b/docs/wiki/CLI-and-API-Reference.md
@@ -332,6 +332,20 @@ Generate a multi-agent system from a prompt.
       "next_steps": [],
       "warnings": []
     },
+    "qa_reports": [],
+    "qa_summary": {
+      "status": "passed",
+      "artifacts_usable": true,
+      "counts": {
+        "total": 0,
+        "passed": 0,
+        "failed": 0,
+        "blocking": 0,
+        "non_blocking": 0,
+        "informational": 0
+      },
+      "findings": []
+    },
     "warnings": [],
     "export_results": {
       "ipynb": {"status": "completed", "path": "./output/api/notebook.ipynb"}
@@ -599,7 +613,8 @@ Every successful generation produces:
 ### Manifest Structure
 
 The `manifest.json` contains complete generation metadata, including structured
-phase timing, per-format export status, graph-design exports, and non-fatal warnings:
+phase timing, per-format export status, graph-design exports, exact QA
+summaries, and non-fatal warnings:
 
 ```json
 {
@@ -674,6 +689,20 @@ phase timing, per-format export status, graph-design exports, and non-fatal warn
     "unrepaired_failures": [],
     "next_steps": [],
     "warnings": []
+  },
+  "qa_reports": [],
+  "qa_summary": {
+    "status": "passed",
+    "artifacts_usable": true,
+    "counts": {
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "blocking": 0,
+      "non_blocking": 0,
+      "informational": 0
+    },
+    "findings": []
   },
   "notebook_path": "./output/api/notebook.ipynb",
   "html_path": "./output/api/notebook.html",

--- a/src/langgraph_system_generator/api/static/app.js
+++ b/src/langgraph_system_generator/api/static/app.js
@@ -148,6 +148,56 @@ function appendLabeledValue(parent, label, value, options = {}) {
     parent.appendChild(item);
 }
 
+function appendQaSummary(parent, qaSummary) {
+    if (!qaSummary || !Array.isArray(qaSummary.findings) || qaSummary.findings.length === 0) {
+        return;
+    }
+
+    const qaItem = document.createElement('div');
+    qaItem.className = 'result-item';
+    qaItem.style.background = 'var(--bg-primary)';
+    qaItem.style.padding = '1rem';
+    qaItem.style.borderRadius = '0.5rem';
+    qaItem.style.marginTop = '1rem';
+
+    const heading = document.createElement('h4');
+    heading.textContent = qaSummary.status === 'blocking_failed'
+        ? 'QA Findings'
+        : 'QA Advisories';
+    heading.style.marginBottom = '0.5rem';
+    qaItem.appendChild(heading);
+
+    const status = document.createElement('p');
+    status.textContent = qaSummary.artifacts_usable === false
+        ? 'Generated artifacts need review before use.'
+        : 'Generated artifacts remain usable.';
+    qaItem.appendChild(status);
+
+    const findingsList = document.createElement('ul');
+    qaSummary.findings.forEach((finding) => {
+        const item = document.createElement('li');
+        const stage = finding.stage || 'qa';
+        const checkName = finding.check_name || 'QA Check';
+        const severity = finding.severity || 'info';
+        const message = finding.message || 'No QA message was provided.';
+        item.textContent = `${stage} / ${checkName} (${severity}): ${message}`;
+
+        if (Array.isArray(finding.suggestions) && finding.suggestions.length > 0) {
+            const suggestions = document.createElement('ul');
+            finding.suggestions.forEach((suggestion) => {
+                const suggestionItem = document.createElement('li');
+                suggestionItem.textContent = suggestion;
+                suggestions.appendChild(suggestionItem);
+            });
+            item.appendChild(suggestions);
+        }
+
+        findingsList.appendChild(item);
+    });
+    qaItem.appendChild(findingsList);
+    parent.appendChild(qaItem);
+}
+
 // Update character count
 promptTextarea.addEventListener('input', () => {
     const count = getCharacterCount(promptTextarea.value);
@@ -383,6 +433,8 @@ function showResult(data) {
     const manifest = data.manifest || {};
     const mode = data.mode || 'unknown';
     const warnings = Array.isArray(manifest.warnings) ? manifest.warnings : [];
+    const qaSummary = manifest.qa_summary || {};
+    const hasQaAdvisories = qaSummary.status === 'advisories';
 
     resultContent.replaceChildren();
 
@@ -395,9 +447,9 @@ function showResult(data) {
     const successHeading = document.createElement('h3');
     successHeading.style.color = 'var(--success-color)';
     successHeading.style.marginBottom = '0.5rem';
-    successHeading.textContent = warnings.length > 0
-        ? 'Generation Completed With Warnings'
-        : 'Generation Successful!';
+    successHeading.textContent = hasQaAdvisories
+        ? 'Generation Completed With Advisories'
+        : (warnings.length > 0 ? 'Generation Completed With Warnings' : 'Generation Successful!');
 
     const successParagraph = document.createElement('p');
     successParagraph.textContent = `Your system was generated in ${mode} mode.`;
@@ -448,6 +500,8 @@ function showResult(data) {
         warningItem.appendChild(warningList);
         resultWrapper.appendChild(warningItem);
     }
+
+    appendQaSummary(resultWrapper, qaSummary);
 
     const exportSection = document.createElement('div');
     exportSection.className = 'result-item';

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -34,6 +34,7 @@ from langgraph_system_generator.generator.architecture_registry import (
     get_default_architecture_registry,
 )
 from langgraph_system_generator.generator.tool_registry import get_tool_registry
+from langgraph_system_generator.qa.summary import build_qa_summary, serialize_qa_report
 from langgraph_system_generator.generator.graph_design_registry import (
     build_graph_exports,
     graph_design_issue_messages,
@@ -124,6 +125,7 @@ def _default_state(
         "qa_reports": [],
         "qa_history": [],
         "repair_attempts": 0,
+        "qa_summary": build_qa_summary([]),
         "artifacts_manifest": {},
         "generation_complete": False,
         "error_message": None,
@@ -410,11 +412,15 @@ def _tool_planning_warning_entries(
 def _qa_repair_warning_entries(
     feedback: Dict[str, Any] | None,
     reports: List[Dict[str, Any]] | None,
+    qa_summary: Dict[str, Any] | None = None,
 ) -> List[Dict[str, Any]]:
     """Convert structured QA/repair feedback into manifest warnings."""
 
     feedback = feedback if isinstance(feedback, dict) else {}
     reports = reports if isinstance(reports, list) else []
+    qa_summary = qa_summary if isinstance(qa_summary, dict) else build_qa_summary(reports)
+    counts = qa_summary.get("counts") or {}
+    findings = list(qa_summary.get("findings") or [])
 
     severe_reports = [
         report
@@ -433,18 +439,46 @@ def _qa_repair_warning_entries(
     warning_entries: List[Dict[str, Any]] = []
 
     if unresolved_failures:
+        blocking_message = next(
+            (
+                warning
+                for warning in warnings
+                if str(warning).startswith("Blocking QA issues")
+            ),
+            "Blocking QA issues remain after validation or repair.",
+        )
         warning_entries.append(
             {
                 "code": "qa_validation_failed",
                 "phase": "qa",
-                "message": (
-                    warnings[0]
-                    if warnings
-                    else "Blocking QA issues remain after validation or repair."
-                ),
+                "message": blocking_message,
                 "unrepaired_failures": unresolved_failures,
                 "next_steps": next_steps,
                 "repair_attempts": int(feedback.get("repair_attempts") or 0),
+                "findings": [
+                    finding
+                    for finding in findings
+                    if finding.get("classification") == "blocking"
+                ],
+            }
+        )
+
+    if counts.get("non_blocking", 0) or counts.get("informational", 0):
+        warning_entries.append(
+            {
+                "code": "qa_advisories",
+                "phase": "qa",
+                "message": (
+                    "Generation completed with non-blocking QA advisories; "
+                    "artifacts remain usable."
+                ),
+                "artifacts_usable": qa_summary.get("artifacts_usable", True),
+                "counts": counts,
+                "findings": [
+                    finding
+                    for finding in findings
+                    if finding.get("classification") != "blocking"
+                ],
             }
         )
 
@@ -1109,6 +1143,7 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
         "qa_reports": [],
         "qa_history": [],
         "repair_attempts": 0,
+        "qa_summary": build_qa_summary([]),
         "artifacts_manifest": {},
         "generation_complete": True,
         "error_message": None,
@@ -1226,6 +1261,8 @@ async def generate_artifacts(
     notebook_dependency_plan = serialized.get("notebook_dependency_plan") or {}
     qa_repair_feedback = serialized.get("qa_repair_feedback") or {}
     qa_reports = serialized.get("qa_reports") or []
+    serialized_qa_reports = [serialize_qa_report(report) for report in qa_reports]
+    qa_summary = build_qa_summary(serialized_qa_reports)
 
     manifest: Dict[str, Any] = {
         "prompt": prompt,
@@ -1241,13 +1278,19 @@ async def generate_artifacts(
         "notebook_composition_feedback": notebook_composition_feedback,
         "notebook_dependency_plan": notebook_dependency_plan,
         "qa_repair_feedback": qa_repair_feedback,
+        "qa_reports": serialized_qa_reports,
+        "qa_summary": qa_summary,
         "warnings": [
             *_requirements_warning_entries(requirements_feedback),
             *_architecture_warning_entries(architecture_feedback),
             *_graph_design_warning_entries(graph_design_feedback),
             *_tool_planning_warning_entries(tool_planning_feedback),
             *_notebook_composition_warning_entries(notebook_composition_feedback),
-            *_qa_repair_warning_entries(qa_repair_feedback, qa_reports),
+            *_qa_repair_warning_entries(
+                qa_repair_feedback,
+                serialized_qa_reports,
+                qa_summary,
+            ),
         ],
         "export_results": {},
     }

--- a/src/langgraph_system_generator/generator/agents/architecture_selector.py
+++ b/src/langgraph_system_generator/generator/agents/architecture_selector.py
@@ -91,10 +91,10 @@ Consider:
 
 Return a JSON object with this structure:
 {{
-  "architecture_type": "router" | "subagents" | "hybrid" | "autoagent",
+  "architecture_type": "router" | "subagents" | "hybrid" | "autoagent" | "deepagents",
   "patterns": {{
-    "primary": "pattern_name",
-    "secondary": ["additional_patterns"]
+    "primary": "same registered id as architecture_type",
+    "secondary": ["registered supporting architecture ids"]
   }},
   "justification": "detailed explanation of why this architecture was chosen",
   "feedback": {{
@@ -121,7 +121,32 @@ Documentation Context:
 Recommend the best architecture."""
         )
 
-        response = await self.llm.ainvoke([selection_prompt, user_message])
+        messages = [selection_prompt, user_message]
+
+        structured_llm = self._structured_output_llm()
+        if structured_llm is not None:
+            try:
+                return await self._select_with_structured_output(
+                    structured_llm,
+                    messages,
+                    docs_considered=docs_considered,
+                )
+            except (ValueError, KeyError, TypeError, ValidationError) as exc:
+                reason = f"Architecture selection fallback used: {exc}"
+                logger.warning(reason)
+                return self._fallback_result(
+                    reason,
+                    docs_considered=docs_considered,
+                    validation_errors=[str(exc)],
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Strict structured architecture selection was unavailable; "
+                    "falling back to legacy JSON parsing: %s",
+                    exc,
+                )
+
+        response = await self.llm.ainvoke(messages)
 
         try:
             result = extract_json_from_llm_response(response.content)
@@ -134,6 +159,79 @@ Recommend the best architecture."""
                 docs_considered=docs_considered,
                 validation_errors=[str(exc)],
             )
+
+    def _structured_output_llm(self) -> Any | None:
+        """Return a strict structured-output runnable when the model supports it."""
+
+        structured_output = getattr(self.llm, "with_structured_output", None)
+        if structured_output is None:
+            return None
+        try:
+            return structured_output(
+                ArchitectureSelectionResult,
+                method="json_schema",
+                strict=True,
+            )
+        except (NotImplementedError, TypeError, ValueError) as exc:
+            logger.debug(
+                "Strict structured architecture selection binding unavailable: %s",
+                exc,
+            )
+            return None
+
+    async def _select_with_structured_output(
+        self,
+        structured_llm: Any,
+        messages: list[SystemMessage | HumanMessage],
+        *,
+        docs_considered: List[str],
+    ) -> ArchitectureSelectionResult:
+        """Invoke strict structured output with one validation retry."""
+
+        validation_errors: list[str] = []
+        allowed_ids = ", ".join(
+            sorted(self.architecture_registry.selectable_architecture_types())
+        )
+        for attempt in range(2):
+            attempt_messages = list(messages)
+            if attempt:
+                attempt_messages.append(
+                    HumanMessage(
+                        content=(
+                            "The previous architecture selection failed validation: "
+                            f"{validation_errors[-1]}. Retry with only these registered "
+                            f"architecture ids: {allowed_ids}."
+                        )
+                    )
+                )
+            try:
+                result = await structured_llm.ainvoke(attempt_messages)
+                payload = self._coerce_selection_payload(result)
+                return self._normalize_selection_result(
+                    payload,
+                    docs_considered=docs_considered,
+                )
+            except (ValueError, KeyError, TypeError, ValidationError) as exc:
+                validation_errors.append(str(exc))
+
+        raise ValueError(
+            "Strict structured architecture selection failed validation after retry: "
+            + " | ".join(validation_errors)
+        )
+
+    def _coerce_selection_payload(self, result: Any) -> Any:
+        """Convert structured-output responses into the normal selection payload."""
+
+        if isinstance(result, ArchitectureSelectionResult):
+            return result.model_dump()
+        if hasattr(result, "model_dump"):
+            return result.model_dump()
+        if isinstance(result, dict):
+            return result
+        content = getattr(result, "content", None)
+        if isinstance(content, str):
+            return extract_json_from_llm_response(content)
+        raise TypeError("Architecture selection response was not a structured payload.")
 
     def _normalize_doc(self, doc: Any) -> Dict[str, Any]:
         if isinstance(doc, DocSnippet):
@@ -241,7 +339,9 @@ Recommend the best architecture."""
         return content[:80] if content else "doc"
 
     def _normalize_architecture_type(self, value: Any) -> str:
-        normalized = normalize_agent_type(value if isinstance(value, str) else None)
+        normalized = self.architecture_registry.resolve_architecture_id(
+            value if isinstance(value, str) else None
+        )
         selectable = set(self.architecture_registry.selectable_architecture_types())
         if normalized not in selectable:
             raise ValueError(
@@ -271,10 +371,15 @@ Recommend the best architecture."""
             raise ValueError("Architecture selection returned malformed patterns payload.")
 
         primary = raw_patterns.get("primary")
-        normalized_primary = normalize_agent_type(
+        normalized_primary = self.architecture_registry.resolve_architecture_id(
             primary if isinstance(primary, str) else None
         )
         if normalized_primary is None:
+            if isinstance(primary, str) and primary.strip():
+                raise ValueError(
+                    "Architecture selection returned malformed patterns payload: "
+                    f"unsupported primary '{primary}'."
+                )
             normalized_primary = architecture_type
         elif normalized_primary not in SUPPORTED_AGENT_TYPES:
             raise ValueError(
@@ -298,7 +403,9 @@ Recommend the best architecture."""
             secondary_patterns=secondary,
         )
         for item in secondary:
-            normalized_item = normalize_agent_type(item if isinstance(item, str) else None)
+            normalized_item = self.architecture_registry.resolve_architecture_id(
+                item if isinstance(item, str) else None
+            )
             if normalized_item is None:
                 continue
             if normalized_item not in SUPPORTED_AGENT_TYPES:

--- a/src/langgraph_system_generator/generator/agents/architecture_selector.py
+++ b/src/langgraph_system_generator/generator/agents/architecture_selector.py
@@ -420,13 +420,16 @@ from pydantic import ValidationError
                 item if isinstance(item, str) else None
             )
             if normalized_item is None:
+                raise ValueError(f"Architecture selection returned malformed patterns payload: unsupported secondary '{item}'.")
+            if normalized_item not in SUPPORTED_AGENT_TYPES:
+                raise ValueError(f"Architecture selection returned malformed patterns payload: unsupported secondary '{normalized_item}'.")
+            if normalized_item is None:
                 continue
             if normalized_item not in SUPPORTED_AGENT_TYPES:
                 raise ValueError(
                     "Architecture selection returned malformed patterns payload: "
                     f"unsupported secondary '{item}'."
                 )
-
         return (
             ArchitecturePatternSelection(
                 primary=normalized_primary,

--- a/src/langgraph_system_generator/generator/agents/architecture_selector.py
+++ b/src/langgraph_system_generator/generator/agents/architecture_selector.py
@@ -131,19 +131,6 @@ Recommend the best architecture."""
                     messages,
                     docs_considered=docs_considered,
                 )
-from pydantic import ValidationError
-
-# ... (existing imports)
-
-# ... (lines 121-134 replacement)
-        structured_llm = self._structured_output_llm()
-        if structured_llm is not None:
-            try:
-                return await self._select_with_structured_output(
-                    structured_llm,
-                    messages,
-                    docs_considered=docs_considered,
-                )
             except (ValueError, KeyError, TypeError, ValidationError) as exc:
                 reason = f"Architecture selection fallback used: {exc}"
                 logger.warning(reason)

--- a/src/langgraph_system_generator/generator/agents/architecture_selector.py
+++ b/src/langgraph_system_generator/generator/agents/architecture_selector.py
@@ -131,6 +131,19 @@ Recommend the best architecture."""
                     messages,
                     docs_considered=docs_considered,
                 )
+from pydantic import ValidationError
+
+# ... (existing imports)
+
+# ... (lines 121-134 replacement)
+        structured_llm = self._structured_output_llm()
+        if structured_llm is not None:
+            try:
+                return await self._select_with_structured_output(
+                    structured_llm,
+                    messages,
+                    docs_considered=docs_considered,
+                )
             except (ValueError, KeyError, TypeError, ValidationError) as exc:
                 reason = f"Architecture selection fallback used: {exc}"
                 logger.warning(reason)

--- a/src/langgraph_system_generator/generator/architecture_registry.py
+++ b/src/langgraph_system_generator/generator/architecture_registry.py
@@ -67,7 +67,39 @@ class ArchitectureRegistration:
             selector_prompt_description=description,
             aliases=[
                 alias
+def _normalize_patterns(patterns: Iterable[str] | None) -> list[str]:
+    """Normalize a list of pattern strings."""
+    if not patterns:
+        return []
+    return sorted({str(p).strip().lower() for p in patterns if p})
+
+
+@dataclass(frozen=True)
+class ArchitectureRegistration:
+    architecture_id: str
+    selector_prompt_description: str
+    aliases: list[str] = field(default_factory=list)
+    default_secondary_patterns: list[str] = field(default_factory=list)
+    docs_queries: list[str] = field(default_factory=list)
+    docs_weight: float = 1.0
+    deterministic: bool = True
+
+    def normalized(self) -> "ArchitectureRegistration":
+        return ArchitectureRegistration(
+            architecture_id=self.architecture_id,
+            selector_prompt_description=self.selector_prompt_description,
+            aliases=[
+                alias
                 for alias in _normalize_patterns(self.aliases)
+                if alias != self.architecture_id
+            ],
+            default_secondary_patterns=_normalize_patterns(
+                self.default_secondary_patterns
+            ),
+            docs_queries=self.docs_queries,
+            docs_weight=self.docs_weight,
+            deterministic=self.deterministic,
+        )
                 if alias != architecture_id
             ],
             default_secondary_patterns=_normalize_patterns(

--- a/src/langgraph_system_generator/generator/architecture_registry.py
+++ b/src/langgraph_system_generator/generator/architecture_registry.py
@@ -47,6 +47,7 @@ class ArchitectureRegistration:
 
     architecture_id: str
     selector_prompt_description: str
+    aliases: list[str] = field(default_factory=list)
     default_secondary_patterns: list[str] = field(default_factory=list)
     docs_queries: list[str] = field(default_factory=list)
     docs_weight: float = 1.0
@@ -64,6 +65,11 @@ class ArchitectureRegistration:
         return ArchitectureRegistration(
             architecture_id=architecture_id,
             selector_prompt_description=description,
+            aliases=[
+                alias
+                for alias in _normalize_patterns(self.aliases)
+                if alias != architecture_id
+            ],
             default_secondary_patterns=_normalize_patterns(
                 self.default_secondary_patterns
             ),
@@ -78,6 +84,7 @@ class ArchitectureRegistry:
 
     def __init__(self, registrations: Iterable[ArchitectureRegistration] | None = None):
         self._registrations: dict[str, ArchitectureRegistration] = {}
+        self._aliases: dict[str, str] = {}
         for registration in registrations or []:
             self.register(registration)
 
@@ -91,6 +98,8 @@ class ArchitectureRegistry:
 
         normalized = registration.normalized()
         self._registrations[normalized.architecture_id] = normalized
+        for alias in normalized.aliases:
+            self._aliases[alias] = normalized.architecture_id
         return normalized
 
     def get(self, architecture_id: str) -> ArchitectureRegistration:
@@ -98,6 +107,18 @@ class ArchitectureRegistry:
 
         normalized = _normalize_architecture_id(architecture_id)
         return self._registrations[normalized]
+
+    def resolve_architecture_id(self, value: str | None) -> str | None:
+        """Return the canonical architecture id for a registered id or alias."""
+
+        if value is None:
+            return None
+        normalized = str(value or "").strip().lower() or None
+        if not normalized:
+            return None
+        if normalized in self._registrations:
+            return normalized
+        return self._aliases.get(normalized)
 
     def supported_architecture_types(self) -> list[str]:
         """Return registered architecture identifiers in insertion order."""
@@ -124,7 +145,9 @@ class ArchitectureRegistry:
         registration = self.get(normalized_primary)
         normalized_secondary = list(registration.default_secondary_patterns)
         for raw_value in secondary_patterns or []:
-            normalized = str(raw_value or "").strip().lower() or None
+            normalized = self.resolve_architecture_id(
+                str(raw_value) if raw_value is not None else None
+            )
             if (
                 normalized
                 and normalized != normalized_primary
@@ -188,6 +211,10 @@ def _default_registrations() -> list[ArchitectureRegistration]:
             selector_prompt_description=(
                 "Single router that classifies incoming work and dispatches it to direct specialists."
             ),
+            aliases=[
+                "single-router-with-deterministic-classifier",
+                "single_router_with_specialist_handlers",
+            ],
             default_secondary_patterns=[],
             docs_queries=[
                 "LangGraph router pattern implementation best practices",

--- a/src/langgraph_system_generator/generator/architecture_registry.py
+++ b/src/langgraph_system_generator/generator/architecture_registry.py
@@ -67,39 +67,7 @@ class ArchitectureRegistration:
             selector_prompt_description=description,
             aliases=[
                 alias
-def _normalize_patterns(patterns: Iterable[str] | None) -> list[str]:
-    """Normalize a list of pattern strings."""
-    if not patterns:
-        return []
-    return sorted({str(p).strip().lower() for p in patterns if p})
-
-
-@dataclass(frozen=True)
-class ArchitectureRegistration:
-    architecture_id: str
-    selector_prompt_description: str
-    aliases: list[str] = field(default_factory=list)
-    default_secondary_patterns: list[str] = field(default_factory=list)
-    docs_queries: list[str] = field(default_factory=list)
-    docs_weight: float = 1.0
-    deterministic: bool = True
-
-    def normalized(self) -> "ArchitectureRegistration":
-        return ArchitectureRegistration(
-            architecture_id=self.architecture_id,
-            selector_prompt_description=self.selector_prompt_description,
-            aliases=[
-                alias
                 for alias in _normalize_patterns(self.aliases)
-                if alias != self.architecture_id
-            ],
-            default_secondary_patterns=_normalize_patterns(
-                self.default_secondary_patterns
-            ),
-            docs_queries=self.docs_queries,
-            docs_weight=self.docs_weight,
-            deterministic=self.deterministic,
-        )
                 if alias != architecture_id
             ],
             default_secondary_patterns=_normalize_patterns(

--- a/src/langgraph_system_generator/generator/graph.py
+++ b/src/langgraph_system_generator/generator/graph.py
@@ -19,6 +19,7 @@ from langgraph_system_generator.generator.nodes import (
     tooling_plan_node,
 )
 from langgraph_system_generator.generator.state import GeneratorState
+from langgraph_system_generator.qa.summary import has_blocking_failures
 from langgraph_system_generator.utils.config import settings
 
 
@@ -35,15 +36,19 @@ def should_repair(
     """
     qa_reports = state.get("qa_reports", [])
     failed_reports = [r for r in qa_reports if not r.passed]
+    blocking_reports = [
+        report for report in failed_reports if report.severity == "error"
+    ]
 
-    # If no failures, proceed to package
-    if not failed_reports:
+    # If there are no blocking failures, proceed to package. Warning/info
+    # findings are advisory and remain visible through qa_summary.
+    if not has_blocking_failures(qa_reports):
         return "package"
 
     # Environment/runtime support failures in live mode are product-gate failures
     # and should not enter the repair loop because repair cannot provision kernels
     # or missing execution dependencies.
-    for report in failed_reports:
+    for report in blocking_reports:
         evidence = report.evidence
         if (
             report.check_name == "Runtime Check"

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -42,6 +42,10 @@ from langgraph_system_generator.notebook.runtime import (
     run_notebook_smoke_test,
 )
 from langgraph_system_generator.qa import NotebookRepairAgent, NotebookValidator
+from langgraph_system_generator.qa.summary import (
+    build_qa_summary,
+    serialize_qa_report,
+)
 from langgraph_system_generator.rag.embeddings import VectorStoreManager
 from langgraph_system_generator.rag.retriever import DocsRetriever
 from langgraph_system_generator.utils.generation_options import (
@@ -183,7 +187,6 @@ def _qa_repair_feedback_from_reports(
     unresolved_failures: List[str] = []
     next_steps: List[str] = []
     warnings: List[str] = []
-    advisory_failures: List[str] = []
 
     for report in reports:
         if report.passed:
@@ -193,23 +196,29 @@ def _qa_repair_feedback_from_reports(
         if report.severity == "error":
             if descriptor not in unresolved_failures:
                 unresolved_failures.append(descriptor)
-        else:
-            if descriptor not in advisory_failures:
-                advisory_failures.append(descriptor)
 
         for suggestion in report.suggestions:
             suggestion_text = str(suggestion or "").strip()
             if suggestion_text and suggestion_text not in next_steps:
                 next_steps.append(suggestion_text)
 
+    qa_summary = build_qa_summary(reports)
+    counts = qa_summary["counts"]
     if unresolved_failures:
         warnings.append("Blocking QA issues remain after validation or repair.")
-    if advisory_failures:
-        warnings.append("Additional non-blocking QA advisories were recorded.")
+    if counts["non_blocking"] or counts["informational"]:
+        warnings.append(
+            "Non-blocking QA advisories were recorded; artifacts remain usable."
+        )
     if rollback_used:
         warnings.append("A repair rollback preserved the previous notebook snapshot.")
     for warning in extra_warnings or []:
         warning_text = str(warning or "").strip()
+        if (
+            not unresolved_failures
+            and warning_text.startswith("No safe deterministic repair matched")
+        ):
+            continue
         if warning_text and warning_text not in warnings:
             warnings.append(warning_text)
     for step in extra_next_steps or []:
@@ -833,6 +842,8 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
     notebook_composition_feedback = state.get("notebook_composition_feedback")
     notebook_dependency_plan = state.get("notebook_dependency_plan")
     qa_repair_feedback = state.get("qa_repair_feedback")
+    qa_reports = list(state.get("qa_reports") or [])
+    qa_summary = build_qa_summary(qa_reports)
     manifest = {
         "notebook_plan": str(state.get("notebook_plan")),
         "cell_count": str(len(state.get("generated_cells", []))),
@@ -894,10 +905,13 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
                 qa_repair_feedback or QARepairFeedback().model_dump()
             )
         ),
+        "qa_reports": [serialize_qa_report(report) for report in qa_reports],
+        "qa_summary": qa_summary,
     }
 
     return {
         "artifacts_manifest": manifest,
+        "qa_summary": qa_summary,
         "generation_complete": True,
         "error_message": None,
     }

--- a/src/langgraph_system_generator/generator/state.py
+++ b/src/langgraph_system_generator/generator/state.py
@@ -668,6 +668,7 @@ class GeneratorState(TypedDict):
     qa_history: List[QAReport]
     repair_attempts: int
     qa_repair_feedback: QARepairFeedback
+    qa_summary: Dict[str, Any]
 
     # Output
     artifacts_manifest: Dict[str, Any]

--- a/src/langgraph_system_generator/qa/summary.py
+++ b/src/langgraph_system_generator/qa/summary.py
@@ -1,0 +1,98 @@
+"""Compact QA report classification for manifests, APIs, and UI surfaces."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from langgraph_system_generator.generator.state import QAReport
+
+
+def serialize_qa_report(report: QAReport | dict[str, Any]) -> dict[str, Any]:
+    """Return a plain dict for a QA report-like object."""
+
+    if hasattr(report, "model_dump"):
+        return report.model_dump()
+    if isinstance(report, dict):
+        return dict(report)
+    return {
+        "check_name": str(getattr(report, "check_name", "QA Check")),
+        "passed": bool(getattr(report, "passed", True)),
+        "message": str(getattr(report, "message", "")),
+        "rule_id": str(getattr(report, "rule_id", "qa_report")),
+        "severity": str(getattr(report, "severity", "info")),
+        "suggestions": list(getattr(report, "suggestions", []) or []),
+        "repairable": bool(getattr(report, "repairable", False)),
+        "stage": getattr(report, "stage", None),
+        "attempt": getattr(report, "attempt", None),
+    }
+
+
+def qa_failure_classification(report: QAReport | dict[str, Any]) -> str | None:
+    """Classify failed QA reports by release impact."""
+
+    payload = serialize_qa_report(report)
+    if payload.get("passed", True):
+        return None
+    severity = str(payload.get("severity") or "info").lower()
+    if severity == "error":
+        return "blocking"
+    if severity == "warning":
+        return "non_blocking"
+    return "informational"
+
+
+def has_blocking_failures(reports: Iterable[QAReport | dict[str, Any]]) -> bool:
+    """Return True when any current QA report is a blocking failure."""
+
+    return any(qa_failure_classification(report) == "blocking" for report in reports)
+
+
+def build_qa_summary(reports: Iterable[QAReport | dict[str, Any]]) -> dict[str, Any]:
+    """Build a compact manifest/API summary for the current QA snapshot."""
+
+    serialized_reports = [serialize_qa_report(report) for report in reports]
+    findings: list[dict[str, Any]] = []
+    counts = {
+        "total": len(serialized_reports),
+        "passed": 0,
+        "failed": 0,
+        "blocking": 0,
+        "non_blocking": 0,
+        "informational": 0,
+    }
+
+    for report in serialized_reports:
+        if report.get("passed", True):
+            counts["passed"] += 1
+            continue
+
+        counts["failed"] += 1
+        classification = qa_failure_classification(report) or "informational"
+        counts[classification] += 1
+        findings.append(
+            {
+                "classification": classification,
+                "stage": report.get("stage"),
+                "check_name": report.get("check_name", "QA Check"),
+                "rule_id": report.get("rule_id", "qa_report"),
+                "severity": report.get("severity", "info"),
+                "message": report.get("message", ""),
+                "suggestions": list(report.get("suggestions") or []),
+                "repairable": bool(report.get("repairable", False)),
+                "attempt": report.get("attempt"),
+            }
+        )
+
+    if counts["blocking"]:
+        status = "blocking_failed"
+    elif counts["non_blocking"] or counts["informational"]:
+        status = "advisories"
+    else:
+        status = "passed"
+
+    return {
+        "status": status,
+        "artifacts_usable": counts["blocking"] == 0,
+        "counts": counts,
+        "findings": findings,
+    }

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -706,6 +706,74 @@ async def test_generate_artifacts_surfaces_qa_feedback_as_warnings(
     warning_codes = {warning["code"] for warning in artifacts["manifest"]["warnings"]}
     assert "qa_validation_failed" in warning_codes
     assert artifacts["manifest"]["qa_repair_feedback"]["repair_attempts"] == 1
+    assert artifacts["manifest"]["qa_summary"]["status"] == "blocking_failed"
+    assert artifacts["manifest"]["qa_reports"][0]["rule_id"] == "python_syntax"
+
+
+@pytest.mark.asyncio
+async def test_generate_artifacts_surfaces_non_blocking_qa_advisories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_qa_advisory_warning")
+
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.cli as cli_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(cli_module)
+
+    original_build_stub_result = cli_module._build_stub_result
+
+    def build_stub_result_with_qa_advisory(prompt: str, agent_type: str | None = None):
+        result = original_build_stub_result(prompt, agent_type=agent_type)
+        result["qa_reports"] = [
+            {
+                "check_name": "Undefined Names",
+                "passed": False,
+                "message": "Define or import 'app' before it is used.",
+                "rule_id": "undefined_names",
+                "severity": "warning",
+                "category": "symbols",
+                "repairable": True,
+                "suggestions": ["Check graph object naming."],
+                "stage": "static",
+                "attempt": 0,
+                "evidence": {},
+            }
+        ]
+        result["qa_repair_feedback"] = {
+            "repair_attempts": 0,
+            "rollback_used": False,
+            "unrepaired_failures": [],
+            "next_steps": ["Check graph object naming."],
+            "warnings": [
+                "Non-blocking QA advisories were recorded; artifacts remain usable."
+            ],
+        }
+        return result
+
+    monkeypatch.setattr(
+        cli_module,
+        "_build_stub_result",
+        build_stub_result_with_qa_advisory,
+    )
+
+    output_dir = constants_module._BASE_OUTPUT / "qa_advisory_stub"
+    artifacts = await cli_module.generate_artifacts(
+        "QA advisory prompt",
+        output_dir=str(output_dir),
+        mode="stub",
+    )
+
+    warning_codes = {warning["code"] for warning in artifacts["manifest"]["warnings"]}
+    assert "qa_advisories" in warning_codes
+    assert "qa_validation_failed" not in warning_codes
+    assert artifacts["manifest"]["qa_summary"]["status"] == "advisories"
+    assert artifacts["manifest"]["qa_summary"]["artifacts_usable"] is True
+    assert artifacts["manifest"]["qa_summary"]["counts"]["non_blocking"] == 1
+    assert artifacts["manifest"]["qa_reports"][0]["stage"] == "static"
 
 
 def test_build_stub_result_raises_for_invalid_stub_graph_design(monkeypatch):

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -129,6 +129,15 @@ def test_architecture_registry_includes_builtin_architectures():
     assert hybrid.default_secondary_patterns == ["router", "subagents"]
     assert hybrid.deterministic is True
 
+    assert (
+        registry.resolve_architecture_id("single-router-with-deterministic-classifier")
+        == "router"
+    )
+    assert (
+        registry.resolve_architecture_id("single_router_with_specialist_handlers")
+        == "router"
+    )
+
     deepagents = registry.get("deepagents")
     assert deepagents.default_secondary_patterns == ["subagents"]
     assert deepagents.deterministic is True
@@ -420,6 +429,48 @@ async def test_requirements_analyst_uses_configured_constraint_type_registry(mon
 
 
 @pytest.mark.asyncio
+async def test_architecture_selector_uses_strict_structured_output(monkeypatch):
+    """ArchitectureSelector should bind strict provider-enforced structured output."""
+
+    captured = {}
+
+    class StructuredLLM:
+        async def ainvoke(self, messages):
+            captured["message_count"] = len(messages)
+            return ArchitectureSelectionResult(
+                architecture_type="router",
+                patterns={"primary": "router", "secondary": []},
+                justification="A router is sufficient for this prompt.",
+            )
+
+    class StrictLLM:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def with_structured_output(self, schema, **kwargs):
+            captured["schema"] = schema
+            captured["kwargs"] = kwargs
+            return StructuredLLM()
+
+        async def ainvoke(self, _messages):  # pragma: no cover - should not be used
+            raise AssertionError("legacy JSON path should not run")
+
+    monkeypatch.setattr(architecture_selector, "ChatOpenAI", StrictLLM)
+
+    selector = architecture_selector.ArchitectureSelector()
+    result = await selector.select_architecture(
+        [Constraint(type="goal", value="Route requests", priority=5)],
+        [],
+    )
+
+    assert result.architecture_type == "router"
+    assert result.feedback.fallback_used is False
+    assert captured["schema"] is ArchitectureSelectionResult
+    assert captured["kwargs"] == {"method": "json_schema", "strict": True}
+    assert captured["message_count"] == 2
+
+
+@pytest.mark.asyncio
 async def test_architecture_selector_parsing(monkeypatch):
     """ArchitectureSelector returns typed results with structured feedback."""
     payload = """
@@ -534,6 +585,72 @@ async def test_architecture_selector_normalizes_pattern_primary(monkeypatch):
     assert result.patterns.primary == "autoagent"
     assert any(
         "primary pattern did not match architecture_type" in error
+        for error in result.feedback.validation_errors
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "alias",
+    [
+        "single-router-with-deterministic-classifier",
+        "single_router_with_specialist_handlers",
+    ],
+)
+async def test_architecture_selector_normalizes_known_router_aliases(alias, monkeypatch):
+    """Known router-like model ids should normalize without user-visible fallback."""
+
+    payload = f"""
+    {{
+      "architecture_type": "router",
+      "patterns": {{"primary": "{alias}", "secondary": []}},
+      "justification": "The answer is semantically a router."
+    }}
+    """
+    monkeypatch.setattr(
+        architecture_selector,
+        "ChatOpenAI",
+        make_stub_llm(payload),
+    )
+    selector = architecture_selector.ArchitectureSelector()
+    result = await selector.select_architecture(
+        [Constraint(type="goal", value="Route requests", priority=5)],
+        [],
+    )
+
+    assert result.architecture_type == "router"
+    assert result.patterns.primary == "router"
+    assert result.feedback.fallback_used is False
+    assert result.feedback.validation_errors == []
+
+
+@pytest.mark.asyncio
+async def test_architecture_selector_falls_back_on_unknown_primary_alias(monkeypatch):
+    """Unknown router-like ids should still be rejected and fall back."""
+
+    payload = """
+    {
+      "architecture_type": "router",
+      "patterns": {"primary": "single_router_with_unknown_handlers", "secondary": []},
+      "justification": "The answer is semantically a router."
+    }
+    """
+    monkeypatch.setattr(
+        architecture_selector,
+        "ChatOpenAI",
+        make_stub_llm(payload),
+    )
+    selector = architecture_selector.ArchitectureSelector()
+    result = await selector.select_architecture(
+        [Constraint(type="goal", value="Route requests", priority=5)],
+        [],
+    )
+
+    assert result.architecture_type == "router"
+    assert result.patterns.primary == "router"
+    assert result.feedback.fallback_used is True
+    assert any(
+        "unsupported primary 'single_router_with_unknown_handlers'" in error
         for error in result.feedback.validation_errors
     )
 

--- a/tests/unit/test_generator_graph.py
+++ b/tests/unit/test_generator_graph.py
@@ -28,6 +28,7 @@ def failing_report() -> QAReport:
         check_name="Graph Compilation",
         passed=False,
         message="Compilation failed",
+        severity="error",
         suggestions=["Fix graph"],
     )
 
@@ -67,6 +68,25 @@ def test_should_repair_mixed_reports(passing_report, failing_report):
     assert should_repair(state) == "repair"
 
 
+def test_should_repair_advisory_only_reports_package(passing_report):
+    """Warning/info QA findings should be packaged as advisories."""
+
+    warning_report = QAReport(
+        check_name="Undefined Names",
+        passed=False,
+        message="Define or import 'app' before it is used.",
+        rule_id="undefined_names",
+        severity="warning",
+        suggestions=["Check graph object naming."],
+    )
+    state = build_state(
+        qa_reports=[passing_report, warning_report],
+        repair_attempts=0,
+    )
+
+    assert should_repair(state) == "package"
+
+
 @pytest.mark.skipif(settings.max_repair_attempts < 2, reason="Requires max_repair_attempts >= 2")
 def test_should_repair_attempts_remaining(failing_report):
     """Failures with attempts remaining should repair."""
@@ -94,6 +114,7 @@ def test_should_repair_runtime_unavailable_live_fails_fast():
         check_name="Runtime Check",
         passed=False,
         message="Runtime validation unavailable: kernel 'python3' is not registered.",
+        severity="error",
         stage="runtime",
         evidence={"failure_kind": "runtime_unavailable", "generation_mode": "live"},
     )

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -540,6 +540,39 @@ async def test_static_qa_node_surfaces_blocking_feedback(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_static_qa_node_surfaces_non_blocking_feedback(monkeypatch):
+    advisory_report = QAReport(
+        check_name="Undefined Names",
+        passed=False,
+        message="Define or import 'app' before it is used.",
+        rule_id="undefined_names",
+        severity="warning",
+        category="symbols",
+        repairable=True,
+        suggestions=["Check for small naming typos."],
+    )
+
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.nodes.NotebookValidator.validate_all",
+        lambda *_args, **_kwargs: [advisory_report],
+    )
+
+    result = await static_qa_node(
+        {
+            "generated_cells": [CellSpec(cell_type="code", content="app.invoke({})", metadata={})],
+            "qa_reports": [],
+            "repair_attempts": 0,
+        }
+    )
+
+    assert result["qa_repair_feedback"].unrepaired_failures == []
+    assert "Check for small naming typos." in result["qa_repair_feedback"].next_steps
+    assert result["qa_repair_feedback"].warnings == [
+        "Non-blocking QA advisories were recorded; artifacts remain usable."
+    ]
+
+
+@pytest.mark.asyncio
 async def test_static_qa_node_uses_plugin_validators(monkeypatch):
     module_name = "test_nodes_qa_plugin_validator"
 
@@ -954,3 +987,43 @@ async def test_package_outputs_node_manifest_fields():
     assert "requests" in manifest["notebook_dependency_plan"]["packages"]
     assert manifest["qa_repair_feedback"]["repair_attempts"] == 1
     assert result["generation_complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_package_outputs_node_includes_qa_reports_and_summary():
+    report = QAReport(
+        check_name="Undefined Names",
+        passed=False,
+        message="Define or import 'app' before it is used.",
+        rule_id="undefined_names",
+        severity="warning",
+        category="symbols",
+        repairable=True,
+        suggestions=["Check graph object naming."],
+        stage="static",
+        attempt=0,
+    )
+
+    result = await package_outputs_node(
+        {
+            "notebook_plan": "Plan",
+            "generated_cells": [CellSpec(cell_type="markdown", content="Hi", metadata={})],
+            "constraints": [Constraint(type="goal", value="Test", priority=1)],
+            "selected_patterns": {"primary": "router"},
+            "qa_reports": [report],
+            "qa_repair_feedback": QARepairFeedback(
+                warnings=[
+                    "Non-blocking QA advisories were recorded; artifacts remain usable."
+                ],
+                next_steps=["Check graph object naming."],
+            ),
+        }
+    )
+
+    manifest = result["artifacts_manifest"]
+    assert manifest["qa_reports"][0]["rule_id"] == "undefined_names"
+    assert manifest["qa_summary"]["status"] == "advisories"
+    assert manifest["qa_summary"]["artifacts_usable"] is True
+    assert manifest["qa_summary"]["counts"]["non_blocking"] == 1
+    assert manifest["qa_summary"]["findings"][0]["stage"] == "static"
+    assert result["qa_summary"] == manifest["qa_summary"]

--- a/tests/unit/test_shared_platform_hardening.py
+++ b/tests/unit/test_shared_platform_hardening.py
@@ -289,6 +289,20 @@ def test_web_ui_avoids_innerhtml_for_manifest_values():
         assert pattern not in app_js
 
 
+def test_web_ui_renders_qa_summary_details():
+    """Successful web results should expose non-blocking QA advisory details."""
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    app_js = (repo_root / "src/langgraph_system_generator/api/static/app.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert "manifest.qa_summary" in app_js
+    assert "Generation Completed With Advisories" in app_js
+    assert "appendQaSummary(resultWrapper, qaSummary)" in app_js
+    assert "finding.check_name" in app_js
+    assert "finding.suggestions" in app_js
+
+
 def test_web_ui_only_treats_server_sent_sse_errors_as_terminal():
     """Transport-level EventSource errors should be allowed to reconnect."""
     repo_root = Path(__file__).resolve().parent.parent.parent


### PR DESCRIPTION
## Summary
- request strict `json_schema` structured output for architecture selection and normalize the observed router aliases through the architecture registry
- add manifest/API `qa_reports` and `qa_summary` fields with blocking, non-blocking, and informational QA finding classification
- route advisory-only QA findings directly to packaging, render exact QA details in the web result panel, and document the additive output contract

## Testing
- `pytest tests/unit/test_generator_agents.py tests/unit/test_generator_graph.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py tests/unit/test_shared_platform_hardening.py --asyncio-mode=auto -q`
- `pytest tests/unit/ --asyncio-mode=auto -q`

Closes #318
Closes #319
