### PR TITLE
[codex] Fix cold FAISS retrieval load

### DIFF
--- a/src/langgraph_system_generator/api/static/index.html
+++ b/src/langgraph_system_generator/api/static/index.html
@@ -199,7 +199,7 @@
                                         name="maxTokens" 
                                         min="100" 
                                         max="32768" 
-                                        step="100"
+                                        step="1"
                                         placeholder="Default (4000)"
                                     >
                                 </div>

--- a/src/langgraph_system_generator/rag/embeddings.py
+++ b/src/langgraph_system_generator/rag/embeddings.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+from threading import RLock
 from typing import List, Optional
 
 from langchain_community.vectorstores import FAISS
@@ -20,6 +21,7 @@ class VectorStoreManager:
         self.store_path = str(store_path)
         self.embeddings = embeddings or OpenAIEmbeddings()
         self.vector_store: Optional[FAISS] = None
+        self._store_lock = RLock()
 
     def index_exists(self) -> bool:
         """Return True if a saved FAISS index is already present."""
@@ -71,16 +73,23 @@ class VectorStoreManager:
             If the integrity check for stored index files fails.
         """
 
-        if not self.index_exists():
-            raise FileNotFoundError(f"Vector store not found at {self.store_path}")
+        if self.vector_store is not None:
+            return self.vector_store
 
-        self._validate_integrity()
-        self.vector_store = FAISS.load_local(
-            self.store_path,
-            self.embeddings,
-            allow_dangerous_deserialization=True,
-        )
-        return self.vector_store
+        with self._store_lock:
+            if self.vector_store is not None:
+                return self.vector_store
+
+            if not self.index_exists():
+                raise FileNotFoundError(f"Vector store not found at {self.store_path}")
+
+            self._validate_integrity()
+            self.vector_store = FAISS.load_local(
+                self.store_path,
+                self.embeddings,
+                allow_dangerous_deserialization=True,
+            )
+            return self.vector_store
 
     def load_or_create(self, documents: List[Document]) -> FAISS:
         """Load an existing index or create a new one if missing."""

--- a/src/langgraph_system_generator/rag/retriever.py
+++ b/src/langgraph_system_generator/rag/retriever.py
@@ -27,7 +27,7 @@ class DocsRetriever:
         if store is None:
             try:
                 store = self.vector_store_manager.load_index()
-            except FileNotFoundError:
+            except (FileNotFoundError, ValueError, MemoryError, OSError):
                 return []
 
         if store is None:

--- a/tests/unit/test_advanced_options_ui.py
+++ b/tests/unit/test_advanced_options_ui.py
@@ -63,6 +63,12 @@ def test_advanced_options_html_structure():
     assert "OpenAI" in optgroup_labels, "Missing OpenAI optgroup"
     assert "Custom" in optgroup_labels, "Missing Custom optgroup"
 
+    max_tokens_input = soup.find(id="maxTokens")
+    assert max_tokens_input is not None, "Missing maxTokens input"
+    assert max_tokens_input.get("step") == "1", (
+        "Max token input should accept any integer token budget supported by the API"
+    )
+
     unsupported_field_ids = ["preset", "memoryConfig", "graphStyle", "retrieverType", "documentLoader"]
     for field_id in unsupported_field_ids:
         field = soup.find(id=field_id)

--- a/tests/unit/test_rag.py
+++ b/tests/unit/test_rag.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 from langchain_community.embeddings import FakeEmbeddings
 from langchain_core.documents import Document
@@ -82,11 +84,50 @@ def test_vector_store_manager_errors(tmp_path):
         manager.load_index()
 
 
+def test_vector_store_manager_load_index_is_single_flight(monkeypatch, tmp_path):
+    manager = VectorStoreManager(
+        store_path=str(tmp_path), embeddings=FakeEmbeddings(size=32)
+    )
+    sentinel_store = object()
+    load_calls = 0
+
+    def fake_load_local(*args, **kwargs):
+        nonlocal load_calls
+        load_calls += 1
+        return sentinel_store
+
+    monkeypatch.setattr(manager, "index_exists", lambda: True)
+    monkeypatch.setattr(manager, "_validate_integrity", lambda: None)
+    monkeypatch.setattr(
+        "langgraph_system_generator.rag.embeddings.FAISS.load_local",
+        fake_load_local,
+    )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _idx: manager.load_index(), range(8)))
+
+    assert load_calls == 1
+    assert all(result is sentinel_store for result in results)
+
+
 def test_retriever_handles_missing_index(tmp_path):
     manager = VectorStoreManager(
         store_path=str(tmp_path), embeddings=FakeEmbeddings(size=32)
     )
     retriever = DocsRetriever(manager)
+    assert retriever.retrieve("anything") == []
+
+
+@pytest.mark.parametrize("error", [MemoryError("std::bad_alloc"), ValueError("bad index")])
+def test_retriever_handles_unloadable_index(error):
+    class FailingVectorStoreManager:
+        vector_store = None
+
+        def load_index(self):
+            raise error
+
+    retriever = DocsRetriever(FailingVectorStoreManager())
+
     assert retriever.retrieve("anything") == []
 
 


### PR DESCRIPTION
## Summary

Fixes the live-generation cold-start failure observed during post-merge smoke testing after PR #320.

## Root Cause

Architecture selection retrieves prompt documentation for multiple architecture patterns concurrently. On a cold server, those retrieval calls could all observe an unloaded FAISS vector store and call `FAISS.load_local(...)` at the same time. In the live smoke run, one of those concurrent cold loads failed with `MemoryError: std::bad_alloc` during `faiss.read_index(...)`, aborting `/generate` even though the OpenAI API calls had succeeded.

The repository's documented RAG contract says retrieval should degrade gracefully when the vector store cannot load. The existing retriever only handled `FileNotFoundError`, so memory, integrity, or OS-level load failures could still escape.

## Changes

- Add single-flight locking around `VectorStoreManager.load_index()` so one process-local manager performs only one cold FAISS load.
- Return the cached vector store for subsequent concurrent or later retrieval calls.
- Keep retrieval failure-tolerant for missing, corrupt, memory-exhausted, or OS-level FAISS load failures.
- Allow the web UI max-token control to accept `4096` by changing the input step from `100` to `1`, matching the API's integer token-budget contract.
- Add regression tests for concurrent cold loads, unloadable index fallback, and the UI max-token input contract.

## Validation

- `python -m pytest tests/unit/test_rag.py tests/unit/test_advanced_options_ui.py tests/unit/test_generator_nodes_additional.py tests/unit/test_generator_agents.py tests/unit/test_cli_api.py tests/unit/test_shared_platform_hardening.py --asyncio-mode=auto -q`
  - `146 passed, 3 warnings`
- Earlier full local unit sweep on the same patch:
  - `python -m pytest tests/unit/ --asyncio-mode=auto -q`
  - `528 passed, 4 warnings`
- Live smoke retest on patched cold server:
  - direct `/generate` with `mode=live`, `model=gpt-5-mini`, `max_tokens=4096` returned HTTP 200 with `success=true`, `architecture_type=router`, `qa_summary.status=advisories`, `artifacts_usable=true`, `blocking_count=0`.
  - headed Playwright UI submit with `max_tokens=4096` rendered `Generation Completed With Advisories`, showed QA advisory details, and recorded zero browser console/page errors.
