### PR TITLE
Fix live Cloud Run notebook generation QA

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ langchain-community>=0.4.1,<1.0.0
 # Notebook generation
 nbformat>=5.9.0
 nbconvert>=7.14.0
+jupyter_client>=8.0.0
+nbclient>=0.8.0
+ipykernel>=6.0.0
 
 # Document generation
 python-docx>=1.1.0

--- a/src/langgraph_system_generator/generator/agents/graph_designer.py
+++ b/src/langgraph_system_generator/generator/agents/graph_designer.py
@@ -124,7 +124,7 @@ class GraphDesigner:
                 '  "tool_reachability": [\n'
                 "    {\n"
                 '      "tool_id": "tool_name",\n'
-                '      "execution_path": "deterministic_node|tool_node|manual_loop|create_react_agent|omitted_demo_only",\n'
+                '      "execution_path": "deterministic_node|tool_node|manual_loop|create_react_agent|demo_only|omitted",\n'
                 '      "node": "node_name",\n'
                 '      "rationale": "How the graph can execute this tool, or why it is intentionally omitted"\n'
                 "    }\n"

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -1349,10 +1349,10 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
         }
         if normalized_name in terminal_names:
             return True
+        if normalized_name in {"finish", "end", "__end__"}:
+            return True
         terminal_roles = {"synthesizer", "terminal", "finalizer", "finish", "final"}
-        return normalized_name in {"finish", "end", "__end__"} and (
-            not role or role in terminal_roles
-        )
+        return bool(role and role in terminal_roles)
 
     @staticmethod
     def _split_hybrid_nodes(

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import inspect
 import json
@@ -893,6 +894,13 @@ Generate the complete Python function implementation."""
                     ),
                     feedback=feedback,
                 )
+            syntax_error = self._python_syntax_error(generated_code)
+            if syntax_error is not None:
+                return self._generate_tool_fallback(
+                    tool,
+                    reason=f"LLM tool generation returned invalid Python: {syntax_error}.",
+                    feedback=feedback,
+                )
 
             # Add header comment
             header = f"""# Tool: {tool_name}
@@ -1165,6 +1173,14 @@ Generate the complete Python function implementation."""
                     reason=(
                         "LLM node generation returned placeholder or incomplete code."
                     ),
+                    feedback=feedback,
+                )
+            syntax_error = self._python_syntax_error(generated_code)
+            if syntax_error is not None:
+                return self._generate_node_fallback(
+                    node,
+                    workflow_design,
+                    reason=f"LLM node generation returned invalid Python: {syntax_error}.",
                     feedback=feedback,
                 )
 
@@ -1974,6 +1990,17 @@ print(final_state)"""
         if normalized.endswith("```"):
             normalized = normalized[:-3]
         return normalized.strip()
+
+    @staticmethod
+    def _python_syntax_error(content: str) -> str | None:
+        """Return a compact syntax error for generated Python, if parsing fails."""
+
+        try:
+            ast.parse(content)
+        except SyntaxError as exc:
+            location = f"line {exc.lineno}" if exc.lineno is not None else "unknown line"
+            return f"{exc.msg} at {location}"
+        return None
 
     @staticmethod
     def _is_meaningful_tool_code(content: str) -> bool:

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -1333,13 +1333,39 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
 {chr(10).join(update_lines)}"""
 
     @staticmethod
+    def _is_pattern_terminal_node(
+        node: Dict[str, Any],
+        workflow_design: Dict[str, Any] | None = None,
+    ) -> bool:
+        """Return whether a graph node is a terminal handled by pattern templates."""
+
+        name = str(node.get("name", "")).strip()
+        normalized_name = name.lower()
+        role = str(node.get("role", "")).strip().lower()
+        terminal_names = {
+            str(value).strip().lower()
+            for value in (workflow_design or {}).get("terminal_nodes", [])
+            if str(value).strip()
+        }
+        if normalized_name in terminal_names:
+            return True
+        terminal_roles = {"synthesizer", "terminal", "finalizer", "finish", "final"}
+        return normalized_name in {"finish", "end", "__end__"} and (
+            not role or role in terminal_roles
+        )
+
+    @staticmethod
     def _split_hybrid_nodes(
         nodes: List[Dict[str, Any]],
+        workflow_design: Dict[str, Any] | None = None,
     ) -> tuple[List[str], Dict[str, str], List[str], Dict[str, str]]:
         """Split hybrid nodes into direct-specialist and team-worker groups."""
 
         non_router_nodes = [
-            node for node in nodes if node.get("name") not in {"router", "supervisor"}
+            node
+            for node in nodes
+            if node.get("name") not in {"router", "supervisor"}
+            and not NotebookComposer._is_pattern_terminal_node(node, workflow_design)
         ]
         direct_role_names = {"direct", "direct_specialist", "specialist"}
         worker_role_names = {
@@ -1442,7 +1468,10 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
         if architecture_type == "router":
             # Extract routes from nodes
             routes = [
-                node.get("name") for node in nodes if node.get("name") != "router"
+                node.get("name")
+                for node in nodes
+                if node.get("name") != "router"
+                and not self._is_pattern_terminal_node(node, workflow_design)
             ]
 
             # Generate router node
@@ -1455,7 +1484,9 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
 
             # Generate route handler nodes
             for node in nodes:
-                if node.get("name") != "router":
+                if node.get("name") != "router" and not self._is_pattern_terminal_node(
+                    node, workflow_design
+                ):
                     route_code = RouterPattern.generate_route_node_code(
                         node.get("name"),
                         node.get("purpose", f"Handle {node.get('name')} requests"),
@@ -1468,12 +1499,16 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
         elif architecture_type == "subagents":
             # Extract subagents (excluding supervisor)
             subagents = [
-                node.get("name") for node in nodes if node.get("name") != "supervisor"
+                node.get("name")
+                for node in nodes
+                if node.get("name") != "supervisor"
+                and not self._is_pattern_terminal_node(node, workflow_design)
             ]
             subagent_descriptions = {
                 node.get("name"): node.get("purpose", "")
                 for node in nodes
                 if node.get("name") != "supervisor"
+                and not self._is_pattern_terminal_node(node, workflow_design)
             }
 
             # Generate supervisor node
@@ -1486,7 +1521,9 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
 
             # Generate subagent nodes
             for node in nodes:
-                if node.get("name") != "supervisor":
+                if node.get("name") != "supervisor" and not self._is_pattern_terminal_node(
+                    node, workflow_design
+                ):
                     subagent_code = SubagentsPattern.generate_subagent_code(
                         node.get("name"),
                         node.get("purpose", f"{node.get('name')} specialist"),
@@ -1503,7 +1540,7 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
                 direct_descriptions,
                 team_workers,
                 worker_descriptions,
-            ) = self._split_hybrid_nodes(nodes)
+            ) = self._split_hybrid_nodes(nodes, workflow_design)
 
             router_code = HybridPattern.generate_router_node_code(
                 direct_specialists,
@@ -1552,11 +1589,13 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
                 node.get("name")
                 for node in nodes
                 if node.get("name") not in {"coordinator", "supervisor"}
+                and not self._is_pattern_terminal_node(node, workflow_design)
             ]
             worker_descriptions = {
                 node.get("name"): node.get("purpose", "")
                 for node in nodes
                 if node.get("name") not in {"coordinator", "supervisor"}
+                and not self._is_pattern_terminal_node(node, workflow_design)
             }
 
             coordinator_code = AutoAgentPattern.generate_coordinator_code(
@@ -1567,7 +1606,10 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
             )
 
             for node in nodes:
-                if node.get("name") not in {"coordinator", "supervisor"}:
+                if node.get("name") not in {
+                    "coordinator",
+                    "supervisor",
+                } and not self._is_pattern_terminal_node(node, workflow_design):
                     worker_code = AutoAgentPattern.generate_worker_code(
                         node.get("name"),
                         node.get("purpose", f"{node.get('name')} worker"),
@@ -1675,19 +1717,27 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
         nodes = workflow_design.get("nodes", [])
         if architecture_type == "router":
             routes = [
-                node.get("name") for node in nodes if node.get("name") != "router"
+                node.get("name")
+                for node in nodes
+                if node.get("name") != "router"
+                and not self._is_pattern_terminal_node(node, workflow_design)
             ]
             graph_code = RouterPattern.generate_graph_code(routes)
         elif architecture_type == "subagents":
             subagents = [
-                node.get("name") for node in nodes if node.get("name") != "supervisor"
+                node.get("name")
+                for node in nodes
+                if node.get("name") != "supervisor"
+                and not self._is_pattern_terminal_node(node, workflow_design)
             ]
             graph_code = SubagentsPattern.generate_graph_code(
                 subagents,
                 max_iterations=max_iterations,
             )
         elif architecture_type == "hybrid":
-            direct_specialists, _, team_workers, _ = self._split_hybrid_nodes(nodes)
+            direct_specialists, _, team_workers, _ = self._split_hybrid_nodes(
+                nodes, workflow_design
+            )
             graph_code = HybridPattern.generate_graph_code(
                 direct_specialists,
                 team_workers,
@@ -1698,6 +1748,7 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
                 node.get("name")
                 for node in nodes
                 if node.get("name") not in {"coordinator", "supervisor"}
+                and not self._is_pattern_terminal_node(node, workflow_design)
             ]
             graph_code = AutoAgentPattern.generate_graph_code(
                 workers,

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -124,6 +124,14 @@ class NotebookComposer:
             "previous_quality_score",
         },
     }
+    _PATTERN_TERMINAL_NAMES = {"finish", "__end__"}
+    _PATTERN_TERMINAL_ROLES = {
+        "synthesizer",
+        "terminal",
+        "finalizer",
+        "finish",
+        "final",
+    }
 
     def __init__(
         self,
@@ -1344,15 +1352,94 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
         role = str(node.get("role", "")).strip().lower()
         terminal_names = {
             str(value).strip().lower()
-            for value in (workflow_design or {}).get("terminal_nodes", [])
+            for value in (workflow_design or {}).get("terminal_nodes") or []
             if str(value).strip()
         }
         if normalized_name in terminal_names:
             return True
-        if normalized_name in {"finish", "end", "__end__"}:
+        if normalized_name in NotebookComposer._PATTERN_TERMINAL_NAMES:
             return True
-        terminal_roles = {"synthesizer", "terminal", "finalizer", "finish", "final"}
-        return bool(role and role in terminal_roles)
+        return bool(role and role in NotebookComposer._PATTERN_TERMINAL_ROLES)
+
+    @classmethod
+    def _router_route_specs(
+        cls,
+        nodes: List[Dict[str, Any]],
+        workflow_design: Dict[str, Any] | None = None,
+    ) -> list[tuple[str, str]]:
+        """Return route labels and descriptions for router pattern cells."""
+
+        specs: list[tuple[str, str]] = []
+        seen: set[str] = set()
+        for node in nodes:
+            name = str(node.get("name") or "").strip()
+            if not name or name == "router":
+                continue
+            if cls._is_pattern_terminal_node(node, workflow_design):
+                continue
+            if name in seen:
+                continue
+            seen.add(name)
+            purpose = str(
+                node.get("purpose") or f"Handle {name} requests"
+            ).strip()
+            specs.append((name, purpose or f"Handle {name} requests"))
+
+        if specs:
+            return specs
+        return [("default", "Handle the default routed request.")]
+
+    @classmethod
+    def _subagent_specs(
+        cls,
+        nodes: List[Dict[str, Any]],
+        workflow_design: Dict[str, Any] | None = None,
+    ) -> list[tuple[str, str]]:
+        """Return subagent labels and descriptions for supervisor pattern cells."""
+
+        specs: list[tuple[str, str]] = []
+        seen: set[str] = set()
+        for node in nodes:
+            name = str(node.get("name") or "").strip()
+            if not name or name == "supervisor":
+                continue
+            if cls._is_pattern_terminal_node(node, workflow_design):
+                continue
+            if name in seen:
+                continue
+            seen.add(name)
+            purpose = str(node.get("purpose") or f"{name} specialist").strip()
+            specs.append((name, purpose or f"{name} specialist"))
+
+        if specs:
+            return specs
+        return [("worker", "General worker specialist.")]
+
+    @classmethod
+    def _autoagent_worker_specs(
+        cls,
+        nodes: List[Dict[str, Any]],
+        workflow_design: Dict[str, Any] | None = None,
+    ) -> list[tuple[str, str]]:
+        """Return worker labels and descriptions for autoagent pattern cells."""
+
+        specs: list[tuple[str, str]] = []
+        seen: set[str] = set()
+        for node in nodes:
+            name = str(node.get("name") or "").strip()
+            if not name or name in {"coordinator", "supervisor"}:
+                continue
+            if cls._is_pattern_terminal_node(node, workflow_design):
+                continue
+            if name in seen:
+                continue
+            seen.add(name)
+            purpose = str(node.get("purpose") or f"{name} worker").strip()
+            specs.append((name, purpose or f"{name} worker"))
+
+        if specs:
+            return specs
+        return [("worker", "General worker specialist.")]
 
     @staticmethod
     def _split_hybrid_nodes(
@@ -1466,13 +1553,8 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
         model_config = self.model_config
 
         if architecture_type == "router":
-            # Extract routes from nodes
-            routes = [
-                node.get("name")
-                for node in nodes
-                if node.get("name") != "router"
-                and not self._is_pattern_terminal_node(node, workflow_design)
-            ]
+            route_specs = self._router_route_specs(nodes, workflow_design)
+            routes = [name for name, _ in route_specs]
 
             # Generate router node
             router_code = RouterPattern.generate_router_node_code(
@@ -1483,33 +1565,20 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
             )
 
             # Generate route handler nodes
-            for node in nodes:
-                if node.get("name") != "router" and not self._is_pattern_terminal_node(
-                    node, workflow_design
-                ):
-                    route_code = RouterPattern.generate_route_node_code(
-                        node.get("name"),
-                        node.get("purpose", f"Handle {node.get('name')} requests"),
-                        model_config=model_config,
-                    )
-                    cells.append(
-                        CellSpec(cell_type="code", content=route_code, section="nodes")
-                    )
+            for route_name, route_purpose in route_specs:
+                route_code = RouterPattern.generate_route_node_code(
+                    route_name,
+                    route_purpose,
+                    model_config=model_config,
+                )
+                cells.append(
+                    CellSpec(cell_type="code", content=route_code, section="nodes")
+                )
 
         elif architecture_type == "subagents":
-            # Extract subagents (excluding supervisor)
-            subagents = [
-                node.get("name")
-                for node in nodes
-                if node.get("name") != "supervisor"
-                and not self._is_pattern_terminal_node(node, workflow_design)
-            ]
-            subagent_descriptions = {
-                node.get("name"): node.get("purpose", "")
-                for node in nodes
-                if node.get("name") != "supervisor"
-                and not self._is_pattern_terminal_node(node, workflow_design)
-            }
+            subagent_specs = self._subagent_specs(nodes, workflow_design)
+            subagents = [name for name, _ in subagent_specs]
+            subagent_descriptions = dict(subagent_specs)
 
             # Generate supervisor node
             supervisor_code = SubagentsPattern.generate_supervisor_code(
@@ -1520,20 +1589,15 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
             )
 
             # Generate subagent nodes
-            for node in nodes:
-                if node.get("name") != "supervisor" and not self._is_pattern_terminal_node(
-                    node, workflow_design
-                ):
-                    subagent_code = SubagentsPattern.generate_subagent_code(
-                        node.get("name"),
-                        node.get("purpose", f"{node.get('name')} specialist"),
-                        model_config=model_config,
-                    )
-                    cells.append(
-                        CellSpec(
-                            cell_type="code", content=subagent_code, section="nodes"
-                        )
-                    )
+            for subagent_name, subagent_purpose in subagent_specs:
+                subagent_code = SubagentsPattern.generate_subagent_code(
+                    subagent_name,
+                    subagent_purpose,
+                    model_config=model_config,
+                )
+                cells.append(
+                    CellSpec(cell_type="code", content=subagent_code, section="nodes")
+                )
         elif architecture_type == "hybrid":
             (
                 direct_specialists,
@@ -1585,18 +1649,9 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
                     CellSpec(cell_type="code", content=worker_code, section="nodes")
                 )
         elif architecture_type == "autoagent":
-            workers = [
-                node.get("name")
-                for node in nodes
-                if node.get("name") not in {"coordinator", "supervisor"}
-                and not self._is_pattern_terminal_node(node, workflow_design)
-            ]
-            worker_descriptions = {
-                node.get("name"): node.get("purpose", "")
-                for node in nodes
-                if node.get("name") not in {"coordinator", "supervisor"}
-                and not self._is_pattern_terminal_node(node, workflow_design)
-            }
+            worker_specs = self._autoagent_worker_specs(nodes, workflow_design)
+            workers = [name for name, _ in worker_specs]
+            worker_descriptions = dict(worker_specs)
 
             coordinator_code = AutoAgentPattern.generate_coordinator_code(
                 workers, worker_descriptions, model_config=model_config
@@ -1605,19 +1660,15 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
                 CellSpec(cell_type="code", content=coordinator_code, section="nodes")
             )
 
-            for node in nodes:
-                if node.get("name") not in {
-                    "coordinator",
-                    "supervisor",
-                } and not self._is_pattern_terminal_node(node, workflow_design):
-                    worker_code = AutoAgentPattern.generate_worker_code(
-                        node.get("name"),
-                        node.get("purpose", f"{node.get('name')} worker"),
-                        model_config=model_config,
-                    )
-                    cells.append(
-                        CellSpec(cell_type="code", content=worker_code, section="nodes")
-                    )
+            for worker_name, worker_purpose in worker_specs:
+                worker_code = AutoAgentPattern.generate_worker_code(
+                    worker_name,
+                    worker_purpose,
+                    model_config=model_config,
+                )
+                cells.append(
+                    CellSpec(cell_type="code", content=worker_code, section="nodes")
+                )
 
         elif architecture_type == "deepagents":
             subagents = [
@@ -1717,18 +1768,12 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
         nodes = workflow_design.get("nodes", [])
         if architecture_type == "router":
             routes = [
-                node.get("name")
-                for node in nodes
-                if node.get("name") != "router"
-                and not self._is_pattern_terminal_node(node, workflow_design)
+                name for name, _ in self._router_route_specs(nodes, workflow_design)
             ]
             graph_code = RouterPattern.generate_graph_code(routes)
         elif architecture_type == "subagents":
             subagents = [
-                node.get("name")
-                for node in nodes
-                if node.get("name") != "supervisor"
-                and not self._is_pattern_terminal_node(node, workflow_design)
+                name for name, _ in self._subagent_specs(nodes, workflow_design)
             ]
             graph_code = SubagentsPattern.generate_graph_code(
                 subagents,
@@ -1745,10 +1790,7 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
             )
         elif architecture_type == "autoagent":
             workers = [
-                node.get("name")
-                for node in nodes
-                if node.get("name") not in {"coordinator", "supervisor"}
-                and not self._is_pattern_terminal_node(node, workflow_design)
+                name for name, _ in self._autoagent_worker_specs(nodes, workflow_design)
             ]
             graph_code = AutoAgentPattern.generate_graph_code(
                 workers,

--- a/src/langgraph_system_generator/generator/graph_design_registry.py
+++ b/src/langgraph_system_generator/generator/graph_design_registry.py
@@ -669,7 +669,17 @@ def normalize_graph_design(
             if isinstance(route, Mapping)
         ]
         tool_reachability = [
-            GraphToolReachabilitySpec.model_validate(reachability)
+            GraphToolReachabilitySpec.model_validate(
+                {
+                    **dict(reachability),
+                    "execution_path": (
+                        "demo_only"
+                        if reachability.get("execution_path")
+                        == "omitted_demo_only"
+                        else reachability.get("execution_path")
+                    ),
+                }
+            )
             for reachability in list(payload.get("tool_reachability") or [])
             if isinstance(reachability, Mapping)
         ]

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -1112,6 +1112,49 @@ async def test_graph_designer_returns_typed_result_with_exports(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_graph_designer_normalizes_legacy_omitted_demo_only_path(monkeypatch):
+    """Legacy live output should not force fallback for a retired reachability value."""
+
+    payload = """
+    {
+      "state_schema": {"messages": "Conversation state"},
+      "nodes": [
+        {"name": "router", "purpose": "Route requests", "role": "router"}
+      ],
+      "edges": [],
+      "conditional_edges": [],
+      "command_routes": [],
+      "tool_reachability": [
+        {
+          "tool_id": "demo_tool",
+          "execution_path": "omitted_demo_only",
+          "node": "router",
+          "rationale": "Demo-only helper omitted from execution."
+        }
+      ],
+      "domain_terms": ["support"],
+      "entry_point": "router",
+      "compiled_graph_variable": "graph",
+      "checkpointing": false
+    }
+    """
+    monkeypatch.setattr(graph_designer, "ChatOpenAI", make_stub_llm(payload))
+
+    designer = graph_designer.GraphDesigner()
+    result = await designer.design_workflow(
+        {
+            "architecture_type": "router",
+            "justification": "Routing is sufficient.",
+            "selected_patterns": {"primary": "router", "secondary": []},
+        },
+        [Constraint(type="goal", value="Build a support router workflow", priority=5)],
+    )
+
+    assert result.feedback.fallback_used is False
+    assert result.tool_reachability[0].execution_path == "demo_only"
+
+
+@pytest.mark.asyncio
 async def test_graph_designer_prompt_requests_canonical_contract_fields(monkeypatch):
     """Live GraphDesigner prompt should ask for every canonical graph contract field."""
 
@@ -1158,6 +1201,13 @@ async def test_graph_designer_prompt_requests_canonical_contract_fields(monkeypa
         "compiled_graph_variable",
     ]:
         assert field_name in system_prompt
+
+    reachability_schema = (
+        '"execution_path": '
+        '"deterministic_node|tool_node|manual_loop|create_react_agent|demo_only|omitted"'
+    )
+    assert reachability_schema in system_prompt
+    assert "omitted_demo_only" not in system_prompt
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -1332,6 +1332,75 @@ async def test_compose_notebook_hybrid_sparse_nodes_keep_defaults_aligned(
 
 
 @pytest.mark.asyncio
+async def test_compose_notebook_hybrid_terminal_finish_is_not_duplicated(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Pattern templates own terminal finish nodes even when graph specs expose them."""
+
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Hybrid With Terminal Finish",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["hybrid"],
+            architecture_type="hybrid",
+        ),
+        workflow_design={
+            "architecture_type": "hybrid",
+            "state_schema": {},
+            "terminal_nodes": ["finish"],
+            "nodes": [
+                {"name": "router", "purpose": "Route requests", "role": "router"},
+                {
+                    "name": "gender_setup",
+                    "purpose": "Collect the selected character gender",
+                    "role": "direct_specialist",
+                },
+                {
+                    "name": "supervisor",
+                    "purpose": "Coordinate response checks",
+                    "role": "coordinator",
+                },
+                {
+                    "name": "anachronism_verifier",
+                    "purpose": "Check for future knowledge",
+                    "role": "worker",
+                },
+                {
+                    "name": "believability_verifier",
+                    "purpose": "Check period-appropriate realism",
+                    "role": "worker",
+                },
+                {
+                    "name": "finish",
+                    "purpose": "Synthesize final results",
+                    "role": "synthesizer",
+                },
+            ],
+        },
+        tools=[],
+        architecture={
+            "architecture_type": "hybrid",
+            "justification": "Live-style hybrid design.",
+        },
+    )
+
+    code = "\n\n".join(
+        cell.content for cell in composition.cells if cell.cell_type == "code"
+    )
+
+    assert code.count("def finish_node") == 1
+    assert code.count('workflow.add_node("finish", finish_node)') == 1
+    assert 'workflow.add_node("gender_setup", gender_setup_node)' in code
+    assert 'workflow.add_node("anachronism_verifier", anachronism_verifier_node)' in code
+    assert 'workflow.add_node("believability_verifier", believability_verifier_node)' in code
+    assert 'workflow.add_edge("finish", "finish")' not in code
+    ast.parse(code)
+
+
+@pytest.mark.asyncio
 async def test_compose_notebook_normalizes_mixed_case_architecture_type(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -144,6 +144,25 @@ class DelayedEmptyLLM(DummyLLM):
         return self.invoke("")
 
 
+class InvalidPythonLLM(DummyLLM):
+    """LLM stub that returns meaningful-looking but invalid Python code."""
+
+    async def ainvoke(self, messages, *args, **kwargs):
+        user_content = getattr(messages[-1], "content", "")
+        if "Tool Name:" in user_content:
+            return self.invoke(
+                "def schema_validator(value):\n"
+                "    modern_markers = ['internet']\n"
+                "    18th_century_markers = ['thee']\n"
+                "    return value"
+            )
+        return self.invoke(
+            "def historical_check_node(state: WorkflowState) -> WorkflowState:\n"
+            "    18th_century_markers = ['thee']\n"
+            "    return {'messages': state.get('messages', [])}"
+        )
+
+
 def test_notebook_composer_registry_includes_builtin_architectures():
     registry = get_notebook_composer_registry().clone()
 
@@ -1540,6 +1559,59 @@ async def test_generate_node_implementation_records_visible_fallback_warning(
     assert fallback_code.startswith("# WARNING: Deterministic fallback generated")
     assert feedback.fallback_used is True
     assert feedback.fallback_events[0].kind == "node"
+
+
+@pytest.mark.asyncio
+async def test_generate_tool_implementation_rejects_invalid_python_and_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(composer_module, "ChatOpenAI", InvalidPythonLLM)
+    composer = composer_module.NotebookComposer()
+    feedback = composer_module.NotebookCompositionFeedback()
+
+    tool_code = await composer._generate_tool_implementation(
+        {
+            "name": "Schema Validator",
+            "purpose": "Validate 18th century commoner chatbot outputs.",
+            "category": "validation",
+        },
+        feedback=feedback,
+    )
+
+    assert tool_code.startswith("# WARNING: Deterministic fallback generated")
+    assert "18th_century_markers" not in tool_code
+    compile(tool_code, "<tool_code>", "exec")
+    assert feedback.fallback_used is True
+    assert feedback.fallback_events[0].kind == "tool"
+    assert "invalid Python" in feedback.fallback_events[0].reason
+
+
+@pytest.mark.asyncio
+async def test_generate_node_implementation_rejects_invalid_python_and_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(composer_module, "ChatOpenAI", InvalidPythonLLM)
+    composer = composer_module.NotebookComposer()
+    feedback = composer_module.NotebookCompositionFeedback()
+
+    node_code = await composer._generate_node_implementation(
+        {"name": "historical check", "purpose": "Check 18th century realism."},
+        {
+            "architecture_type": "custom",
+            "state_schema": {"messages": "Conversation messages"},
+            "nodes": [
+                {"name": "historical check", "purpose": "Check 18th century realism."}
+            ],
+        },
+        feedback=feedback,
+    )
+
+    assert node_code.startswith("# WARNING: Deterministic fallback generated")
+    assert "18th_century_markers" not in node_code
+    compile(node_code, "<node_code>", "exec")
+    assert feedback.fallback_used is True
+    assert feedback.fallback_events[0].kind == "node"
+    assert "invalid Python" in feedback.fallback_events[0].reason
 
 
 def test_tool_fallback_sanitizes_identifier_and_compiles(

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -1350,7 +1350,6 @@ async def test_compose_notebook_hybrid_terminal_finish_is_not_duplicated(
         workflow_design={
             "architecture_type": "hybrid",
             "state_schema": {},
-            "terminal_nodes": ["finish"],
             "nodes": [
                 {"name": "router", "purpose": "Route requests", "role": "router"},
                 {
@@ -1376,7 +1375,7 @@ async def test_compose_notebook_hybrid_terminal_finish_is_not_duplicated(
                 {
                     "name": "finish",
                     "purpose": "Synthesize final results",
-                    "role": "synthesizer",
+                    "role": "direct_specialist",
                 },
             ],
         },

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -1399,6 +1399,168 @@ async def test_compose_notebook_hybrid_terminal_finish_is_not_duplicated(
     ast.parse(code)
 
 
+def test_pattern_terminal_detection_handles_nulls_and_allows_end_node():
+    """Only pattern-owned terminal labels should be filtered by name."""
+
+    assert composer_module.NotebookComposer._is_pattern_terminal_node(
+        {"name": "finish", "role": "direct_specialist"},
+        {"terminal_nodes": None},
+    )
+    assert not composer_module.NotebookComposer._is_pattern_terminal_node(
+        {"name": "end", "role": "direct_specialist"},
+        {"terminal_nodes": None},
+    )
+    assert composer_module.NotebookComposer._is_pattern_terminal_node(
+        {"name": "archive", "role": "direct_specialist"},
+        {"terminal_nodes": ["archive"]},
+    )
+
+
+@pytest.mark.asyncio
+async def test_compose_notebook_router_terminal_only_generates_default_route(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Router pattern fallbacks must define the same route used by graph wiring."""
+
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Router With Only Terminal",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["router"],
+            architecture_type="router",
+        ),
+        workflow_design={
+            "architecture_type": "router",
+            "terminal_nodes": None,
+            "state_schema": {},
+            "nodes": [
+                {"name": "router", "purpose": "Route requests", "role": "router"},
+                {
+                    "name": "finish",
+                    "purpose": "Synthesize final results",
+                    "role": "terminal",
+                },
+            ],
+        },
+        tools=[],
+        architecture={
+            "architecture_type": "router",
+            "justification": "Terminal-only router design.",
+        },
+    )
+
+    code = "\n\n".join(
+        cell.content for cell in composition.cells if cell.cell_type == "code"
+    )
+
+    assert "def default_node" in code
+    assert 'workflow.add_node("default", default_node)' in code
+    assert 'workflow.add_node("finish", finish_node)' not in code
+    ast.parse(code)
+
+
+@pytest.mark.asyncio
+async def test_compose_notebook_subagents_terminal_only_generates_worker(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Subagent fallbacks must emit the worker node referenced by the graph."""
+
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Subagents With Only Terminal",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["subagents"],
+            architecture_type="subagents",
+        ),
+        workflow_design={
+            "architecture_type": "subagents",
+            "terminal_nodes": None,
+            "state_schema": {},
+            "nodes": [
+                {
+                    "name": "supervisor",
+                    "purpose": "Coordinate agents",
+                    "role": "supervisor",
+                },
+                {
+                    "name": "finish",
+                    "purpose": "Synthesize final results",
+                    "role": "terminal",
+                },
+            ],
+        },
+        tools=[],
+        architecture={
+            "architecture_type": "subagents",
+            "justification": "Terminal-only subagent design.",
+        },
+    )
+
+    code = "\n\n".join(
+        cell.content for cell in composition.cells if cell.cell_type == "code"
+    )
+
+    assert "def worker_node" in code
+    assert 'workflow.add_node("worker", worker_node)' in code
+    assert code.count("def finish_node") == 1
+    ast.parse(code)
+
+
+@pytest.mark.asyncio
+async def test_compose_notebook_autoagent_terminal_only_generates_worker(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Autoagent fallback workers must match the worker graph route."""
+
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+
+    composition = await composer.compose_notebook(
+        notebook_plan=NotebookPlan(
+            title="Autoagent With Only Terminal",
+            sections=["Setup", "Workflow", "Execution"],
+            patterns_used=["autoagent"],
+            architecture_type="autoagent",
+        ),
+        workflow_design={
+            "architecture_type": "autoagent",
+            "terminal_nodes": None,
+            "state_schema": {},
+            "nodes": [
+                {
+                    "name": "coordinator",
+                    "purpose": "Coordinate agents",
+                    "role": "coordinator",
+                },
+                {
+                    "name": "finish",
+                    "purpose": "Synthesize final results",
+                    "role": "terminal",
+                },
+            ],
+        },
+        tools=[],
+        architecture={
+            "architecture_type": "autoagent",
+            "justification": "Terminal-only autoagent design.",
+        },
+    )
+
+    code = "\n\n".join(
+        cell.content for cell in composition.cells if cell.cell_type == "code"
+    )
+
+    assert "def worker_node" in code
+    assert 'workflow.add_node("worker", worker_node)' in code
+    ast.parse(code)
+
+
 @pytest.mark.asyncio
 async def test_compose_notebook_normalizes_mixed_case_architecture_type(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_release_readiness_metadata.py
+++ b/tests/unit/test_release_readiness_metadata.py
@@ -66,6 +66,13 @@ def test_cloud_run_workflow_mounts_openai_key_from_secret_manager() -> None:
     assert "secrets.OPENAI_API_KEY" not in workflow
 
 
+def test_cloud_run_requirements_include_live_runtime_qa_dependencies() -> None:
+    requirements = _read("requirements.txt")
+
+    for dependency in ("jupyter_client", "nbclient", "ipykernel"):
+        assert dependency in requirements
+
+
 def test_public_docs_no_longer_describe_release_as_alpha() -> None:
     checked_paths = [
         "README.md",


### PR DESCRIPTION
## Summary
- Fixes live Cloud Run notebook generation blockers found during headed testing.
- Aligns graph tool reachability prompt values with the schema and normalizes legacy `omitted_demo_only` model output.
- Rejects invalid LLM-generated Python snippets before notebook assembly and falls back to deterministic runnable code.
- Adds Cloud Run notebook runtime dependencies required for live runtime QA.
- Reserves pattern-managed terminal nodes such as `finish` so generated graph specs do not render duplicate node definitions or self-loop topology failures.

## Verification
- `python -m pytest tests/unit/test_generator_notebook_composer.py tests/unit/test_generator_graph.py tests/unit/test_generator_nodes_additional.py tests/unit/test_validators.py --asyncio-mode=auto -q`
- `python -m pytest tests/unit/test_release_readiness_metadata.py tests/unit/test_generator_agents.py --asyncio-mode=auto -q`
- `git diff --check`
- `docker build -t lnf-cloudrun-live-debugging:local .`
- `docker run --rm lnf-cloudrun-live-debugging:local python -c "from langgraph_system_generator.notebook.runtime import inspect_notebook_runtime_support; ok,msg,evidence=inspect_notebook_runtime_support(); print(ok); print(msg); print(evidence)"`
- local container `/health` smoke on port 18080
- deployed Cloud Run revision `langgraph-system-generator-00008-gvm` from commit `cc6a57a4e7d088f8c90e849bae8bdcb63f274932`
- headed live UI test via `http://localhost:8080/` with `gpt-5.4-mini`, `max_tokens=16000`, and the 18th-century chatbot prompt

## Live acceptance evidence
- `/generate-async` returned `200`.
- SSE reached completion with 25 progress events and one complete event.
- Result card displayed without an error card.
- Manifest reported `mode=live`, `model=gpt-5.4-mini`, `max_tokens=16000`.
- `qa_summary.status=advisories`, `artifacts_usable=true`, and Runtime Check passed using the `python3` kernel.
- Downloaded notebook parsed with `ast.parse`.
- No `omitted_demo_only`, `18th_century_markers`, duplicate `workflow.add_node`, duplicate function definitions, or topology failures remained.