### PR TITLE
Fix Cloud Run deployment health check authentication

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -98,23 +98,26 @@ jobs:
 
       - name: Verify Cloud Run health
         shell: bash
+        env:
+          SERVICE_URL: ${{ steps.deploy.outputs.url }}
         run: |
           set -euo pipefail
-          gcloud run services proxy "${SERVICE}" \
-            --project "${PROJECT_ID}" \
-            --region "${REGION}" \
-            --port 8080 &
-          proxy_pid=$!
-
-          cleanup() {
-            kill "$proxy_pid" 2>/dev/null || true
-            wait "$proxy_pid" 2>/dev/null || true
-          }
-          trap cleanup EXIT
+          if [ -z "${SERVICE_URL:-}" ]; then
+            echo "::error::Deploy step did not return a Cloud Run service URL"
+            exit 1
+          fi
 
           for attempt in {1..30}; do
-            if curl --fail --silent --show-error --max-time 5 \
-              "http://127.0.0.1:8080/health" > /tmp/cloud-run-health.json; then
+            identity_token="$(gcloud auth print-identity-token --audiences="${SERVICE_URL}")"
+            http_status="$(
+              curl --fail --silent --show-error --max-time 10 \
+                --output /tmp/cloud-run-health.json \
+                --write-out "%{http_code}" \
+                --header "Authorization: Bearer ${identity_token}" \
+                "${SERVICE_URL}/health" || true
+            )"
+
+            if [ "$http_status" = "200" ]; then
               if grep -Eq '"status"[[:space:]]*:[[:space:]]*"ok"' /tmp/cloud-run-health.json; then
                 echo "Cloud Run health check passed."
                 exit 0
@@ -123,7 +126,12 @@ jobs:
               cat /tmp/cloud-run-health.json
               exit 1
             fi
-            echo "Waiting for Cloud Run health check, attempt ${attempt}/30..."
+
+            echo "Cloud Run /health returned HTTP ${http_status:-000}; waiting, attempt ${attempt}/30..."
+            if [ -s /tmp/cloud-run-health.json ]; then
+              head -c 500 /tmp/cloud-run-health.json
+              echo
+            fi
             sleep 5
           done
 

--- a/README.md
+++ b/README.md
@@ -347,9 +347,10 @@ The workflow builds and pushes:
 `$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/$GCP_ARTIFACT_REGISTRY_REPOSITORY/langgraph-system-generator:$GITHUB_SHA`
 
 Then it deploys that image to `GCP_CLOUD_RUN_SERVICE` and performs an
-authenticated `/health` smoke check through `gcloud run services proxy`. A
-failed health check fails the GitHub Actions job so operators have an obvious
-signal that the deployed revision needs investigation or rollback.
+authenticated `/health` smoke check against the deployed Cloud Run URL using a
+Google identity token with the service URL as its audience. A failed health
+check fails the GitHub Actions job so operators have an obvious signal that the
+deployed revision needs investigation or rollback.
 
 ## Colab Usage
 

--- a/tests/unit/test_release_readiness_metadata.py
+++ b/tests/unit/test_release_readiness_metadata.py
@@ -74,9 +74,14 @@ def test_cloud_run_workflow_smoke_checks_private_service_after_deploy() -> None:
     show_url_index = workflow.index("- name: Show service URL")
 
     assert deploy_index < health_index < show_url_index
-    assert 'gcloud run services proxy "${SERVICE}"' in workflow
-    assert '"http://127.0.0.1:8080/health"' in workflow
-    assert "curl --fail --silent --show-error" in workflow
+    assert "SERVICE_URL" in workflow
+    assert "steps.deploy.outputs.url" in workflow
+    assert "gcloud auth print-identity-token" in workflow
+    assert "--audiences=" in workflow
+    assert "Authorization: Bearer" in workflow
+    assert "/health" in workflow
+    assert "--fail" in workflow
+    assert "gcloud run services proxy" not in workflow
     assert '"status"[[:space:]]*:[[:space:]]*"ok"' in workflow
 
 


### PR DESCRIPTION
## Summary
- fixes the Cloud Run deployment health check after the PR #323 merge deploy failed at `Verify Cloud Run health`
- replaces the CI-local `gcloud run services proxy` probe with a direct request to the deployed Cloud Run URL using `gcloud auth print-identity-token`
- updates README deployment wording and the release-readiness workflow contract test

## Evidence
- Latest failed deploy run `26066324382` completed build/push/deploy, then failed only during the private service health check.
- Cloud Run logs showed unauthenticated `/health` requests with an empty Authorization header.
- A direct authenticated request to `/health` returned `200 {"status":"ok"}`.

## Verification
- `python -m pytest tests/unit/test_release_readiness_metadata.py --asyncio-mode=auto -q`
- `git diff --check`