### PR TITLE
Fix Cloud Run health token and refresh repo context

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -96,24 +96,38 @@ jobs:
           secrets_update_strategy: merge
           flags: --port=8000 --memory=2Gi
 
+      - name: Mint Cloud Run health identity token
+        id: health-auth
+        # google-github-actions/auth v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          token_format: id_token
+          id_token_audience: ${{ steps.deploy.outputs.url }}
+
       - name: Verify Cloud Run health
         shell: bash
         env:
           SERVICE_URL: ${{ steps.deploy.outputs.url }}
+          IDENTITY_TOKEN: ${{ steps.health-auth.outputs.id_token }}
         run: |
           set -euo pipefail
           if [ -z "${SERVICE_URL:-}" ]; then
             echo "::error::Deploy step did not return a Cloud Run service URL"
             exit 1
           fi
+          if [ -z "${IDENTITY_TOKEN:-}" ]; then
+            echo "::error::Cloud Run health identity token was not minted"
+            exit 1
+          fi
 
           for attempt in {1..30}; do
-            identity_token="$(gcloud auth print-identity-token --audiences="${SERVICE_URL}")"
             http_status="$(
               curl --fail --silent --show-error --max-time 10 \
                 --output /tmp/cloud-run-health.json \
                 --write-out "%{http_code}" \
-                --header "Authorization: Bearer ${identity_token}" \
+                --header "Authorization: Bearer ${IDENTITY_TOKEN}" \
                 "${SERVICE_URL}/health" || true
             )"
 

--- a/README.md
+++ b/README.md
@@ -348,9 +348,10 @@ The workflow builds and pushes:
 
 Then it deploys that image to `GCP_CLOUD_RUN_SERVICE` and performs an
 authenticated `/health` smoke check against the deployed Cloud Run URL using a
-Google identity token with the service URL as its audience. A failed health
-check fails the GitHub Actions job so operators have an obvious signal that the
-deployed revision needs investigation or rollback.
+Google identity token minted by `google-github-actions/auth` with the service
+URL as its audience. A failed health check fails the GitHub Actions job so
+operators have an obvious signal that the deployed revision needs investigation
+or rollback.
 
 ## Colab Usage
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -7,9 +7,12 @@
 - Current documentation work includes the docs-owned
   `docs/diagrams/repo-architecture-visualizer/2026-04-30/` bundle for
   package/module/env relationship snapshots.
-- Current release work is preparing the 1.0.0 readiness branch with packaging
-  smoke tests, release metadata, local LangGraph evaluation gates, and workflow
-  cleanup before opening the final release PR.
+- Current release work is now post-1.0 maintenance: `v1.0.0` is published,
+  the release-readiness tracker is closed, and follow-up work should be scoped
+  to concrete quality, deployment, or runtime-generation issues.
+- Current deployment work centers on the private Google Cloud Run service,
+  which is deployed by GitHub Actions through Workload Identity Federation and
+  Google Secret Manager rather than long-lived service account keys.
 
 ## Recent Changes Reflected in the Codebase
 
@@ -37,16 +40,27 @@
   agents.
 - `docs/diagrams/README.md` now indexes both the hand-maintained generator
   stage/state map and the generated repo architecture visualizer bundle.
-- The 1.0 readiness branch adds a root MIT license, changelog, stable package
-  metadata, isolated install smoke tests, and `scripts/run_release_eval.py` for
-  local-only release evaluation.
+- The 1.0 release work landed with a root MIT license, changelog, stable
+  package metadata, isolated install smoke tests, and
+  `scripts/run_release_eval.py` for local-only release evaluation.
 - Release-readiness issue triage closed stale completed RequirementsAnalyst,
-  pattern/example, cross-cutting, and duplicate CYOA items; remaining open
-  issues are explicit post-1.0/residual work unless #258 is still waiting for
-  the release PR merge.
-- After PR #305 merged, the `Create diagram` workflow still failed while
-  creating the automation PR because checkout did not persist the configured
-  `GH_PAT` credentials for later git fetch/push operations.
+  pattern/example, cross-cutting, and duplicate CYOA items; #256 and #258 are
+  closed and the `v1.0.0` release is published.
+- PR #337 closed the contributor-facing agent/skill alignment lane by updating
+  LNF custom agents and mirrored skills to match the finalized runtime notebook
+  contract without blending contributor assets into runtime product agents.
+- PR #338 fixed live Cloud Run notebook-generation QA failures by restoring the
+  container notebook runtime stack and hardening generated notebook fallbacks.
+- PR #323 added the Cloud Run deployment workflow: pinned GitHub Actions, OIDC
+  authentication, Artifact Registry image push, private Cloud Run deployment,
+  Secret Manager-backed `OPENAI_API_KEY`, `2Gi` memory sizing, and release
+  readiness tests for the deployment contract.
+- PR #339 corrected the first private-service health-check failure by replacing
+  the CI-local Cloud Run proxy with a direct authenticated health request. The
+  follow-up deployment check mints the Cloud Run ID token through
+  `google-github-actions/auth` with `id_token_audience` set to the deployed
+  service URL; `gcloud auth print-identity-token --audiences=...` was not valid
+  for the GitHub Actions WIF account type used here.
 - The active default-branch ruleset requires CodeQL contexts for `actions`,
   `javascript-typescript`, and `python`; the reusable CodeQL workflow must keep
   that matrix aligned or otherwise green PR checks can still remain unmergeable.
@@ -62,11 +76,13 @@
   maintenance specialists for the current codebase rather than initial
   phase-by-phase builders, and mirrored LangChain/LangSmith skills should stay
   synchronized where they are true mirrors.
-- Keep the 1.0 release tracker (#256) aligned with packaging, workflow,
-  evaluation, metadata, issue-triage, and PR progress until the `v1.0.0`
-  release is published.
-- Land the follow-up `Create diagram` authentication hotfix and verify the next
-  `main` workflow run is green before tagging `v1.0.0`.
+- Keep Cloud Run deployment changes isolated from runtime generation changes
+  unless a live service failure proves the runtime code is involved.
+- Verify the next `main` Cloud Run deployment after health-check changes,
+  especially the authenticated `/health` step, before treating production
+  deployment as fully settled.
+- Keep post-1.0 issue work tied to explicit follow-up issues rather than
+  reopening completed release-readiness or runtime-notebook-contract lanes.
 - Keep maintainer visualization docs aligned when generator stages, package
   boundaries, module relationships, or environment-variable usage changes.
 - Preserve parity between CLI-driven, API-driven, and web-driven artifact
@@ -94,6 +110,10 @@
 - The local release evaluation gate defaults to no upload; LangSmith can remain
   a separate explicit release-candidate comparison step when credentials are
   available.
-- The current release-readiness branch verification baseline is `python -m
-  pytest --asyncio-mode=auto` with 625 passing tests and 4 skipped tests, plus
-  the CI fatal-error flake8 gate.
+- Cloud Run live mode gets `OPENAI_API_KEY` from Google Secret Manager at
+  runtime; GitHub repository secrets are only used for deployment plumbing.
+- Cloud Run deploys with `2Gi` memory because live generation and artifact
+  packaging exceeded the default `512Mi` limit during live testing.
+- The release-readiness verification baseline was `python -m pytest
+  --asyncio-mode=auto` with 625 passing tests and 4 skipped tests, plus the CI
+  fatal-error flake8 gate.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -19,23 +19,34 @@
 - The local 1.0 release evaluation gate validates deterministic architecture
   selection, graph design, notebook composition, QA/repair, and example
   inventory surfaces without requiring LangSmith upload.
-- The release-readiness branch has a green full local verification baseline:
+- The release-readiness branch had a green full local verification baseline:
   `python -m pytest --asyncio-mode=auto` reports 625 passed and 4 skipped, and
   the CI fatal-error flake8 gate reports 0 findings.
 - Stale completed release-plan issues were closed with evidence, reducing the
   open issue inventory from 49 to 26 while keeping true residual items open.
+- The `v1.0.0` release is published, and #256 plus #258 are closed.
+- Contributor-facing LNF custom agents and mirrored skills now align with the
+  finalized runtime notebook contract from PR #336 through the merged #337
+  follow-up.
+- Google Cloud Run deployment is present through GitHub Actions OIDC, Artifact
+  Registry, private Cloud Run, Secret Manager-backed `OPENAI_API_KEY`, `2Gi`
+  memory sizing, and an authenticated `/health` smoke check.
+- Live Cloud Run notebook generation was debugged through PR #338, which added
+  the missing notebook runtime dependencies and hardened generated notebook
+  fallbacks for the live QA path.
 
 ## What Is Still Incomplete
 
 - Experimental Deep Agents support is opt-in through `agent_type="deepagents"`
   and keeps the optional SDK out of core imports.
-- The 1.0 release is not tagged yet; #258 should close through the release PR
-  merge, and #256 remains the canonical tracker until `v1.0.0` is published.
+- Production Cloud Run deployment uses an authenticated health-check path. The
+  deploy job mints a Cloud Run ID token through `google-github-actions/auth`
+  with the deployed service URL as the token audience.
 
 ## Current Status
 
-- The package metadata in `setup.py` now uses the 1.0.0 Production/Stable
-  release baseline on the release-readiness branch.
+- The package metadata in `setup.py` uses the 1.0.0 Production/Stable release
+  baseline on `main`, and `v1.0.0` is published.
 - The repository already contains substantial scaffolding for CLI, API, RAG,
   notebook export, QA/repair, registry-backed planning, and pattern generation
   workflows.
@@ -46,13 +57,11 @@
   instead of stale phase-by-phase scaffold work.
 - Repository architecture diagrams are discoverable through public docs,
   contributor guidance, and MemoryBank context.
-- Release metadata now includes a root MIT license, changelog, and 1.0.0 package
-  version/classifier updates on the release-readiness branch.
-- A follow-up `Create diagram` hotfix branch checks `GH_PAT` before checkout,
-  uses that token for checkout and pull-request creation, and skips cleanly
-  with a notice when the secret is unavailable.
-- The same hotfix branch aligns the reusable CodeQL matrix with the active
-  ruleset-required contexts: `actions`, `javascript-typescript`, and `python`.
+- Release metadata includes a root MIT license, changelog, and 1.0.0 package
+  version/classifier updates on `main`.
+- The Cloud Run deploy workflow builds and pushes the container image, deploys
+  the private service, mounts `OPENAI_API_KEY` from Secret Manager, and checks
+  `/health` after deployment.
 
 ## Known Issues and Limitations
 
@@ -68,5 +77,7 @@
 - Router fallback/general routing (#60), iterative requirements refinement
   (#202), and the remaining CYOA notebook cell issues are tracked as residual
   follow-up work rather than closed stale items.
-- The `Create diagram` workflow must pass on `main` after the authentication
-  hotfix merges before the `v1.0.0` release is tagged.
+- The Cloud Run workflow's private-service health check is sensitive to token
+  minting details in GitHub Actions WIF. Do not use `gcloud auth
+  print-identity-token --audiences=...` for this workflow's health token; the
+  ID token is minted through `google-github-actions/auth` instead.

--- a/memory-bank/tasks/TASK002-1-0-release-readiness.md
+++ b/memory-bank/tasks/TASK002-1-0-release-readiness.md
@@ -1,8 +1,8 @@
 # TASK002 - 1.0 Release Readiness Implementation
 
-**Status:** In Progress
+**Status:** Complete
 **Added:** 2026-05-04
-**Updated:** 2026-05-04
+**Updated:** 2026-05-19
 
 ## Original Request
 
@@ -32,7 +32,7 @@ test-first.
 
 ## Progress Tracking
 
-**Overall Status:** In Progress - 90%
+**Overall Status:** Complete - 100%
 
 ### Subtasks
 
@@ -44,7 +44,7 @@ test-first.
 | 2.4 | Add release metadata and diagram workflow fix | Complete | 2026-05-04 | Version, classifier, license, changelog, and workflow token updated. |
 | 2.5 | Add local release evaluation gate | Complete | 2026-05-04 | Dataset and `scripts/run_release_eval.py` added; targeted test passes. |
 | 2.6 | Triage stale issues with evidence | Complete | 2026-05-04 | Closed stale completed and duplicate issues; kept true residuals open with audit comments. |
-| 2.7 | Run final verification and open PR | In Progress | 2026-05-04 | Full pytest and flake8 fatal-error gate pass; publication pending. |
+| 2.7 | Run final verification and open PR | Complete | 2026-05-19 | Release work merged, #256/#258 closed, and `v1.0.0` published. |
 
 ## Progress Log
 
@@ -67,3 +67,10 @@ test-first.
   tests/patterns -v`, `python -m pytest tests/integration -q`, full `python -m
   pytest --asyncio-mode=auto` (625 passed, 4 skipped), CI fatal-error flake8,
   opt-in packaging smokes, and the local release evaluation gate.
+
+### 2026-05-19
+
+- Confirmed the 1.0 release-readiness work is merged into `main`.
+- Confirmed #256 and #258 are closed and the `v1.0.0` GitHub release exists.
+- Updated MemoryBank status so future sessions treat release-readiness as a
+  completed baseline, not an active branch.

--- a/memory-bank/tasks/TASK003-cloud-run-deployment-live-qa.md
+++ b/memory-bank/tasks/TASK003-cloud-run-deployment-live-qa.md
@@ -1,0 +1,67 @@
+# TASK003 - Cloud Run Deployment and Live QA Hardening
+
+**Status:** Complete
+**Added:** 2026-05-19
+**Updated:** 2026-05-19
+
+## Original Request
+
+Set up and harden production deployment for `langgraph_system_generator` on a
+private Google Cloud Run service using GitHub Actions Workload Identity
+Federation, Artifact Registry, Secret Manager, and live notebook QA evidence.
+
+## Thought Process
+
+Cloud Run deployment is a repository operations lane, not a runtime-agent design
+lane. Keep deployment workflow changes isolated from runtime generation unless
+live service evidence shows runtime code is involved. Avoid long-lived Google
+service account keys and avoid copying runtime provider secrets into GitHub.
+
+## Implementation Plan
+
+- Deploy the containerized FastAPI app to Cloud Run from GitHub Actions.
+- Use GitHub Actions OIDC and a Google service account instead of JSON keys.
+- Push images to Artifact Registry and deploy with production environment
+  gating.
+- Mount `OPENAI_API_KEY` from Google Secret Manager at runtime.
+- Size Cloud Run above the default memory limit for live generation.
+- Validate private-service health with an authenticated `/health` smoke check.
+- Keep workflow contract assertions in
+  `tests/unit/test_release_readiness_metadata.py`.
+
+## Progress Tracking
+
+**Overall Status:** Complete - 100%
+
+### Subtasks
+
+| ID | Description | Status | Updated | Notes |
+|----|-------------|--------|---------|-------|
+| 3.1 | Add Cloud Run deployment workflow | Complete | 2026-05-18 | PR #323 merged with pinned actions, OIDC auth, Artifact Registry push, private Cloud Run deploy, and production gate. |
+| 3.2 | Mount OpenAI key from Secret Manager | Complete | 2026-05-18 | Workflow mounts `OPENAI_API_KEY` from the configured Secret Manager secret; GitHub `OPENAI_API_KEY` is not used for runtime. |
+| 3.3 | Increase production memory for live generation | Complete | 2026-05-18 | Cloud Run deploy flags set `--memory=2Gi` after the 512 MiB limit killed live generation. |
+| 3.4 | Restore live notebook QA in the container | Complete | 2026-05-18 | PR #338 added notebook runtime dependencies and fixed generated notebook fallback issues. |
+| 3.5 | Stabilize private health check | Complete | 2026-05-19 | The health check uses an action-minted ID token with the deployed service URL as audience. |
+
+## Progress Log
+
+### 2026-05-18
+
+- PR #323 merged the deployment workflow and README Cloud Run docs.
+- Live testing exposed Cloud Run memory pressure at the default 512 MiB limit;
+  the workflow now deploys with `2Gi`.
+- Live notebook QA exposed missing container runtime dependencies and generated
+  notebook fallback problems; PR #338 fixed the live QA path.
+
+### 2026-05-19
+
+- PR #339 replaced the CI-local Cloud Run proxy with a direct authenticated
+  `/health` request after the proxy sent unauthenticated requests to the private
+  service.
+- The next `main` deploy showed that `gcloud auth print-identity-token
+  --audiences=...` is not valid for the GitHub Actions WIF account type in this
+  workflow.
+- The health-check implementation now mints an ID token through
+  `google-github-actions/auth` with `token_format: id_token` and
+  `id_token_audience` set to `steps.deploy.outputs.url`, then uses that output
+  as the `Authorization: Bearer` token for `/health`.

--- a/memory-bank/tasks/_index.md
+++ b/memory-bank/tasks/_index.md
@@ -2,11 +2,13 @@
 
 ## In Progress
 
-- [TASK002 - 1.0 release readiness implementation](TASK002-1-0-release-readiness.md)
+- None
 
 ## Completed
 
 - [TASK001 - Repo architecture visualizer docs sync](TASK001-repo-architecture-visualizer-docs-sync.md)
+- [TASK002 - 1.0 release readiness implementation](TASK002-1-0-release-readiness.md)
+- [TASK003 - Cloud Run deployment and live QA hardening](TASK003-cloud-run-deployment-live-qa.md)
 
 ## Current State
 
@@ -14,6 +16,8 @@
   - `_index.md`
   - `TASK001-repo-architecture-visualizer-docs-sync.md`
   - `TASK002-1-0-release-readiness.md`
+  - `TASK003-cloud-run-deployment-live-qa.md`
 - Task-level Memory Bank tracking has started with the documentation and
-  visualization sync for the checked-in repo architecture bundle and the 1.0
-  release-readiness branch.
+  visualization sync for the checked-in repo architecture bundle, the completed
+  1.0 release-readiness branch, and the active Cloud Run deployment hardening
+  lane.

--- a/tests/unit/test_release_readiness_metadata.py
+++ b/tests/unit/test_release_readiness_metadata.py
@@ -70,18 +70,21 @@ def test_cloud_run_workflow_smoke_checks_private_service_after_deploy() -> None:
     workflow = _read(".github/workflows/deploy-cloud-run.yml")
 
     deploy_index = workflow.index("- name: Deploy to Cloud Run")
+    token_index = workflow.index("- name: Mint Cloud Run health identity token")
     health_index = workflow.index("- name: Verify Cloud Run health")
     show_url_index = workflow.index("- name: Show service URL")
 
-    assert deploy_index < health_index < show_url_index
+    assert deploy_index < token_index < health_index < show_url_index
     assert "SERVICE_URL" in workflow
     assert "steps.deploy.outputs.url" in workflow
-    assert "gcloud auth print-identity-token" in workflow
-    assert "--audiences=" in workflow
+    assert "token_format: id_token" in workflow
+    assert "id_token_audience" in workflow
+    assert "steps.health-auth.outputs.id_token" in workflow
     assert "Authorization: Bearer" in workflow
     assert "/health" in workflow
     assert "--fail" in workflow
     assert "gcloud run services proxy" not in workflow
+    assert "gcloud auth print-identity-token" not in workflow
     assert '"status"[[:space:]]*:[[:space:]]*"ok"' in workflow
 
 


### PR DESCRIPTION
## Summary
- fixes the post-#339 Cloud Run deploy failure by minting the private-service health token with `google-github-actions/auth` instead of `gcloud auth print-identity-token --audiences=...`
- keeps the health check audience bound to the deployed Cloud Run service URL and uses the action `id_token` output for the `Authorization: Bearer` header
- refreshes MemoryBank state after the 1.0 release, #322/#323/#337/#338/#339 closeout, and the active Cloud Run deployment lane

## Evidence
- Main deploy run `26068563004` failed in `Verify Cloud Run health` with `Invalid account type for --audiences. Requires valid service account.`
- `google-github-actions/auth` documents `token_format: id_token` plus `id_token_audience` for invoking Cloud Run services.
- Cloud Run service-to-service docs require an ID token whose audience is the receiving service URL and sent as a bearer token.

## Verification
- `python -m pytest tests/unit/test_release_readiness_metadata.py --asyncio-mode=auto -q`
- `git diff --check`
- workflow YAML parse smoke