### PR TITLE
[codex] Harden runtime pipeline reliability

### DIFF
--- a/src/langgraph_system_generator/generator/agents/qa_repair_agent.py
+++ b/src/langgraph_system_generator/generator/agents/qa_repair_agent.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import List
 
 from langchain_openai import ChatOpenAI
@@ -42,12 +40,11 @@ class QARepairAgent:
         """
         notebook_builder = NotebookFileComposer()
         validator = NotebookValidator()
-
-        with TemporaryDirectory() as temp_dir:
-            notebook = notebook_builder.build_notebook(cells)
-            notebook_path = Path(temp_dir) / "generated.ipynb"
-            notebook_builder.write(notebook, notebook_path)
-            return validator.validate_all(notebook_path)
+        notebook = notebook_builder.build_notebook(cells)
+        return await asyncio.to_thread(
+            validator.validate_notebook,
+            notebook,
+        )
 
     def _check_no_placeholders(self, cells: List[CellSpec]) -> QAReport:
         """Ensure no TODO or placeholder text in critical cells."""

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -224,8 +224,8 @@ def get_cached_docs_retriever(
         return retriever
 
 
-def _clear_docs_retriever_cache() -> None:
-    """Clear all process-local docs retriever cache entries."""
+def _reset_docs_retriever_cache_for_tests() -> None:
+    """Clear all process-local docs retriever cache entries for test isolation."""
 
     with _DOCS_RETRIEVER_CACHE_LOCK:
         _DOCS_RETRIEVER_CACHE.clear()

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
-from tempfile import TemporaryDirectory
+from threading import Lock
 from typing import Any, Dict, List
 
 import nbformat
@@ -28,6 +28,7 @@ from langgraph_system_generator.generator.state import (
     GenerationContextPack,
     GraphDesignFeedback,
     GraphExportBundle,
+    MAX_QA_HISTORY,
     NotebookCompositionFeedback,
     NotebookDependencyPlan,
     NotebookPlan,
@@ -61,6 +62,8 @@ logger = logging.getLogger(__name__)
 RUNTIME_UNAVAILABLE_PREFIX = "runtime validation unavailable"
 TRUSTED_SMOKE_TEST_SCOPE = "trusted_smoke_test"
 ARCHITECTURE_REGISTRY = get_default_architecture_registry()
+_DOCS_RETRIEVER_CACHE: Dict[str, DocsRetriever] = {}
+_DOCS_RETRIEVER_CACHE_LOCK = Lock()
 
 
 def _resolve_model_config(state: GeneratorState):
@@ -126,6 +129,115 @@ def _qa_history_from_state(state: GeneratorState) -> List[QAReport]:
     if "qa_history" in state and state.get("qa_history") is not None:
         return list(state.get("qa_history") or [])
     return list(state.get("qa_reports") or [])
+
+
+def _qa_history_key(report: QAReport) -> str:
+    """Return a stable key for QA history de-duplication."""
+
+    return "|".join(
+        [
+            str(report.rule_id),
+            str(report.check_name),
+            str(report.stage),
+            str(report.attempt),
+            str(report.severity),
+            str(report.passed),
+            str(report.message),
+        ]
+    )
+
+
+def bounded_qa_history(
+    existing: List[QAReport],
+    new_reports: List[QAReport],
+    *,
+    limit: int = MAX_QA_HISTORY,
+) -> List[QAReport]:
+    """Merge QA history while preserving current-attempt blocking failures."""
+
+    combined = [*(existing or []), *(new_reports or [])]
+    if limit <= 0 or not combined:
+        return []
+
+    latest_by_key: Dict[str, tuple[int, QAReport]] = {}
+    for index, report in enumerate(combined):
+        latest_by_key[_qa_history_key(report)] = (index, report)
+
+    deduped = [
+        entry[1] for entry in sorted(latest_by_key.values(), key=lambda item: item[0])
+    ]
+    if len(deduped) <= limit:
+        return deduped
+
+    attempts = [report.attempt for report in deduped if isinstance(report.attempt, int)]
+    current_attempt = max(attempts) if attempts else None
+    pinned_keys: set[str] = set()
+    if current_attempt is not None:
+        pinned_keys = {
+            _qa_history_key(report)
+            for report in deduped
+            if report.attempt == current_attempt
+            and not report.passed
+            and report.severity == "error"
+        }
+
+    latest_slice = deduped[-limit:]
+    selected_keys = {_qa_history_key(report) for report in latest_slice}
+    missing_pinned = [key for key in pinned_keys if key not in selected_keys]
+    if not missing_pinned:
+        return latest_slice
+
+    missing_pinned_set = set(missing_pinned)
+    pinned_reports = [
+        report for report in deduped if _qa_history_key(report) in missing_pinned_set
+    ][-limit:]
+    available_slots = max(limit - len(pinned_reports), 0)
+    filler = [
+        report
+        for report in reversed(deduped)
+        if _qa_history_key(report) not in missing_pinned_set
+    ][:available_slots]
+    selected = [*pinned_reports, *reversed(filler)]
+    return sorted(
+        selected,
+        key=lambda report: latest_by_key[_qa_history_key(report)][0],
+    )
+
+
+def _docs_retriever_cache_key(vector_store_path: str | Path | None = None) -> str:
+    """Normalize the vector-store path used for retriever cache identity."""
+
+    configured_path = vector_store_path or settings.vector_store_path
+    return str(Path(configured_path).expanduser().resolve())
+
+
+def get_cached_docs_retriever(
+    vector_store_path: str | Path | None = None,
+) -> DocsRetriever:
+    """Return a process-local docs retriever for the configured vector store."""
+
+    cache_key = _docs_retriever_cache_key(vector_store_path)
+    with _DOCS_RETRIEVER_CACHE_LOCK:
+        retriever = _DOCS_RETRIEVER_CACHE.get(cache_key)
+        if retriever is None:
+            vector_store_manager = VectorStoreManager(cache_key)
+            retriever = DocsRetriever(vector_store_manager)
+            _DOCS_RETRIEVER_CACHE[cache_key] = retriever
+        return retriever
+
+
+def _clear_docs_retriever_cache() -> None:
+    """Clear the process-local docs retriever cache for tests."""
+
+    with _DOCS_RETRIEVER_CACHE_LOCK:
+        _DOCS_RETRIEVER_CACHE.clear()
+
+
+def _retrieve_docs_for_prompt(prompt: str) -> List[Dict[str, Any]]:
+    """Retrieve docs for a prompt using the shared cached retriever."""
+
+    retriever = get_cached_docs_retriever()
+    return retriever.retrieve(prompt, k=10)
 
 
 def _qa_repair_feedback_from_state(state: GeneratorState) -> QARepairFeedback:
@@ -294,7 +406,7 @@ def _upsert_qa_repair_summary_cell(
     """Replace any existing QA repair summary cell with the latest summary."""
 
     retained_cells = [
-        cell.model_copy(deep=True)
+        cell
         for cell in cells
         if cell.section != "qa_repair_summary"
         and cell.metadata.get("kind") != "qa_repair_summary"
@@ -339,11 +451,10 @@ async def rag_retrieval_node(state: GeneratorState) -> Dict[str, Any]:
         Updated state with retrieved documentation
     """
     try:
-        vector_store_manager = VectorStoreManager(settings.vector_store_path)
-        retriever = DocsRetriever(vector_store_manager)
-
-        # Retrieve general docs based on user prompt
-        snippets = retriever.retrieve(state["user_prompt"], k=10)
+        snippets = await asyncio.to_thread(
+            _retrieve_docs_for_prompt,
+            state["user_prompt"],
+        )
 
         # Convert to DocSnippet format
         docs = [
@@ -359,6 +470,7 @@ async def rag_retrieval_node(state: GeneratorState) -> Dict[str, Any]:
         return {"docs_context": docs}
     except Exception as e:
         logger.warning("RAG retrieval failed: %s", e)
+        _clear_docs_retriever_cache()
         # If RAG fails, continue without docs
         return {"docs_context": []}
 
@@ -549,8 +661,7 @@ async def architecture_selection_node(state: GeneratorState) -> Dict[str, Any]:
         }
 
     try:
-        vector_store_manager = VectorStoreManager(settings.vector_store_path)
-        retriever = DocsRetriever(vector_store_manager)
+        retriever = await asyncio.to_thread(get_cached_docs_retriever)
     except Exception as e:
         logger.warning(
             "Failed to load vector store for architecture selection: %s",
@@ -752,30 +863,20 @@ async def static_qa_node(state: GeneratorState) -> Dict[str, Any]:
     validator = NotebookValidator()
 
     cells = state.get("generated_cells", [])
-    with TemporaryDirectory() as temp_dir:
-        notebook = notebook_builder.build_notebook(cells)
-        notebook_path = Path(temp_dir) / "generated.ipynb"
-        notebook_builder.write(notebook, notebook_path)
-
-        # Log temp path for debugging failed validations
-        logger.debug(f"Running validation on temporary notebook: {notebook_path}")
-
-        reports = validator.validate_all(notebook_path)
-
-        # If validation fails, log details for debugging
-        if any(not r.passed for r in reports):
-            logger.info(
-                "Validation failed for temporary notebook at %s "
-                "(stored in a TemporaryDirectory that will be removed after this step).",
-                notebook_path,
-            )
+    notebook = notebook_builder.build_notebook(cells)
+    reports = await asyncio.to_thread(
+        validator.validate_notebook,
+        notebook,
+    )
+    if any(not r.passed for r in reports):
+        logger.info("Validation failed for generated in-memory notebook.")
 
     annotated_reports = _stamp_reports(
         reports,
         stage="static",
         attempt=int(state.get("repair_attempts", 0)),
     )
-    qa_history = [*_qa_history_from_state(state), *annotated_reports]
+    qa_history = bounded_qa_history(_qa_history_from_state(state), annotated_reports)
     qa_repair_feedback = _qa_repair_feedback_from_reports(
         annotated_reports,
         repair_attempts=int(state.get("repair_attempts", 0)),
@@ -894,7 +995,7 @@ async def runtime_qa_node(state: GeneratorState) -> Dict[str, Any]:
             )
 
     combined_reports = [*existing_reports, report]
-    qa_history = [*_qa_history_from_state(state), report]
+    qa_history = bounded_qa_history(_qa_history_from_state(state), [report])
     qa_repair_feedback = _qa_repair_feedback_from_reports(
         combined_reports,
         repair_attempts=attempt,
@@ -921,7 +1022,12 @@ async def repair_node(state: GeneratorState) -> Dict[str, Any]:
     cells = state.get("generated_cells", [])
     qa_reports = list(state.get("qa_reports", []))
     attempt = int(state.get("repair_attempts", 0))
-    outcome = repair_agent.repair_cells(cells, qa_reports, attempt=attempt)
+    outcome = await asyncio.to_thread(
+        repair_agent.repair_cells,
+        cells,
+        qa_reports,
+        attempt=attempt,
+    )
 
     normalized_reports = _stamp_reports(
         outcome.qa_reports,
@@ -978,7 +1084,9 @@ async def repair_node(state: GeneratorState) -> Dict[str, Any]:
     return {
         "generated_cells": regenerated_cells,
         "qa_reports": normalized_reports,
-        "qa_history": [*_qa_history_from_state(state), repair_summary],
+        "qa_history": bounded_qa_history(
+            _qa_history_from_state(state), [repair_summary]
+        ),
         "repair_attempts": attempt + 1,
         "qa_repair_feedback": qa_repair_feedback,
     }

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -131,19 +131,17 @@ def _qa_history_from_state(state: GeneratorState) -> List[QAReport]:
     return list(state.get("qa_reports") or [])
 
 
-def _qa_history_key(report: QAReport) -> str:
+def _qa_history_key(report: QAReport) -> tuple[Any, ...]:
     """Return a stable key for QA history de-duplication."""
 
-    return "|".join(
-        [
-            str(report.rule_id),
-            str(report.check_name),
-            str(report.stage),
-            str(report.attempt),
-            str(report.severity),
-            str(report.passed),
-            str(report.message),
-        ]
+    return (
+        report.rule_id,
+        report.check_name,
+        report.stage,
+        report.attempt,
+        report.severity,
+        report.passed,
+        report.message,
     )
 
 
@@ -231,6 +229,16 @@ def _clear_docs_retriever_cache() -> None:
 
     with _DOCS_RETRIEVER_CACHE_LOCK:
         _DOCS_RETRIEVER_CACHE.clear()
+
+
+def _drop_docs_retriever_cache_entry(
+    vector_store_path: str | Path | None = None,
+) -> None:
+    """Remove one docs retriever cache entry after a path-scoped failure."""
+
+    cache_key = _docs_retriever_cache_key(vector_store_path)
+    with _DOCS_RETRIEVER_CACHE_LOCK:
+        _DOCS_RETRIEVER_CACHE.pop(cache_key, None)
 
 
 def _retrieve_docs_for_prompt(prompt: str) -> List[Dict[str, Any]]:
@@ -470,7 +478,7 @@ async def rag_retrieval_node(state: GeneratorState) -> Dict[str, Any]:
         return {"docs_context": docs}
     except Exception as e:
         logger.warning("RAG retrieval failed: %s", e)
-        _clear_docs_retriever_cache()
+        _drop_docs_retriever_cache_entry()
         # If RAG fails, continue without docs
         return {"docs_context": []}
 

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -225,7 +225,7 @@ def get_cached_docs_retriever(
 
 
 def _clear_docs_retriever_cache() -> None:
-    """Clear the process-local docs retriever cache for tests."""
+    """Clear all process-local docs retriever cache entries."""
 
     with _DOCS_RETRIEVER_CACHE_LOCK:
         _DOCS_RETRIEVER_CACHE.clear()

--- a/src/langgraph_system_generator/generator/state.py
+++ b/src/langgraph_system_generator/generator/state.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import operator
+import json
 from typing import Annotated, Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -18,6 +18,59 @@ DEFAULT_REQUIREMENTS_CONSTRAINT_TYPES = (
     "runtime",
     "environment",
 )
+MAX_CONSTRAINTS = 50
+MAX_DOCS_CONTEXT = 50
+MAX_QA_HISTORY = 100
+
+
+def _state_item_key(item: Any) -> str:
+    """Return a stable best-effort key for de-duplicating accumulated state."""
+
+    if hasattr(item, "model_dump"):
+        payload = item.model_dump(mode="json")
+    elif isinstance(item, dict):
+        payload = item
+    else:
+        payload = repr(item)
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+def _bounded_latest_unique(left: List[Any], right: List[Any], limit: int) -> List[Any]:
+    """Merge two state lists, keeping the latest unique items within the cap."""
+
+    combined = [*(left or []), *(right or [])]
+    if not combined:
+        return []
+
+    seen: set[str] = set()
+    latest_unique_reversed: List[Any] = []
+    for item in reversed(combined):
+        key = _state_item_key(item)
+        if key in seen:
+            continue
+        seen.add(key)
+        latest_unique_reversed.append(item)
+
+    latest_unique = list(reversed(latest_unique_reversed))
+    return latest_unique[-limit:]
+
+
+def bounded_constraints_reducer(
+    left: List["Constraint"],
+    right: List["Constraint"],
+) -> List["Constraint"]:
+    """Accumulate constraints without unbounded growth across graph retries."""
+
+    return _bounded_latest_unique(left, right, MAX_CONSTRAINTS)
+
+
+def bounded_docs_context_reducer(
+    left: List["DocSnippet"],
+    right: List["DocSnippet"],
+) -> List["DocSnippet"]:
+    """Accumulate retrieved snippets without unbounded growth across retries."""
+
+    return _bounded_latest_unique(left, right, MAX_DOCS_CONTEXT)
 
 
 def normalize_constraint_type(value: str) -> str:
@@ -774,7 +827,7 @@ class GeneratorState(TypedDict):
     uploaded_files: Optional[List[str]]
 
     # Extracted requirements
-    constraints: Annotated[List[Constraint], operator.add]
+    constraints: Annotated[List[Constraint], bounded_constraints_reducer]
     requirements_feedback: RequirementsFeedback
     architecture_feedback: ArchitectureFeedback
     graph_design_feedback: GraphDesignFeedback
@@ -782,7 +835,7 @@ class GeneratorState(TypedDict):
     selected_patterns: Dict[str, Any]
 
     # RAG context
-    docs_context: Annotated[List[DocSnippet], operator.add]
+    docs_context: Annotated[List[DocSnippet], bounded_docs_context_reducer]
     generation_context_pack: GenerationContextPack
 
     # Planning

--- a/src/langgraph_system_generator/qa/repair.py
+++ b/src/langgraph_system_generator/qa/repair.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Any, Dict, List, Sequence
 
 import nbformat
@@ -616,11 +615,8 @@ class NotebookRepairAgent:
     def _validate_cells(self, cells: Sequence[CellSpec]) -> List[QAReport]:
         """Validate cells using the shared notebook validator."""
 
-        with TemporaryDirectory() as temp_dir:
-            notebook = self.notebook_builder.build_notebook(cells)
-            notebook_path = Path(temp_dir) / "repaired.ipynb"
-            self.notebook_builder.write(notebook, notebook_path)
-            return self.validator.validate_all(notebook_path)
+        notebook = self.notebook_builder.build_notebook(cells)
+        return self.validator.validate_notebook(notebook, source="<repair>")
 
     def _clone_cells(self, cells: Sequence[CellSpec]) -> List[CellSpec]:
         """Clone cell specs so repair attempts do not mutate caller-owned state."""

--- a/src/langgraph_system_generator/qa/validators.py
+++ b/src/langgraph_system_generator/qa/validators.py
@@ -1902,6 +1902,44 @@ class NotebookValidator:
         notebook = self._load_notebook(notebook_path)
         return NotebookValidationContext.from_notebook(notebook_path, notebook)
 
+    def _validate_loaded_notebook_json(
+        self,
+        notebook: NotebookNode,
+        source: str | Path,
+    ) -> QAReport:
+        """Validate an already-loaded notebook object's nbformat structure."""
+
+        try:
+            nbformat.validate(notebook)
+            return QAReport(
+                check_name="JSON Validity",
+                passed=True,
+                message="Notebook JSON is valid and properly structured.",
+                rule_id="json_structure",
+                severity="info",
+                category="serialization",
+                repairable=False,
+                evidence={"path": str(source)},
+            )
+        except nbformat.ValidationError as exc:
+            return QAReport(
+                check_name="JSON Validity",
+                passed=False,
+                message=f"Invalid notebook structure: {exc}",
+                rule_id="json_structure",
+                severity="error",
+                category="serialization",
+                repairable=False,
+                suggestions=[
+                    "Verify all required notebook fields and cell metadata are present.",
+                ],
+                evidence={
+                    "path": str(source),
+                    "error_type": "nbformat",
+                    "message": str(exc),
+                },
+            )
+
     def validate_json_structure(self, notebook_path: str | Path) -> QAReport:
         """Check that notebook JSON is valid and can be loaded."""
 
@@ -1923,17 +1961,7 @@ class NotebookValidator:
                 )
 
             notebook = self._load_notebook(path)
-            nbformat.validate(notebook)
-            return QAReport(
-                check_name="JSON Validity",
-                passed=True,
-                message="Notebook JSON is valid and properly structured.",
-                rule_id="json_structure",
-                severity="info",
-                category="serialization",
-                repairable=False,
-                evidence={"path": str(path)},
-            )
+            return self._validate_loaded_notebook_json(notebook, path)
         except (json.JSONDecodeError, nbformat.reader.NotJSONError) as exc:
             return QAReport(
                 check_name="JSON Validity",
@@ -1961,7 +1989,11 @@ class NotebookValidator:
                 suggestions=[
                     "Verify all required notebook fields and cell metadata are present.",
                 ],
-                evidence={"error_type": "nbformat", "message": str(exc)},
+                evidence={
+                    "path": str(notebook_path),
+                    "error_type": "nbformat",
+                    "message": str(exc),
+                },
             )
         except Exception as exc:
             return QAReport(
@@ -1975,6 +2007,40 @@ class NotebookValidator:
                 suggestions=["Check file permissions and notebook path resolution."],
                 evidence={"error_type": type(exc).__name__, "message": str(exc)},
             )
+
+    def validate_notebook(
+        self,
+        notebook: NotebookNode,
+        source: str = "<memory>",
+    ) -> List[QAReport]:
+        """Run all validation checks against an already-loaded notebook."""
+
+        reports: List[QAReport] = []
+        json_report = self._validate_loaded_notebook_json(notebook, source)
+        reports.append(json_report)
+
+        if not json_report.passed:
+            return reports
+
+        context = NotebookValidationContext.from_notebook(source, notebook)
+        syntax_report: QAReport | None = None
+        for rule in self.registry.rules():
+            if isinstance(rule, PythonSyntaxRule):
+                report = rule.validate(context)
+                syntax_report = report
+                if report is not None:
+                    reports.append(report)
+                continue
+
+            if isinstance(rule, (UndefinedNameRule, GraphStructureRule)) and (
+                syntax_report is not None and not syntax_report.passed
+            ):
+                continue
+            report = rule.validate(context)
+            if report is not None:
+                reports.append(report)
+
+        return reports
 
     def check_no_placeholders(self, notebook_path: str | Path) -> QAReport:
         """Ensure no placeholder text remains in the notebook."""
@@ -2110,29 +2176,12 @@ class NotebookValidator:
     def validate_all(self, notebook_path: str | Path) -> List[QAReport]:
         """Run all validation checks on a notebook."""
 
-        reports: List[QAReport] = []
         json_report = self.validate_json_structure(notebook_path)
-        reports.append(json_report)
-
         if not json_report.passed:
-            return reports
+            return [json_report]
 
-        context = self._context_from_path(notebook_path)
-        syntax_report: QAReport | None = None
-        for rule in self.registry.rules():
-            if isinstance(rule, PythonSyntaxRule):
-                report = rule.validate(context)
-                syntax_report = report
-                if report is not None:
-                    reports.append(report)
-                continue
-
-            if isinstance(rule, (UndefinedNameRule, GraphStructureRule)) and (
-                syntax_report is not None and not syntax_report.passed
-            ):
-                continue
-            report = rule.validate(context)
-            if report is not None:
-                reports.append(report)
-
+        notebook = self._load_notebook(notebook_path)
+        reports = self.validate_notebook(notebook, source=str(notebook_path))
+        if reports:
+            reports[0] = json_report
         return reports

--- a/src/langgraph_system_generator/qa/validators.py
+++ b/src/langgraph_system_generator/qa/validators.py
@@ -1940,88 +1940,101 @@ class NotebookValidator:
                 },
             )
 
-    def validate_json_structure(self, notebook_path: str | Path) -> QAReport:
-        """Check that notebook JSON is valid and can be loaded."""
+    def _load_and_validate_notebook_json(
+        self,
+        notebook_path: str | Path,
+    ) -> tuple[QAReport, NotebookNode | None]:
+        """Load a notebook once and validate its nbformat structure."""
 
         try:
             path = Path(notebook_path)
             if not path.exists():
-                return QAReport(
+                return (
+                    QAReport(
+                        check_name="JSON Validity",
+                        passed=False,
+                        message=f"Notebook file not found: {notebook_path}",
+                        rule_id="json_structure",
+                        severity="error",
+                        category="serialization",
+                        repairable=False,
+                        suggestions=[
+                            "Ensure the notebook was generated and saved correctly."
+                        ],
+                        evidence={"path": str(path)},
+                    ),
+                    None,
+                )
+
+            notebook = self._load_notebook(path)
+            json_report = self._validate_loaded_notebook_json(notebook, path)
+            return json_report, notebook if json_report.passed else None
+        except (json.JSONDecodeError, nbformat.reader.NotJSONError) as exc:
+            return (
+                QAReport(
                     check_name="JSON Validity",
                     passed=False,
-                    message=f"Notebook file not found: {notebook_path}",
+                    message=f"Invalid JSON: {exc}",
                     rule_id="json_structure",
                     severity="error",
                     category="serialization",
                     repairable=False,
                     suggestions=[
-                        "Ensure the notebook was generated and saved correctly."
+                        "Check for malformed JSON syntax in the notebook file.",
+                        "Ensure the file is encoded as UTF-8 and fully written.",
                     ],
-                    evidence={"path": str(path)},
-                )
-
-            notebook = self._load_notebook(path)
-            return self._validate_loaded_notebook_json(notebook, path)
-        except (json.JSONDecodeError, nbformat.reader.NotJSONError) as exc:
-            return QAReport(
-                check_name="JSON Validity",
-                passed=False,
-                message=f"Invalid JSON: {exc}",
-                rule_id="json_structure",
-                severity="error",
-                category="serialization",
-                repairable=False,
-                suggestions=[
-                    "Check for malformed JSON syntax in the notebook file.",
-                    "Ensure the file is encoded as UTF-8 and fully written.",
-                ],
-                evidence={"error_type": "json", "message": str(exc)},
+                    evidence={"error_type": "json", "message": str(exc)},
+                ),
+                None,
             )
         except nbformat.ValidationError as exc:
-            return QAReport(
-                check_name="JSON Validity",
-                passed=False,
-                message=f"Invalid notebook structure: {exc}",
-                rule_id="json_structure",
-                severity="error",
-                category="serialization",
-                repairable=False,
-                suggestions=[
-                    "Verify all required notebook fields and cell metadata are present.",
-                ],
-                evidence={
-                    "path": str(notebook_path),
-                    "error_type": "nbformat",
-                    "message": str(exc),
-                },
+            return (
+                QAReport(
+                    check_name="JSON Validity",
+                    passed=False,
+                    message=f"Invalid notebook structure: {exc}",
+                    rule_id="json_structure",
+                    severity="error",
+                    category="serialization",
+                    repairable=False,
+                    suggestions=[
+                        "Verify all required notebook fields and cell metadata are present.",
+                    ],
+                    evidence={
+                        "path": str(notebook_path),
+                        "error_type": "nbformat",
+                        "message": str(exc),
+                    },
+                ),
+                None,
             )
         except Exception as exc:
-            return QAReport(
-                check_name="JSON Validity",
-                passed=False,
-                message=f"Error reading notebook: {exc}",
-                rule_id="json_structure",
-                severity="error",
-                category="serialization",
-                repairable=False,
-                suggestions=["Check file permissions and notebook path resolution."],
-                evidence={"error_type": type(exc).__name__, "message": str(exc)},
+            return (
+                QAReport(
+                    check_name="JSON Validity",
+                    passed=False,
+                    message=f"Error reading notebook: {exc}",
+                    rule_id="json_structure",
+                    severity="error",
+                    category="serialization",
+                    repairable=False,
+                    suggestions=[
+                        "Check file permissions and notebook path resolution."
+                    ],
+                    evidence={"error_type": type(exc).__name__, "message": str(exc)},
+                ),
+                None,
             )
 
-    def validate_notebook(
+    def _validate_notebook_rules(
         self,
         notebook: NotebookNode,
-        source: str = "<memory>",
+        source: str | Path,
+        json_report: QAReport,
     ) -> List[QAReport]:
-        """Run all validation checks against an already-loaded notebook."""
+        """Run registry-backed rules after JSON structure has already passed."""
 
-        reports: List[QAReport] = []
-        json_report = self._validate_loaded_notebook_json(notebook, source)
-        reports.append(json_report)
-
-        if not json_report.passed:
-            return reports
-
+        reports: List[QAReport] = [json_report]
         context = NotebookValidationContext.from_notebook(source, notebook)
         syntax_report: QAReport | None = None
         for rule in self.registry.rules():
@@ -2041,6 +2054,25 @@ class NotebookValidator:
                 reports.append(report)
 
         return reports
+
+    def validate_json_structure(self, notebook_path: str | Path) -> QAReport:
+        """Check that notebook JSON is valid and can be loaded."""
+
+        json_report, _ = self._load_and_validate_notebook_json(notebook_path)
+        return json_report
+
+    def validate_notebook(
+        self,
+        notebook: NotebookNode,
+        source: str = "<memory>",
+    ) -> List[QAReport]:
+        """Run all validation checks against an already-loaded notebook."""
+
+        json_report = self._validate_loaded_notebook_json(notebook, source)
+        if not json_report.passed:
+            return [json_report]
+
+        return self._validate_notebook_rules(notebook, source, json_report)
 
     def check_no_placeholders(self, notebook_path: str | Path) -> QAReport:
         """Ensure no placeholder text remains in the notebook."""
@@ -2176,12 +2208,12 @@ class NotebookValidator:
     def validate_all(self, notebook_path: str | Path) -> List[QAReport]:
         """Run all validation checks on a notebook."""
 
-        json_report = self.validate_json_structure(notebook_path)
-        if not json_report.passed:
+        json_report, notebook = self._load_and_validate_notebook_json(notebook_path)
+        if not json_report.passed or notebook is None:
             return [json_report]
 
-        notebook = self._load_notebook(notebook_path)
-        reports = self.validate_notebook(notebook, source=str(notebook_path))
-        if reports:
-            reports[0] = json_report
-        return reports
+        return self._validate_notebook_rules(
+            notebook,
+            source=str(notebook_path),
+            json_report=json_report,
+        )

--- a/tests/unit/test_generator_nodes.py
+++ b/tests/unit/test_generator_nodes.py
@@ -8,7 +8,7 @@ from langgraph_system_generator.generator.agents.requirements_analyst import (
     RequirementsAnalyst,
 )
 from langgraph_system_generator.generator.nodes import (
-    _clear_docs_retriever_cache,
+    _reset_docs_retriever_cache_for_tests,
     intake_node,
     notebook_assembly_node,
     rag_retrieval_node,
@@ -32,9 +32,9 @@ from langgraph_system_generator.generator.state import (
 
 @pytest.fixture(autouse=True)
 def clear_docs_retriever_cache():
-    _clear_docs_retriever_cache()
+    _reset_docs_retriever_cache_for_tests()
     yield
-    _clear_docs_retriever_cache()
+    _reset_docs_retriever_cache_for_tests()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_nodes.py
+++ b/tests/unit/test_generator_nodes.py
@@ -8,6 +8,7 @@ from langgraph_system_generator.generator.agents.requirements_analyst import (
     RequirementsAnalyst,
 )
 from langgraph_system_generator.generator.nodes import (
+    _clear_docs_retriever_cache,
     intake_node,
     notebook_assembly_node,
     rag_retrieval_node,
@@ -27,6 +28,13 @@ from langgraph_system_generator.generator.state import (
     ToolPlanningResult,
     ToolSpec,
 )
+
+
+@pytest.fixture(autouse=True)
+def clear_docs_retriever_cache():
+    _clear_docs_retriever_cache()
+    yield
+    _clear_docs_retriever_cache()
 
 
 @pytest.mark.asyncio
@@ -57,7 +65,10 @@ async def test_intake_node_returns_constraints():
 
     assert result["constraints"] == constraints
     assert result["requirements_feedback"].fallback_used is False
-    assert result["requirements_feedback"].available_constraint_types == ["goal", "tone"]
+    assert result["requirements_feedback"].available_constraint_types == [
+        "goal",
+        "tone",
+    ]
     mock_analyze.assert_awaited_once_with("Build a router workflow")
 
 
@@ -311,11 +322,12 @@ async def test_notebook_assembly_node_fallback_when_selected_patterns_missing():
         "justification": "Fits the request.",
     }
     assert captured_args["tool_planning_feedback"] is None
+
+
 @pytest.mark.parametrize("failure_mode", ["vector_store", "retrieve"])
-async def test_rag_retrieval_node_returns_empty_on_failure(
-    monkeypatch, failure_mode
-):
+async def test_rag_retrieval_node_returns_empty_on_failure(monkeypatch, failure_mode):
     if failure_mode == "vector_store":
+
         class BoomManager:
             def __init__(self, *args, **kwargs):
                 raise RuntimeError("boom")
@@ -325,6 +337,7 @@ async def test_rag_retrieval_node_returns_empty_on_failure(
             BoomManager,
         )
     else:
+
         class DummyManager:
             def __init__(self, *args, **kwargs):
                 pass

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -15,6 +15,7 @@ from langgraph_system_generator.generator.agents import (
 )
 from langgraph_system_generator.generator.nodes import (
     _clear_docs_retriever_cache,
+    _drop_docs_retriever_cache_entry,
     _upsert_qa_repair_summary_cell,
     architecture_selection_node,
     bounded_qa_history,
@@ -452,6 +453,38 @@ async def test_rag_and_architecture_nodes_reuse_cached_docs_retriever(monkeypatc
 
     assert counts == {"manager": 1, "retriever": 1}
     assert get_cached_docs_retriever() is get_cached_docs_retriever()
+    _clear_docs_retriever_cache()
+
+
+def test_drop_docs_retriever_cache_entry_preserves_other_paths(monkeypatch):
+    """A path-scoped failure should not evict unrelated cached retrievers."""
+
+    _clear_docs_retriever_cache()
+
+    class DummyManager:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    class DummyRetriever:
+        def __init__(self, _manager):
+            pass
+
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.nodes.VectorStoreManager",
+        DummyManager,
+    )
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.nodes.DocsRetriever",
+        DummyRetriever,
+    )
+
+    failing_retriever = get_cached_docs_retriever("cache-a")
+    healthy_retriever = get_cached_docs_retriever("cache-b")
+
+    _drop_docs_retriever_cache_entry("cache-a")
+
+    assert get_cached_docs_retriever("cache-b") is healthy_retriever
+    assert get_cached_docs_retriever("cache-a") is not failing_retriever
     _clear_docs_retriever_cache()
 
 

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -14,8 +14,12 @@ from langgraph_system_generator.generator.agents import (
     toolchain_engineer,
 )
 from langgraph_system_generator.generator.nodes import (
+    _clear_docs_retriever_cache,
+    _upsert_qa_repair_summary_cell,
     architecture_selection_node,
+    bounded_qa_history,
     context_pack_node,
+    get_cached_docs_retriever,
     graph_design_node,
     intake_node,
     notebook_assembly_node,
@@ -40,6 +44,8 @@ from langgraph_system_generator.generator.state import (
     QAReport,
     QARepairFeedback,
     ToolPlanningFeedback,
+    bounded_constraints_reducer,
+    bounded_docs_context_reducer,
 )
 from langgraph_system_generator.qa.registry import RepairRoutineRegistration
 from langgraph_system_generator.qa.validators import (
@@ -55,6 +61,70 @@ class DummyResponse:
 
     def __init__(self, content: str):
         self.content = content
+
+
+@pytest.fixture(autouse=True)
+def clear_docs_retriever_cache():
+    _clear_docs_retriever_cache()
+    yield
+    _clear_docs_retriever_cache()
+
+
+def test_bounded_state_reducers_cap_and_preserve_latest_items():
+    """Accumulating list state should stay bounded and keep the newest evidence."""
+
+    constraints = [
+        Constraint(type="goal", value=f"goal-{index}", priority=1)
+        for index in range(55)
+    ]
+    docs = [
+        DocSnippet(
+            content=f"doc-{index}", source=f"source-{index}", relevance_score=0.1
+        )
+        for index in range(55)
+    ]
+    history = [
+        QAReport(check_name=f"Report {index}", passed=True, message="ok")
+        for index in range(105)
+    ]
+
+    bounded_constraints = bounded_constraints_reducer([], constraints)
+    bounded_docs = bounded_docs_context_reducer([], docs)
+    bounded_history = bounded_qa_history([], history)
+
+    assert len(bounded_constraints) == 50
+    assert bounded_constraints[0].value == "goal-5"
+    assert bounded_constraints[-1].value == "goal-54"
+    assert len(bounded_docs) == 50
+    assert bounded_docs[0].content == "doc-5"
+    assert bounded_docs[-1].content == "doc-54"
+    assert len(bounded_history) == 100
+    assert bounded_history[0].check_name == "Report 5"
+    assert bounded_history[-1].check_name == "Report 104"
+
+
+def test_bounded_qa_history_preserves_current_attempt_blockers():
+    """Current-attempt failures should survive pruning even when older history is long."""
+
+    older = [
+        QAReport(check_name=f"Old {index}", passed=True, message="ok", attempt=0)
+        for index in range(100)
+    ]
+    blockers = [
+        QAReport(
+            check_name=f"Blocking {index}",
+            passed=False,
+            message="still failing",
+            severity="error",
+            attempt=3,
+        )
+        for index in range(5)
+    ]
+
+    bounded = bounded_qa_history(older, blockers, limit=100)
+
+    assert len(bounded) == 100
+    assert all(report in bounded for report in blockers)
 
 
 def make_stub_llm(content: str):
@@ -300,6 +370,89 @@ async def test_context_pack_node_falls_back_to_static_repo_facts_without_docs():
     assert pack.warnings
     assert "invocation_config" in pack.qa_gates
     assert pack.source_summary["docs_live_required"] is False
+
+
+@pytest.mark.asyncio
+async def test_rag_retrieval_node_offloads_blocking_retrieval(monkeypatch):
+    """RAG retrieval should run synchronous vector-store work in a worker thread."""
+
+    _clear_docs_retriever_cache()
+    to_thread_calls = []
+
+    class DummyManager:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    class DummyRetriever:
+        def __init__(self, _manager):
+            pass
+
+        def retrieve(self, *_args, **_kwargs):
+            return []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        to_thread_calls.append(getattr(func, "__name__", repr(func)))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.nodes.VectorStoreManager",
+        DummyManager,
+    )
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.nodes.DocsRetriever",
+        DummyRetriever,
+    )
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.nodes.asyncio.to_thread",
+        fake_to_thread,
+    )
+
+    await rag_retrieval_node({"user_prompt": "Find docs"})
+
+    assert "_retrieve_docs_for_prompt" in to_thread_calls
+    _clear_docs_retriever_cache()
+
+
+@pytest.mark.asyncio
+async def test_rag_and_architecture_nodes_reuse_cached_docs_retriever(monkeypatch):
+    """RAG and architecture selection should not reload the vector store separately."""
+
+    _clear_docs_retriever_cache()
+    counts = {"manager": 0, "retriever": 0}
+
+    class DummyManager:
+        def __init__(self, *_args, **_kwargs):
+            counts["manager"] += 1
+
+    class DummyRetriever:
+        def __init__(self, _manager):
+            counts["retriever"] += 1
+
+        def retrieve(self, *_args, **_kwargs):
+            return []
+
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.nodes.VectorStoreManager",
+        DummyManager,
+    )
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.nodes.DocsRetriever",
+        DummyRetriever,
+    )
+    monkeypatch.setattr(
+        architecture_selector,
+        "ChatOpenAI",
+        make_stub_llm(
+            '{"architecture_type":"router","patterns":null,"justification":"Because"}'
+        ),
+    )
+
+    await rag_retrieval_node({"user_prompt": "Find docs"})
+    await architecture_selection_node({"constraints": [], "docs_context": []})
+
+    assert counts == {"manager": 1, "retriever": 1}
+    assert get_cached_docs_retriever() is get_cached_docs_retriever()
+    _clear_docs_retriever_cache()
 
 
 @pytest.mark.asyncio
@@ -599,7 +752,7 @@ async def test_static_qa_node_appends_reports(monkeypatch):
     new_reports = [QAReport(check_name="New", passed=True, message="fine")]
 
     monkeypatch.setattr(
-        "langgraph_system_generator.generator.nodes.NotebookValidator.validate_all",
+        "langgraph_system_generator.generator.nodes.NotebookValidator.validate_notebook",
         lambda *_args, **_kwargs: new_reports,
     )
 
@@ -619,6 +772,50 @@ async def test_static_qa_node_appends_reports(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_static_qa_node_validates_in_memory_and_offloads(monkeypatch):
+    """Static QA should validate the in-memory notebook through a worker thread."""
+
+    new_reports = [QAReport(check_name="New", passed=True, message="fine")]
+    to_thread_calls = []
+
+    def fail_write(*_args, **_kwargs):
+        raise AssertionError("static QA should not write a temporary notebook")
+
+    def validate_notebook(_self, _notebook, source="<memory>"):
+        assert source == "<memory>"
+        return new_reports
+
+    async def fake_to_thread(func, *args, **kwargs):
+        to_thread_calls.append(getattr(func, "__name__", repr(func)))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.nodes.NotebookFileComposer.write",
+        fail_write,
+    )
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.nodes.NotebookValidator.validate_notebook",
+        validate_notebook,
+    )
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.nodes.asyncio.to_thread",
+        fake_to_thread,
+    )
+
+    result = await static_qa_node(
+        {
+            "generated_cells": [CellSpec(cell_type="markdown", content="Hi")],
+            "qa_reports": [],
+            "qa_history": [],
+            "repair_attempts": 0,
+        }
+    )
+
+    assert result["qa_reports"][0].check_name == "New"
+    assert "validate_notebook" in to_thread_calls
+
+
+@pytest.mark.asyncio
 async def test_static_qa_node_surfaces_blocking_feedback(monkeypatch):
     blocking_report = QAReport(
         check_name="Python Syntax",
@@ -632,7 +829,7 @@ async def test_static_qa_node_surfaces_blocking_feedback(monkeypatch):
     )
 
     monkeypatch.setattr(
-        "langgraph_system_generator.generator.nodes.NotebookValidator.validate_all",
+        "langgraph_system_generator.generator.nodes.NotebookValidator.validate_notebook",
         lambda *_args, **_kwargs: [blocking_report],
     )
 
@@ -669,7 +866,7 @@ async def test_static_qa_node_surfaces_non_blocking_feedback(monkeypatch):
     )
 
     monkeypatch.setattr(
-        "langgraph_system_generator.generator.nodes.NotebookValidator.validate_all",
+        "langgraph_system_generator.generator.nodes.NotebookValidator.validate_notebook",
         lambda *_args, **_kwargs: [advisory_report],
     )
 
@@ -882,6 +1079,34 @@ async def test_runtime_qa_node_reports_actual_failure(monkeypatch):
     assert report.evidence["execution"]["execution_scope"] == "trusted_smoke_test"
 
 
+def test_upsert_qa_repair_summary_cell_keeps_unchanged_cell_objects():
+    """Updating the summary cell should not deep-copy every unchanged cell."""
+
+    original = CellSpec(
+        cell_type="code",
+        content="print('keep me')",
+        metadata={"section": "execution"},
+        section="execution",
+    )
+    stale_summary = CellSpec(
+        cell_type="markdown",
+        content="old summary",
+        metadata={"kind": "qa_repair_summary"},
+        section="qa_repair_summary",
+    )
+
+    result = _upsert_qa_repair_summary_cell(
+        [original, stale_summary],
+        QARepairFeedback(repair_attempts=1),
+        status="applied",
+    )
+
+    assert result[0] is original
+    assert len(result) == 2
+    assert result[-1].section == "qa_repair_summary"
+    assert result[-1] is not stale_summary
+
+
 @pytest.mark.asyncio
 async def test_repair_node_success_refreshes_cells_and_appends_history(monkeypatch):
     initial_cells = [CellSpec(cell_type="markdown", content="Hi", metadata={})]
@@ -946,6 +1171,53 @@ async def test_repair_node_success_refreshes_cells_and_appends_history(monkeypat
     assert result["repair_attempts"] == 2
     assert result["qa_repair_feedback"].repair_attempts == 2
     assert result["qa_repair_feedback"].unrepaired_failures == []
+
+
+@pytest.mark.asyncio
+async def test_repair_node_offloads_repair_engine(monkeypatch):
+    """Repair work should run through asyncio.to_thread from async graph nodes."""
+
+    initial_cells = [CellSpec(cell_type="markdown", content="Hi", metadata={})]
+    to_thread_calls = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        to_thread_calls.append(getattr(func, "__name__", repr(func)))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.nodes.asyncio.to_thread",
+        fake_to_thread,
+    )
+
+    def repair_cells(*_args, **_kwargs):
+        return RepairOutcome(
+            status="skipped",
+            cells=initial_cells,
+            qa_reports=[],
+            attempted_fixes=[],
+            persisted=False,
+            message="No repair matched.",
+            validation_summary={"accepted": False},
+        )
+
+    monkeypatch.setattr(
+        "langgraph_system_generator.generator.nodes.NotebookRepairAgent.repair_cells",
+        repair_cells,
+    )
+
+    result = await repair_node(
+        {
+            "generated_cells": initial_cells,
+            "qa_reports": [
+                QAReport(check_name="Runtime Check", passed=False, message="boom")
+            ],
+            "qa_history": [],
+            "repair_attempts": 0,
+        }
+    )
+
+    assert result["repair_attempts"] == 1
+    assert "repair_cells" in to_thread_calls
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -14,7 +14,7 @@ from langgraph_system_generator.generator.agents import (
     toolchain_engineer,
 )
 from langgraph_system_generator.generator.nodes import (
-    _clear_docs_retriever_cache,
+    _reset_docs_retriever_cache_for_tests,
     _drop_docs_retriever_cache_entry,
     _upsert_qa_repair_summary_cell,
     architecture_selection_node,
@@ -66,9 +66,9 @@ class DummyResponse:
 
 @pytest.fixture(autouse=True)
 def clear_docs_retriever_cache():
-    _clear_docs_retriever_cache()
+    _reset_docs_retriever_cache_for_tests()
     yield
-    _clear_docs_retriever_cache()
+    _reset_docs_retriever_cache_for_tests()
 
 
 def test_bounded_state_reducers_cap_and_preserve_latest_items():
@@ -377,7 +377,7 @@ async def test_context_pack_node_falls_back_to_static_repo_facts_without_docs():
 async def test_rag_retrieval_node_offloads_blocking_retrieval(monkeypatch):
     """RAG retrieval should run synchronous vector-store work in a worker thread."""
 
-    _clear_docs_retriever_cache()
+    _reset_docs_retriever_cache_for_tests()
     to_thread_calls = []
 
     class DummyManager:
@@ -411,14 +411,14 @@ async def test_rag_retrieval_node_offloads_blocking_retrieval(monkeypatch):
     await rag_retrieval_node({"user_prompt": "Find docs"})
 
     assert "_retrieve_docs_for_prompt" in to_thread_calls
-    _clear_docs_retriever_cache()
+    _reset_docs_retriever_cache_for_tests()
 
 
 @pytest.mark.asyncio
 async def test_rag_and_architecture_nodes_reuse_cached_docs_retriever(monkeypatch):
     """RAG and architecture selection should not reload the vector store separately."""
 
-    _clear_docs_retriever_cache()
+    _reset_docs_retriever_cache_for_tests()
     counts = {"manager": 0, "retriever": 0}
 
     class DummyManager:
@@ -453,13 +453,13 @@ async def test_rag_and_architecture_nodes_reuse_cached_docs_retriever(monkeypatc
 
     assert counts == {"manager": 1, "retriever": 1}
     assert get_cached_docs_retriever() is get_cached_docs_retriever()
-    _clear_docs_retriever_cache()
+    _reset_docs_retriever_cache_for_tests()
 
 
 def test_drop_docs_retriever_cache_entry_preserves_other_paths(monkeypatch):
     """A path-scoped failure should not evict unrelated cached retrievers."""
 
-    _clear_docs_retriever_cache()
+    _reset_docs_retriever_cache_for_tests()
 
     class DummyManager:
         def __init__(self, *_args, **_kwargs):
@@ -485,7 +485,7 @@ def test_drop_docs_retriever_cache_entry_preserves_other_paths(monkeypatch):
 
     assert get_cached_docs_retriever("cache-b") is healthy_retriever
     assert get_cached_docs_retriever("cache-a") is not failing_retriever
-    _clear_docs_retriever_cache()
+    _reset_docs_retriever_cache_for_tests()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -107,6 +107,28 @@ def test_validate_notebook_accepts_in_memory_notebook(valid_notebook, monkeypatc
     assert _report_by_name(reports, "JSON Validity").evidence["path"] == "<unit-test>"
 
 
+def test_validate_all_loads_path_once(
+    tmp_notebook_path: Path, valid_notebook, monkeypatch
+):
+    """Path-backed full validation should reuse the loaded notebook object."""
+
+    _write_notebook(tmp_notebook_path, valid_notebook)
+    validator = NotebookValidator()
+    original_load = validator._load_notebook
+    calls = []
+
+    def counted_load(path):
+        calls.append(path)
+        return original_load(path)
+
+    monkeypatch.setattr(validator, "_load_notebook", counted_load)
+
+    reports = validator.validate_all(tmp_notebook_path)
+
+    assert _report_by_name(reports, "JSON Validity").passed is True
+    assert len(calls) == 1
+
+
 def test_validate_json_structure_missing_file(tmp_path: Path):
     report = NotebookValidator().validate_json_structure(tmp_path / "missing.ipynb")
 

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -91,6 +91,22 @@ def test_validate_json_structure_valid(tmp_notebook_path: Path, valid_notebook):
     assert report.category == "serialization"
 
 
+def test_validate_notebook_accepts_in_memory_notebook(valid_notebook, monkeypatch):
+    """In-memory validation should not require loading a notebook from disk."""
+
+    def fail_disk_load(*_args, **_kwargs):
+        raise AssertionError("disk-backed notebook loading should not be used")
+
+    validator = NotebookValidator()
+    monkeypatch.setattr(validator, "_load_notebook", fail_disk_load)
+
+    reports = validator.validate_notebook(valid_notebook, source="<unit-test>")
+
+    assert reports
+    assert all(report.passed for report in reports)
+    assert _report_by_name(reports, "JSON Validity").evidence["path"] == "<unit-test>"
+
+
 def test_validate_json_structure_missing_file(tmp_path: Path):
     report = NotebookValidator().validate_json_structure(tmp_path / "missing.ipynb")
 


### PR DESCRIPTION
## Summary
- Adds bounded accumulation for `constraints`, `docs_context`, and `qa_history` to prevent retry loops from growing shared state without limit.
- Adds in-memory notebook validation and routes static QA / repair validation through it instead of normal temp-file writes.
- Caches docs retriever construction by vector-store path and reuses it across RAG retrieval and architecture selection.
- Offloads blocking RAG, static QA, and repair work from async graph nodes with `asyncio.to_thread`.
- Avoids deep-copying unchanged cells when refreshing the QA repair summary cell.

## Why
This implements the runtime pipeline reliability/performance cluster from issues #351-#355. The root problem was that repeated generation/repair passes could accumulate unbounded state, rebuild expensive retrievers, write transient notebooks during normal QA loops, and run blocking work directly inside async nodes.

Refs #351
Refs #352
Refs #353
Refs #354
Refs #355

## Validation
- `pytest tests/unit/test_generator_nodes.py tests/unit/test_generator_nodes_additional.py --asyncio-mode=auto -q`
- `pytest tests/unit/test_validators.py tests/unit/test_repair.py -q`
- `pytest tests/unit/test_generator_agents.py -q`
- `pytest tests/unit/ --asyncio-mode=auto -q`
- `pytest --asyncio-mode=auto` -> 704 passed, 3 skipped, 4 warnings