### PR TITLE
[codex] Fix artifact manifest truth

### DIFF
--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -256,6 +256,18 @@ def _relative_path_or_none(path: Path, base: Path) -> str | None:
         return None
 
 
+def _resolve_path_within_base(
+    path: str | os.PathLike[str], base: Path
+) -> tuple[Path | None, str | None]:
+    base_resolved = base.resolve()
+    candidate = Path(path).resolve()
+    try:
+        candidate.relative_to(base_resolved)
+    except ValueError:
+        return None, None
+    return candidate, str(candidate.relative_to(base_resolved))
+
+
 def _artifact_path_entry(
     *,
     manifest_key: str,
@@ -264,7 +276,20 @@ def _artifact_path_entry(
     path: str | os.PathLike[str],
     output_dir: Path,
 ) -> dict[str, Any]:
-    resolved = Path(path).resolve()
+    resolved, relative_path = _resolve_path_within_base(path, output_dir)
+    if resolved is None:
+        return {
+            "name": name,
+            "format": format_name,
+            "manifest_key": manifest_key,
+            "availability": "standalone",
+            "path_type": "invalid",
+            "path": str(path),
+            "relative_path": None,
+            "exists": False,
+            "size_bytes": None,
+        }
+
     exists = resolved.is_file()
     entry: dict[str, Any] = {
         "name": name,
@@ -273,7 +298,7 @@ def _artifact_path_entry(
         "availability": "standalone",
         "path_type": "server_local",
         "path": str(resolved),
-        "relative_path": _relative_path_or_none(resolved, output_dir),
+        "relative_path": relative_path,
         "exists": exists,
         "size_bytes": resolved.stat().st_size if exists else None,
     }
@@ -304,27 +329,29 @@ def _build_artifact_contract(
 
     zip_members: list[dict[str, Any]] = []
     zip_path_value = manifest.get("zip_path")
-    if zip_path_value and Path(zip_path_value).is_file():
-        with zipfile.ZipFile(zip_path_value, "r") as zf:
-            for member in zf.infolist():
-                source_entry = standalone_by_filename.get(member.filename)
-                source_exists = bool(source_entry and source_entry.get("exists"))
-                zip_members.append(
-                    {
-                        "name": member.filename,
-                        "availability": (
-                            "standalone_and_bundle" if source_exists else "bundle_only"
-                        ),
-                        "source_manifest_key": (
-                            source_entry.get("manifest_key") if source_entry else None
-                        ),
-                        "source_path": (
-                            source_entry.get("path") if source_entry else None
-                        ),
-                        "source_exists": source_exists,
-                        "size_bytes": member.file_size,
-                    }
-                )
+    if zip_path_value:
+        resolved_zip_path, _ = _resolve_path_within_base(zip_path_value, output_dir)
+        if resolved_zip_path and resolved_zip_path.is_file():
+            with zipfile.ZipFile(resolved_zip_path, "r") as zf:
+                for member in zf.infolist():
+                    source_entry = standalone_by_filename.get(member.filename)
+                    source_exists = bool(source_entry and source_entry.get("exists"))
+                    zip_members.append(
+                        {
+                            "name": member.filename,
+                            "availability": (
+                                "standalone_and_bundle" if source_exists else "bundle_only"
+                            ),
+                            "source_manifest_key": (
+                                source_entry.get("manifest_key") if source_entry else None
+                            ),
+                            "source_path": (
+                                source_entry.get("path") if source_entry else None
+                            ),
+                            "source_exists": source_exists,
+                            "size_bytes": member.file_size,
+                        }
+                    )
 
     return {
         "version": 1,
@@ -1411,7 +1438,14 @@ async def generate_artifacts(
     )
 
     tracker = _PhaseTracker(progress_callback)
-    target = Path(output_dir)
+    base_output = settings.base_output_dir.resolve()
+    target = (base_output / Path(output_dir)).resolve()
+    try:
+        target.relative_to(base_output)
+    except ValueError as exc:
+        raise ValueError(
+            "output_dir must reside within the configured base output directory."
+        ) from exc
     target.mkdir(parents=True, exist_ok=True)
 
     tracker.start("init", "Initializing generation...", percentage=5)

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -12,9 +12,11 @@ from datetime import datetime, timezone
 import json
 import logging
 import os
+import zipfile
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Dict, List, Literal, TypedDict
+from urllib.parse import quote
 
 from langgraph_system_generator.generator.state import (
     ArchitectureFeedback,
@@ -50,7 +52,10 @@ from langgraph_system_generator.utils.generation_options import (
     normalize_agent_type,
     resolve_architecture_type,
 )
-from langgraph_system_generator.utils.logging_utils import configure_logging, LOG_LEVEL_CHOICES
+from langgraph_system_generator.utils.logging_utils import (
+    configure_logging,
+    LOG_LEVEL_CHOICES,
+)
 from langgraph_system_generator.utils.optional_deps import (
     OptionalDependencyError,
     require_optional_module,
@@ -104,7 +109,11 @@ def _build_cli_context_pack(
             "supported_architecture_types": get_default_architecture_registry().supported_architecture_types(),
             "default_architecture": "router",
             "experimental_architectures": ["deepagents"],
-            **({"selected_architecture": architecture_type} if architecture_type else {}),
+            **(
+                {"selected_architecture": architecture_type}
+                if architecture_type
+                else {}
+            ),
         },
         notebook_contract={
             "canonical_sections": [
@@ -226,6 +235,108 @@ def _serialize(obj: Any) -> Any:
 
 def _write_json(path: Path, payload: Any) -> None:
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+_ARTIFACT_PATH_KEYS: tuple[tuple[str, str, str], ...] = (
+    ("plan_path", "notebook_plan", "json"),
+    ("cells_path", "generated_cells", "json"),
+    ("notebook_path", "notebook", "ipynb"),
+    ("html_path", "notebook_html", "html"),
+    ("markdown_path", "notebook_markdown", "markdown"),
+    ("docx_path", "notebook_docx", "docx"),
+    ("pdf_path", "notebook_pdf", "pdf"),
+    ("zip_path", "notebook_bundle", "zip"),
+)
+
+
+def _relative_path_or_none(path: Path, base: Path) -> str | None:
+    try:
+        return str(path.resolve().relative_to(base.resolve()))
+    except ValueError:
+        return None
+
+
+def _artifact_path_entry(
+    *,
+    manifest_key: str,
+    name: str,
+    format_name: str,
+    path: str | os.PathLike[str],
+    output_dir: Path,
+) -> dict[str, Any]:
+    resolved = Path(path).resolve()
+    exists = resolved.is_file()
+    entry: dict[str, Any] = {
+        "name": name,
+        "format": format_name,
+        "manifest_key": manifest_key,
+        "availability": "standalone",
+        "path_type": "server_local",
+        "path": str(resolved),
+        "relative_path": _relative_path_or_none(resolved, output_dir),
+        "exists": exists,
+        "size_bytes": resolved.stat().st_size if exists else None,
+    }
+    if exists:
+        entry["api_download_path"] = f"/artifacts?path={quote(str(resolved), safe='')}"
+    return entry
+
+
+def _build_artifact_contract(
+    manifest: dict[str, Any], output_dir: Path
+) -> dict[str, Any]:
+    """Describe artifact availability without relying on ambiguous path keys."""
+
+    standalone_files = [
+        _artifact_path_entry(
+            manifest_key=manifest_key,
+            name=name,
+            format_name=format_name,
+            path=manifest[manifest_key],
+            output_dir=output_dir,
+        )
+        for manifest_key, name, format_name in _ARTIFACT_PATH_KEYS
+        if manifest.get(manifest_key)
+    ]
+    standalone_by_filename = {
+        Path(entry["path"]).name: entry for entry in standalone_files
+    }
+
+    zip_members: list[dict[str, Any]] = []
+    zip_path_value = manifest.get("zip_path")
+    if zip_path_value and Path(zip_path_value).is_file():
+        with zipfile.ZipFile(zip_path_value, "r") as zf:
+            for member in zf.infolist():
+                source_entry = standalone_by_filename.get(member.filename)
+                source_exists = bool(source_entry and source_entry.get("exists"))
+                zip_members.append(
+                    {
+                        "name": member.filename,
+                        "availability": (
+                            "standalone_and_bundle" if source_exists else "bundle_only"
+                        ),
+                        "source_manifest_key": (
+                            source_entry.get("manifest_key") if source_entry else None
+                        ),
+                        "source_path": (
+                            source_entry.get("path") if source_entry else None
+                        ),
+                        "source_exists": source_exists,
+                        "size_bytes": member.file_size,
+                    }
+                )
+
+    return {
+        "version": 1,
+        "path_semantics": (
+            "Legacy *_path fields and standalone_files.path values are server-local "
+            "filesystem paths under output_dir. API clients should use "
+            "api_download_path for downloadable standalone artifacts."
+        ),
+        "output_dir": str(output_dir.resolve()),
+        "standalone_files": standalone_files,
+        "zip_members": zip_members,
+    }
 
 
 def _utc_now_iso() -> str:
@@ -416,9 +527,11 @@ def _notebook_composition_warning_entries(
         {
             "code": "notebook_composition_fallback",
             "phase": "notebook_assembly",
-            "message": advisory_warnings[0]
-            if advisory_warnings
-            else "Notebook composition used deterministic fallback content.",
+            "message": (
+                advisory_warnings[0]
+                if advisory_warnings
+                else "Notebook composition used deterministic fallback content."
+            ),
             "warnings": advisory_warnings,
             "fallback_events": fallback_events,
         }
@@ -498,7 +611,9 @@ def _qa_repair_warning_entries(
 
     feedback = feedback if isinstance(feedback, dict) else {}
     reports = reports if isinstance(reports, list) else []
-    qa_summary = qa_summary if isinstance(qa_summary, dict) else build_qa_summary(reports)
+    qa_summary = (
+        qa_summary if isinstance(qa_summary, dict) else build_qa_summary(reports)
+    )
     counts = qa_summary.get("counts") or {}
     findings = list(qa_summary.get("findings") or [])
 
@@ -671,7 +786,9 @@ class _PhaseTracker:
         status: str = "completed",
         details: Dict[str, Any] | None = None,
     ) -> Dict[str, Any]:
-        timer_start, started_at = self._active.pop(phase, (perf_counter(), _utc_now_iso()))
+        timer_start, started_at = self._active.pop(
+            phase, (perf_counter(), _utc_now_iso())
+        )
         duration_ms = int((perf_counter() - timer_start) * 1000)
         finished_at = _utc_now_iso()
         entry = {
@@ -785,7 +902,9 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
     normalized_agent_type = normalize_agent_type(agent_type)
     if normalized_agent_type in SUPPORTED_AGENT_TYPES:
         architecture_type = normalized_agent_type
-        _, secondary_patterns = architecture_registry.normalize_patterns(architecture_type)
+        _, secondary_patterns = architecture_registry.normalize_patterns(
+            architecture_type
+        )
         justification = (
             f"{normalized_agent_type.title()} pattern selected from the requested "
             "agent_type override."
@@ -799,7 +918,9 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
         )
     else:
         architecture_type, justification = _infer_stub_architecture(prompt)
-        _, secondary_patterns = architecture_registry.normalize_patterns(architecture_type)
+        _, secondary_patterns = architecture_registry.normalize_patterns(
+            architecture_type
+        )
         architecture_feedback = ArchitectureFeedback(
             confidence=0.45,
             tradeoffs=[
@@ -1360,7 +1481,9 @@ async def generate_artifacts(
         "prompt": prompt,
         "mode": mode,
         "architecture_type": architecture_type,
-        "cell_count": len(serialized.get("generated_cells", []) or []),
+        "cell_count": 0,
+        "cell_count_source": "no_notebook",
+        "generated_cell_spec_count": len(serialized.get("generated_cells", []) or []),
         "plan_title": plan_title,
         "requirements_feedback": requirements_feedback,
         "architecture_feedback": architecture_feedback,
@@ -1422,11 +1545,17 @@ async def generate_artifacts(
         cell_specs = [CellSpec(**cell) for cell in cells]
         composer = NotebookComposer(colab_friendly=True)
         notebook = composer.build_notebook(cell_specs, ensure_minimum_sections=True)
+        manifest["cell_count"] = len(notebook.cells)
+        manifest["cell_count_source"] = "serialized_notebook"
+        manifest["generated_cell_spec_count"] = len(cell_specs)
         tracker.finish(
             "compose",
             "Notebook composed successfully.",
             percentage=70,
-            details={"cell_count": len(cell_specs)},
+            details={
+                "generated_cell_spec_count": len(cell_specs),
+                "serialized_notebook_cell_count": len(notebook.cells),
+            },
         )
 
         exporter = NotebookExporter()
@@ -1626,6 +1755,7 @@ async def generate_artifacts(
     tracker.start("finalize", "Finalizing artifacts...", percentage=98)
     tracker.finish("finalize", "Artifacts finalized.", percentage=100)
     manifest["phase_summary"] = list(tracker.summary)
+    manifest["artifact_contract"] = _build_artifact_contract(manifest, target)
     manifest_path = target / "manifest.json"
     _write_json(manifest_path, manifest)
 

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -18,6 +18,7 @@ from time import perf_counter
 from typing import Any, Dict, List, Literal, TypedDict
 from urllib.parse import quote
 
+import langgraph_system_generator.constants as constants_module
 from langgraph_system_generator.generator.state import (
     ArchitectureFeedback,
     build_constraint_type_registry,
@@ -259,13 +260,39 @@ def _relative_path_or_none(path: Path, base: Path) -> str | None:
 def _resolve_path_within_base(
     path: str | os.PathLike[str], base: Path
 ) -> tuple[Path | None, str | None]:
-    base_resolved = base.resolve()
-    candidate = Path(path).resolve()
+    base_resolved = Path(os.path.realpath(os.fspath(base)))
+    raw_path = os.fspath(path)
+    if not raw_path:
+        return None, None
+    candidate_source = Path(raw_path)
+
+    if candidate_source.is_absolute():
+        candidate = Path(os.path.realpath(raw_path))
+    else:
+        normalized = os.path.normpath(raw_path)
+        if normalized in ("", "."):
+            return None, None
+        if normalized.startswith("..") or f"{os.sep}.." in normalized:
+            return None, None
+        candidate = Path(
+            os.path.realpath(os.path.join(os.fspath(base_resolved), normalized))
+        )
     try:
-        candidate.relative_to(base_resolved)
+        if (
+            os.path.commonpath([os.fspath(base_resolved), os.fspath(candidate)])
+            != os.fspath(base_resolved)
+        ):
+            return None, None
     except ValueError:
         return None, None
-    return candidate, str(candidate.relative_to(base_resolved))
+    try:
+        relative = os.path.relpath(
+            os.fspath(candidate),
+            os.fspath(base_resolved),
+        )
+    except ValueError:
+        return None, None
+    return candidate, relative
 
 
 def _artifact_path_entry(
@@ -290,20 +317,48 @@ def _artifact_path_entry(
             "size_bytes": None,
         }
 
-    exists = resolved.is_file()
+    output_dir_real = os.path.realpath(os.fspath(output_dir))
+    resolved_real = os.path.realpath(os.fspath(resolved))
+    try:
+        if os.path.commonpath([output_dir_real, resolved_real]) != output_dir_real:
+            return {
+                "name": name,
+                "format": format_name,
+                "manifest_key": manifest_key,
+                "availability": "standalone",
+                "path_type": "invalid",
+                "path": str(path),
+                "relative_path": None,
+                "exists": False,
+                "size_bytes": None,
+            }
+    except ValueError:
+        return {
+            "name": name,
+            "format": format_name,
+            "manifest_key": manifest_key,
+            "availability": "standalone",
+            "path_type": "invalid",
+            "path": str(path),
+            "relative_path": None,
+            "exists": False,
+            "size_bytes": None,
+        }
+
+    exists = os.path.isfile(resolved_real)
     entry: dict[str, Any] = {
         "name": name,
         "format": format_name,
         "manifest_key": manifest_key,
         "availability": "standalone",
         "path_type": "server_local",
-        "path": str(resolved),
+        "path": resolved_real,
         "relative_path": relative_path,
         "exists": exists,
-        "size_bytes": resolved.stat().st_size if exists else None,
+        "size_bytes": os.path.getsize(resolved_real) if exists else None,
     }
     if exists:
-        entry["api_download_path"] = f"/artifacts?path={quote(str(resolved), safe='')}"
+        entry["api_download_path"] = f"/artifacts?path={quote(resolved_real, safe='')}"
     return entry
 
 
@@ -331,27 +386,38 @@ def _build_artifact_contract(
     zip_path_value = manifest.get("zip_path")
     if zip_path_value:
         resolved_zip_path, _ = _resolve_path_within_base(zip_path_value, output_dir)
-        if resolved_zip_path and resolved_zip_path.is_file():
-            with zipfile.ZipFile(resolved_zip_path, "r") as zf:
-                for member in zf.infolist():
-                    source_entry = standalone_by_filename.get(member.filename)
-                    source_exists = bool(source_entry and source_entry.get("exists"))
-                    zip_members.append(
-                        {
-                            "name": member.filename,
-                            "availability": (
-                                "standalone_and_bundle" if source_exists else "bundle_only"
-                            ),
-                            "source_manifest_key": (
-                                source_entry.get("manifest_key") if source_entry else None
-                            ),
-                            "source_path": (
-                                source_entry.get("path") if source_entry else None
-                            ),
-                            "source_exists": source_exists,
-                            "size_bytes": member.file_size,
-                        }
-                    )
+        if resolved_zip_path:
+            output_dir_real = os.path.realpath(os.fspath(output_dir))
+            resolved_zip_real = os.path.realpath(os.fspath(resolved_zip_path))
+            if (
+                os.path.commonpath([output_dir_real, resolved_zip_real])
+                == output_dir_real
+                and os.path.isfile(resolved_zip_real)
+            ):
+                with zipfile.ZipFile(resolved_zip_real, "r") as zf:
+                    for member in zf.infolist():
+                        source_entry = standalone_by_filename.get(member.filename)
+                        source_exists = bool(source_entry and source_entry.get("exists"))
+                        zip_members.append(
+                            {
+                                "name": member.filename,
+                                "availability": (
+                                    "standalone_and_bundle"
+                                    if source_exists
+                                    else "bundle_only"
+                                ),
+                                "source_manifest_key": (
+                                    source_entry.get("manifest_key")
+                                    if source_entry
+                                    else None
+                                ),
+                                "source_path": (
+                                    source_entry.get("path") if source_entry else None
+                                ),
+                                "source_exists": source_exists,
+                                "size_bytes": member.file_size,
+                            }
+                        )
 
     return {
         "version": 1,
@@ -360,7 +426,7 @@ def _build_artifact_contract(
             "filesystem paths under output_dir. API clients should use "
             "api_download_path for downloadable standalone artifacts."
         ),
-        "output_dir": str(output_dir.resolve()),
+        "output_dir": os.path.realpath(os.fspath(output_dir)),
         "standalone_files": standalone_files,
         "zip_members": zip_members,
     }
@@ -1438,15 +1504,37 @@ async def generate_artifacts(
     )
 
     tracker = _PhaseTracker(progress_callback)
-    base_output = settings.base_output_dir.resolve()
-    target = (base_output / Path(output_dir)).resolve()
+    base_output = Path(
+        os.path.realpath(os.fspath(constants_module._compute_base_output()))
+    )
+    base_output_real = os.path.realpath(os.fspath(base_output))
+    requested_output = os.fspath(output_dir)
+    requested_path = Path(requested_output)
+    if requested_path.is_absolute():
+        target_real = os.path.realpath(requested_output)
+    else:
+        normalized_requested = os.path.normpath(requested_output)
+        if normalized_requested in ("", "."):
+            target_real = base_output_real
+        else:
+            if normalized_requested.startswith("..") or f"{os.sep}.." in normalized_requested:
+                raise ValueError(
+                    "output_dir must reside within the configured base output directory."
+                )
+            target_real = os.path.realpath(
+                os.path.join(base_output_real, normalized_requested)
+            )
     try:
-        target.relative_to(base_output)
+        if os.path.commonpath([base_output_real, target_real]) != base_output_real:
+            raise ValueError(
+                "output_dir must reside within the configured base output directory."
+            )
     except ValueError as exc:
         raise ValueError(
             "output_dir must reside within the configured base output directory."
         ) from exc
-    target.mkdir(parents=True, exist_ok=True)
+    os.makedirs(target_real, exist_ok=True)
+    target = Path(target_real)
 
     tracker.start("init", "Initializing generation...", percentage=5)
     tracker.finish(

--- a/src/langgraph_system_generator/qa/summary.py
+++ b/src/langgraph_system_generator/qa/summary.py
@@ -130,10 +130,24 @@ def _build_validation_scope(reports: list[dict[str, Any]]) -> dict[str, list[str
         if str(report.get("stage") or "").lower() == "runtime"
         or str(report.get("category") or "").lower() == "runtime"
     ]
+
+    def _execution_scope(report: dict[str, Any]) -> str | None:
+        evidence = report.get("evidence")
+        if not isinstance(evidence, dict):
+            return None
+        scope = evidence.get("execution_scope")
+        if isinstance(scope, str):
+            return scope
+        execution = evidence.get("execution")
+        if isinstance(execution, dict):
+            nested_scope = execution.get("execution_scope")
+            if isinstance(nested_scope, str):
+                return nested_scope
+        return None
+
     smoke_only = any(
         report.get("rule_id") == "runtime_smoke_test"
-        and (report.get("evidence") or {}).get("execution_scope")
-        == "trusted_smoke_test"
+        and _execution_scope(report) == "trusted_smoke_test"
         for report in runtime_reports
     )
 

--- a/src/langgraph_system_generator/qa/summary.py
+++ b/src/langgraph_system_generator/qa/summary.py
@@ -20,10 +20,12 @@ def serialize_qa_report(report: QAReport | dict[str, Any]) -> dict[str, Any]:
         "message": str(getattr(report, "message", "")),
         "rule_id": str(getattr(report, "rule_id", "qa_report")),
         "severity": str(getattr(report, "severity", "info")),
+        "category": str(getattr(report, "category", "general")),
         "suggestions": list(getattr(report, "suggestions", []) or []),
         "repairable": bool(getattr(report, "repairable", False)),
         "stage": getattr(report, "stage", None),
         "attempt": getattr(report, "attempt", None),
+        "evidence": dict(getattr(report, "evidence", {}) or {}),
     }
 
 
@@ -95,4 +97,63 @@ def build_qa_summary(reports: Iterable[QAReport | dict[str, Any]]) -> dict[str, 
         "artifacts_usable": counts["blocking"] == 0,
         "counts": counts,
         "findings": findings,
+        "validation_scope": _build_validation_scope(serialized_reports),
+    }
+
+
+def _build_validation_scope(reports: list[dict[str, Any]]) -> dict[str, list[str]]:
+    """Describe what QA reports prove and what remains outside their scope."""
+
+    validated: list[str] = []
+    not_validated: list[str] = []
+    notes: list[str] = []
+
+    if not reports:
+        not_validated.append("No QA reports were recorded for this run.")
+        return {
+            "validated": validated,
+            "not_validated": not_validated,
+            "notes": notes,
+        }
+
+    stages = {str(report.get("stage") or "").lower() for report in reports}
+    rule_ids = {str(report.get("rule_id") or "") for report in reports}
+
+    if "static" in stages:
+        validated.append(
+            "Static QA checked the generated notebook cells covered by qa_reports."
+        )
+
+    runtime_reports = [
+        report
+        for report in reports
+        if str(report.get("stage") or "").lower() == "runtime"
+        or str(report.get("category") or "").lower() == "runtime"
+    ]
+    smoke_only = any(
+        report.get("rule_id") == "runtime_smoke_test"
+        and (report.get("evidence") or {}).get("execution_scope")
+        == "trusted_smoke_test"
+        for report in runtime_reports
+    )
+
+    if smoke_only:
+        validated.append(
+            "Runtime QA validated that the Python/Jupyter environment can execute a trusted smoke notebook."
+        )
+        not_validated.append(
+            "Runtime QA did not execute the full generated notebook or verify prompt-specific behavior."
+        )
+    elif runtime_reports:
+        validated.append(
+            "Runtime QA is limited to the runtime checks reported in qa_reports."
+        )
+
+    if rule_ids - {"runtime_smoke_test"}:
+        notes.append("See qa_reports for rule-level findings and evidence.")
+
+    return {
+        "validated": validated,
+        "not_validated": not_validated,
+        "notes": notes,
     }

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -797,7 +797,9 @@ async def test_generate_artifacts_describes_runtime_smoke_test_scope(
                 "stage": "runtime",
                 "attempt": 0,
                 "evidence": {
-                    "execution_scope": "trusted_smoke_test",
+                    "execution": {
+                        "execution_scope": "trusted_smoke_test",
+                    },
                     "message": "runtime smoke notebook passed",
                 },
             }

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -64,13 +64,19 @@ async def test_generate_artifacts_stub(tmp_path: Path, monkeypatch: pytest.Monke
     assert artifacts["manifest"]["generation_context_pack"]["source_precedence"][0] == (
         "langchain-docs-local"
     )
-    assert artifacts["manifest"]["generation_context_pack"]["notebook_contract"][
-        "compiled_graph_variable"
-    ] == "graph"
-    assert "invocation_config" in artifacts["manifest"]["generation_context_pack"][
-        "qa_gates"
-    ]
-    assert artifacts["manifest"]["notebook_composition_feedback"]["fallback_used"] is False
+    assert (
+        artifacts["manifest"]["generation_context_pack"]["notebook_contract"][
+            "compiled_graph_variable"
+        ]
+        == "graph"
+    )
+    assert (
+        "invocation_config"
+        in artifacts["manifest"]["generation_context_pack"]["qa_gates"]
+    )
+    assert (
+        artifacts["manifest"]["notebook_composition_feedback"]["fallback_used"] is False
+    )
     assert "langgraph" in artifacts["manifest"]["notebook_dependency_plan"]["packages"]
     assert artifacts["manifest"]["qa_repair_feedback"]["repair_attempts"] == 0
     assert artifacts["result"]["requirements_feedback"]["fallback_used"] is False
@@ -79,8 +85,13 @@ async def test_generate_artifacts_stub(tmp_path: Path, monkeypatch: pytest.Monke
     assert artifacts["result"]["graph_design_feedback"]["fallback_used"] is False
     assert "flowchart TD" in artifacts["result"]["graph_exports"]["mermaid"]
     assert artifacts["result"]["tool_planning_feedback"]["fallback_used"] is False
-    assert artifacts["result"]["notebook_composition_feedback"]["fallback_used"] is False
-    assert "OPENAI_API_KEY" in artifacts["result"]["notebook_dependency_plan"]["provider_env_vars"]
+    assert (
+        artifacts["result"]["notebook_composition_feedback"]["fallback_used"] is False
+    )
+    assert (
+        "OPENAI_API_KEY"
+        in artifacts["result"]["notebook_dependency_plan"]["provider_env_vars"]
+    )
     assert artifacts["result"]["qa_repair_feedback"]["repair_attempts"] == 0
     assert Path(artifacts["manifest_path"]).exists()
     assert artifacts["result"]["generation_complete"] is True
@@ -102,7 +113,9 @@ def test_default_state_includes_generation_mode_and_qa_history():
     assert state["graph_design_feedback"].fallback_used is False
     assert state["graph_exports"].schema == {}
     assert state["tool_planning_feedback"].fallback_used is False
-    assert state["generation_context_pack"].source_precedence[0] == "langchain-docs-local"
+    assert (
+        state["generation_context_pack"].source_precedence[0] == "langchain-docs-local"
+    )
     assert state["generation_context_pack"].request["generation_mode"] == "live"
     assert state["notebook_composition_feedback"].fallback_used is False
     assert state["notebook_dependency_plan"].packages == []
@@ -141,8 +154,13 @@ def test_default_and_stub_results_normalize_constraint_type_registry(monkeypatch
     state = cli_module._default_state("Test prompt")
     stub_result = cli_module._build_stub_result("Test prompt")
 
-    assert state["requirements_feedback"].available_constraint_types == expected_registry
-    assert stub_result["requirements_feedback"].available_constraint_types == expected_registry
+    assert (
+        state["requirements_feedback"].available_constraint_types == expected_registry
+    )
+    assert (
+        stub_result["requirements_feedback"].available_constraint_types
+        == expected_registry
+    )
     assert (
         stub_result["notebook_composition_feedback"].resolved_model
         == cli_module.settings.default_model
@@ -214,7 +232,9 @@ async def test_generate_artifacts_stub_hybrid_override(
     assert artifacts["result"]["architecture_type"] == "hybrid"
     assert graph_cells
     assert 'workflow.add_node("router", router_node)' in graph_cells[0]["content"]
-    assert 'workflow.add_node("supervisor", supervisor_node)' in graph_cells[0]["content"]
+    assert (
+        'workflow.add_node("supervisor", supervisor_node)' in graph_cells[0]["content"]
+    )
 
 
 @pytest.mark.asyncio
@@ -251,7 +271,9 @@ async def test_generate_artifacts_stub_deepagents_override(
     assert artifacts["result"]["generation_complete"] is True
     dependency_plan = artifacts["manifest"]["notebook_dependency_plan"]
     assert "deepagents" not in dependency_plan["packages"]
-    assert all("deepagents" not in command for command in dependency_plan["install_commands"])
+    assert all(
+        "deepagents" not in command for command in dependency_plan["install_commands"]
+    )
     assert any(
         "python -m pip install deepagents" in note
         for note in dependency_plan["runtime_notes"]
@@ -326,7 +348,9 @@ async def test_api_generate_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert payload["manifest"]["requirements_feedback"]["fallback_used"] is False
     assert payload["manifest"]["architecture_feedback"]["fallback_used"] is False
     assert payload["manifest"]["tool_planning_feedback"]["fallback_used"] is False
-    assert payload["manifest"]["notebook_composition_feedback"]["fallback_used"] is False
+    assert (
+        payload["manifest"]["notebook_composition_feedback"]["fallback_used"] is False
+    )
     assert "langgraph" in payload["manifest"]["notebook_dependency_plan"]["packages"]
     assert payload["manifest"]["qa_repair_feedback"]["repair_attempts"] == 0
 
@@ -400,7 +424,9 @@ async def test_generate_artifacts_surfaces_requirements_feedback_as_warnings(
         }
         return result
 
-    monkeypatch.setattr(cli_module, "_build_stub_result", build_stub_result_with_feedback)
+    monkeypatch.setattr(
+        cli_module, "_build_stub_result", build_stub_result_with_feedback
+    )
 
     output_dir = constants_module._BASE_OUTPUT / tmp_path.name
     artifacts = await cli_module.generate_artifacts(
@@ -445,7 +471,9 @@ async def test_generate_artifacts_surfaces_architecture_feedback_as_warnings(
         }
         return result
 
-    monkeypatch.setattr(cli_module, "_build_stub_result", build_stub_result_with_feedback)
+    monkeypatch.setattr(
+        cli_module, "_build_stub_result", build_stub_result_with_feedback
+    )
 
     output_dir = constants_module._BASE_OUTPUT / tmp_path.name
     artifacts = await cli_module.generate_artifacts(
@@ -476,7 +504,9 @@ async def test_generate_artifacts_surfaces_graph_design_feedback_as_warnings(
 
     original_build_stub_result = cli_module._build_stub_result
 
-    def build_stub_result_with_graph_feedback(prompt: str, agent_type: str | None = None):
+    def build_stub_result_with_graph_feedback(
+        prompt: str, agent_type: str | None = None
+    ):
         result = original_build_stub_result(prompt, agent_type=agent_type)
         result["graph_design_feedback"] = {
             "fallback_used": True,
@@ -512,7 +542,9 @@ async def test_generate_artifacts_surfaces_graph_design_feedback_as_warnings(
         }
         return result
 
-    monkeypatch.setattr(cli_module, "_build_stub_result", build_stub_result_with_graph_feedback)
+    monkeypatch.setattr(
+        cli_module, "_build_stub_result", build_stub_result_with_graph_feedback
+    )
 
     output_dir = constants_module._BASE_OUTPUT / "graph_feedback_stub"
     artifacts = await cli_module.generate_artifacts(
@@ -544,15 +576,21 @@ async def test_generate_artifacts_surfaces_tool_planning_feedback_as_warnings(
 
     original_build_stub_result = cli_module._build_stub_result
 
-    def build_stub_result_with_tool_feedback(prompt: str, agent_type: str | None = None):
+    def build_stub_result_with_tool_feedback(
+        prompt: str, agent_type: str | None = None
+    ):
         result = original_build_stub_result(prompt, agent_type=agent_type)
         result["tool_planning_feedback"] = {
             "fallback_used": True,
             "fallback_reason": "Tool planning used heuristic fallback inference.",
             "validation_errors": ["Unsupported tool suggestion 'swarm_tool'."],
             "unresolved_tools": ["swarm_tool"],
-            "environment_notes": ["Network access may be unavailable in the target runtime."],
-            "dependency_conflicts": ["Both 'requests' and a custom HTTP client were suggested."],
+            "environment_notes": [
+                "Network access may be unavailable in the target runtime."
+            ],
+            "dependency_conflicts": [
+                "Both 'requests' and a custom HTTP client were suggested."
+            ],
             "available_tool_ids": ["web_search", "http_client"],
             "warnings": ["Tool planning used heuristic fallback inference."],
         }
@@ -653,7 +691,9 @@ async def test_generate_artifacts_surfaces_notebook_composition_feedback_as_warn
 
     warning_codes = {warning["code"] for warning in artifacts["manifest"]["warnings"]}
     assert "notebook_composition_fallback" in warning_codes
-    assert artifacts["manifest"]["notebook_composition_feedback"]["fallback_used"] is True
+    assert (
+        artifacts["manifest"]["notebook_composition_feedback"]["fallback_used"] is True
+    )
     assert "requests" in artifacts["manifest"]["notebook_dependency_plan"]["packages"]
 
 
@@ -719,6 +759,70 @@ async def test_generate_artifacts_surfaces_qa_feedback_as_warnings(
     assert artifacts["manifest"]["qa_repair_feedback"]["repair_attempts"] == 1
     assert artifacts["manifest"]["qa_summary"]["status"] == "blocking_failed"
     assert artifacts["manifest"]["qa_reports"][0]["rule_id"] == "python_syntax"
+
+
+@pytest.mark.asyncio
+async def test_generate_artifacts_describes_runtime_smoke_test_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_runtime_smoke_scope")
+
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.cli as cli_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(cli_module)
+
+    original_build_stub_result = cli_module._build_stub_result
+
+    def build_stub_result_with_runtime_smoke(
+        prompt: str, agent_type: str | None = None
+    ):
+        result = original_build_stub_result(prompt, agent_type=agent_type)
+        result["qa_reports"] = [
+            {
+                "check_name": "Runtime Smoke Test",
+                "passed": True,
+                "message": (
+                    "Runtime execution environment validated using the "
+                    "'python3' kernel."
+                ),
+                "rule_id": "runtime_smoke_test",
+                "severity": "info",
+                "category": "runtime",
+                "repairable": False,
+                "suggestions": [],
+                "stage": "runtime",
+                "attempt": 0,
+                "evidence": {
+                    "execution_scope": "trusted_smoke_test",
+                    "message": "runtime smoke notebook passed",
+                },
+            }
+        ]
+        return result
+
+    monkeypatch.setattr(
+        cli_module,
+        "_build_stub_result",
+        build_stub_result_with_runtime_smoke,
+    )
+
+    artifacts = await cli_module.generate_artifacts(
+        "Runtime scope prompt",
+        output_dir=str(constants_module._BASE_OUTPUT / "runtime_smoke_scope"),
+        mode="stub",
+        formats=["ipynb"],
+    )
+
+    validation_scope = artifacts["manifest"]["qa_summary"]["validation_scope"]
+    validated = " ".join(validation_scope["validated"]).lower()
+    not_validated = " ".join(validation_scope["not_validated"]).lower()
+
+    assert "trusted smoke notebook" in validated
+    assert "did not execute the full generated notebook" in not_validated
 
 
 @pytest.mark.asyncio
@@ -849,9 +953,9 @@ async def test_api_rejects_removed_advanced_options_as_unknown_fields(
 
 
 def test_generation_request_formats_description_mentions_markdown():
-    description = app.openapi()["components"]["schemas"]["GenerationRequest"]["properties"][
-        "formats"
-    ]["description"]
+    description = app.openapi()["components"]["schemas"]["GenerationRequest"][
+        "properties"
+    ]["formats"]["description"]
 
     assert "markdown" in description.lower()
     assert "ipynb, html, markdown, docx, zip" in description

--- a/tests/unit/test_notebook_outputs.py
+++ b/tests/unit/test_notebook_outputs.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import zipfile
 from pathlib import Path
 
+import nbformat
 import pytest
-
 
 
 @pytest.mark.asyncio
@@ -172,6 +172,99 @@ async def test_generate_zip_bundle(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         assert "notebook.ipynb" in names
         # Should also include JSON artifacts
         assert any("json" in name for name in names)
+
+
+@pytest.mark.asyncio
+async def test_manifest_cell_count_matches_serialized_notebook(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Manifest cell_count should describe the emitted notebook, not raw specs."""
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_manifest_cell_count_truth")
+
+    import importlib
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.cli as cli_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(cli_module)
+
+    artifacts = await cli_module.generate_artifacts(
+        "Create a manifest truth test system",
+        output_dir=str(constants_module._BASE_OUTPUT / "cell_count_truth"),
+        mode="stub",
+        formats=["ipynb"],
+    )
+
+    manifest = artifacts["manifest"]
+    notebook_path = constants_module.resolve_under_base(Path(manifest["notebook_path"]))
+    notebook = nbformat.read(notebook_path, as_version=4)
+
+    assert manifest["cell_count"] == len(notebook.cells)
+    assert manifest["cell_count_source"] == "serialized_notebook"
+    assert manifest["generated_cell_spec_count"] == len(
+        artifacts["result"]["generated_cells"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_manifest_artifact_contract_marks_standalone_files_and_zip_members(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Manifest artifact metadata should match files and bundle contents."""
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_manifest_artifact_contract")
+
+    import importlib
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.cli as cli_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(cli_module)
+
+    artifacts = await cli_module.generate_artifacts(
+        "Create an artifact contract test system",
+        output_dir=str(constants_module._BASE_OUTPUT / "artifact_contract"),
+        mode="stub",
+        formats=["ipynb", "html", "zip"],
+    )
+
+    manifest = artifacts["manifest"]
+    contract = manifest["artifact_contract"]
+    standalone_by_key = {
+        entry["manifest_key"]: entry for entry in contract["standalone_files"]
+    }
+
+    for manifest_key in [
+        "plan_path",
+        "cells_path",
+        "notebook_path",
+        "html_path",
+        "zip_path",
+    ]:
+        entry = standalone_by_key[manifest_key]
+        assert entry["availability"] == "standalone"
+        assert entry["path_type"] == "server_local"
+        assert entry["exists"] is True
+        assert constants_module.resolve_under_base(Path(entry["path"])).is_file()
+        assert entry["relative_path"]
+
+    zip_path = constants_module.resolve_under_base(Path(manifest["zip_path"]))
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        actual_members = set(zf.namelist())
+
+    manifest_members = {entry["name"]: entry for entry in contract["zip_members"]}
+    assert set(manifest_members).issubset(actual_members)
+    assert manifest_members["notebook.ipynb"]["availability"] in {
+        "standalone_and_bundle",
+        "bundle_only",
+    }
+    assert manifest_members["notebook_plan.json"]["source_manifest_key"] == "plan_path"
+    assert (
+        manifest_members["generated_cells.json"]["source_manifest_key"] == "cells_path"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- fixes manifest `cell_count` so it reflects the final serialized notebook instead of raw generated cell specs
- adds an explicit `artifact_contract` describing standalone files, server-local path semantics, download URLs, and ZIP members
- extends QA summaries with validation-scope wording so runtime smoke checks do not imply full generated-notebook execution

## Validation
- `pytest tests/unit/test_notebook_outputs.py tests/unit/test_shared_platform_hardening.py tests/unit/test_cli_api.py --asyncio-mode=auto -q` -> 61 passed
- `pytest tests/unit/ --asyncio-mode=auto -q` -> 603 passed
- `pytest --asyncio-mode=auto -q` -> 721 passed, 3 skipped

Closes #350
