### PR TITLE
Complete generated chatbot fidelity wave

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,7 +239,8 @@ aligned when changing notebook assembly behavior:
 - generated tool claims should stay aligned with
   `graph_exports.schema.tool_reachability`; manifests expose
   `tool_contract_summary` to distinguish planned, executable, utility, and
-  unsupported tools
+  unsupported tools, plus unclassified tools when reachability metadata is
+  missing or mismatched
 - register architecture-specific notebook assembly behavior through
   `src/langgraph_system_generator/generator/notebook_composer_registry.py`
   and `NOTEBOOK_COMPOSER_PLUGIN_MODULES` rather than adding more hardcoded

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,17 @@ aligned when changing notebook assembly behavior:
   notebook-scoped helpers explicitly with `use_notebook_helper=True` so node
   code calls `make_llm(...)` and leaves model/API-base settings centralized in
   the config cell
+- generated chatbot notebooks must remain non-blocking on top-to-bottom
+  execution by default; interactive input loops should run only when the
+  notebook-level `RUN_INTERACTIVE_LOOP` flag is enabled, while `chat_once(...)`
+  and repeatable same-thread helper calls remain available for tests and demos
+- generated chatbot verifier/reviser nodes should use the canonical draft,
+  safety, revision, and final-response fields so QA can prove bounded revision
+  routing instead of relying on prose-only verifier cells
+- generated tool claims should stay aligned with
+  `graph_exports.schema.tool_reachability`; manifests expose
+  `tool_contract_summary` to distinguish planned, executable, utility, and
+  unsupported tools
 - register architecture-specific notebook assembly behavior through
   `src/langgraph_system_generator/generator/notebook_composer_registry.py`
   and `NOTEBOOK_COMPOSER_PLUGIN_MODULES` rather than adding more hardcoded
@@ -254,8 +265,9 @@ that shared engine, not a second repair implementation.
 - keep validator coverage aligned with official LangGraph notebook semantics:
   accumulated messages need reducer semantics, graph nodes should return
   partial state updates, tool descriptions must match reachable execution
-  paths, and domain-specific prompts should not render generic architecture
-  placeholders
+  paths, memory/persona fields need registered writers, chatbot verifier loops
+  need executable revise/accept routing, and domain-specific prompts should not
+  render generic architecture placeholders
 - prefer bounded deterministic repairs over free-form rewrites, especially in
   stub mode and CI-facing tests
 

--- a/docs/NOTEBOOK_OUTPUT_GUIDE.md
+++ b/docs/NOTEBOOK_OUTPUT_GUIDE.md
@@ -158,6 +158,19 @@ curl -X POST http://localhost:8000/generate \
         }
       ]
     },
+    "tool_contract_summary": {
+      "counts": {
+        "planned": 2,
+        "executable": 1,
+        "utility": 0,
+        "unsupported": 1
+      },
+      "source_precedence": [
+        "graph_exports.schema.tool_reachability",
+        "tools_plan",
+        "qa_reports.tool_reachability"
+      ]
+    },
     "qa_summary": {
       "validation_scope": {
         "validated": ["Static QA checked the generated notebook cells covered by qa_reports."],

--- a/docs/NOTEBOOK_OUTPUT_GUIDE.md
+++ b/docs/NOTEBOOK_OUTPUT_GUIDE.md
@@ -163,7 +163,8 @@ curl -X POST http://localhost:8000/generate \
         "planned": 2,
         "executable": 1,
         "utility": 0,
-        "unsupported": 1
+        "unsupported": 1,
+        "unclassified": 0
       },
       "source_precedence": [
         "graph_exports.schema.tool_reachability",

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -27,13 +27,15 @@
   runtime smoke-test scope limits.
 - PR #357 merged a broad generated-chat notebook contract pass with chat-loop,
   character-selection, executable-tool, verifier/reviser, memory, and generated
-  credential/config improvements. The child issues #344-#348 remain open and
-  should be re-triaged against the merged code before starting overlapping
-  implementation.
-- PR #359 is open for Wave 3 #343/#348. It preserves canonical graph/spec
-  topology in generated notebooks, manifests, and QA, keeps standalone pattern
-  LLM snippets separate from notebook `make_llm(...)` cells, and has had its six
-  review threads addressed and resolved on the PR branch.
+  credential/config improvements.
+- PR #359 merged Wave 3 #343/#348. It preserves canonical graph/spec topology in
+  generated notebooks, manifests, and QA, and keeps standalone pattern LLM
+  snippets separate from notebook `make_llm(...)` cells.
+- Wave 4 is active on `codex/chatbot-fidelity-wave4` for #344, #345, #346,
+  #347, and #349. The branch hardens existing generated-chat behavior rather
+  than replacing PR #357/#359: non-blocking chat helpers, same-thread turns,
+  canonical verifier/reviser fields, memory writers, tool contract summaries,
+  and prompt-faithfulness/domain QA.
 - `memory-bank/systemPatterns.md` was updated to document the actual repo
   architecture instead of template bullets.
 - The API layer includes guarded output-path resolution and bounded async job
@@ -51,8 +53,10 @@
   manifests, and QA can explain whether docs came from local LangChain docs,
   Context7, cached repo docs, or fallback retrieval context.
 - Runtime QA now checks for LangGraph notebook contract drift such as full-state
-  overwrite node returns, unsafe broad HTTP tool placeholders, and generic
-  architecture labels in domain-specific notebooks.
+  overwrite node returns, unsafe broad HTTP tool placeholders, unwired ToolNode
+  executors, blocking default chatbot loops, terminal verifier/reviser prose
+  nodes, declared memory fields without writers, and generic architecture labels
+  in domain-specific notebooks.
 - `docs/agent-assets-audit.md` records the contributor-facing custom
   agent/skill inventory and keeps those assets separate from runtime product
   agents.
@@ -85,11 +89,11 @@
 
 ## Immediate Next Steps
 
-- Watch PR #359 to completion, then close or update #343 and #348 based on the
-  merge result.
-- Before implementing the next Wave 4 branch, compare #344-#347 and #349
-  against merged PR #357 and PR #359 so follow-up work closes remaining gaps
-  rather than duplicating already-landed chat/runtime behavior.
+- Open the ready Wave 4 PR from `codex/chatbot-fidelity-wave4` for #344, #345,
+  #346, #347, and #349. The branch has passed focused tests, the broad unit
+  gate, and headed/live UI artifact validation.
+- After Wave 4 lands, close epic #342 only if all children #343-#350 are closed;
+  keep #334/#335 active as downstream runtime outer-agent architecture work.
 - Keep public docs, examples, and onboarding copy aligned with the current
   CLI/API contract.
 - Keep contributor-facing LangGraph/LangChain skills and LNF custom agents
@@ -147,3 +151,18 @@
 - The post-refresh broad unit gate was
   `python -m pytest tests/unit/ --asyncio-mode=auto -q` with 622 passed and 4
   warnings.
+- Current Wave 4 focused verification on `codex/chatbot-fidelity-wave4` has
+  passed:
+  `python -m pytest tests/unit/test_generator_notebook_composer.py tests/unit/test_validators.py -q`
+  with 111 passed,
+  `python -m pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py --asyncio-mode=auto -q`
+  with 143 passed, and
+  `python -m pytest tests/unit/test_patterns.py tests/unit/test_patterns_utils.py -q`
+  with 98 passed.
+- The Wave 4 broad unit gate
+  `python -m pytest tests/unit/ --asyncio-mode=auto -q` passed with 634 tests
+  and 4 warnings.
+- The headed/live Wave 4 UI gate used `gpt-5.4-mini` to generate
+  `./output/wave4-live-chatbot`; required artifact downloads worked, the
+  browser reported no console or page errors, and the manifest reported
+  advisory QA only with zero blocking issues.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -15,14 +15,14 @@
   counts from raw generated cell specs, expose an `artifact_contract` for
   standalone files and ZIP members, and include QA validation-scope wording for
   runtime smoke tests.
-- Generated chatbot notebooks now include stronger runtime affordances from PR
-  #357, including chat-loop execution helpers, character selection,
-  executable-tool wiring, verifier/reviser fallbacks, memory checks, and
-  centralized generated LLM configuration patterns.
-- PR #359 is open for #343/#348 with canonical graph/spec rendering, manifest
-  and QA graph-contract preservation, and explicit standalone-versus-notebook
-  LLM initialization boundaries. Its six review threads have been addressed and
-  resolved on the PR branch.
+- Generated chatbot notebooks include stronger runtime affordances from PR #357
+  and current Wave 4 work, including chat-loop execution helpers, character
+  selection, executable-tool wiring, verifier/reviser fallbacks, memory checks,
+  non-blocking top-to-bottom chat execution, and centralized generated LLM
+  configuration patterns.
+- PR #359 merged #343/#348 with canonical graph/spec rendering, manifest and QA
+  graph-contract preservation, and explicit standalone-versus-notebook LLM
+  initialization boundaries.
 - Pattern generators and examples cover router, subagents, hybrid, autoagent,
   experimental deepagents, critique-revise, and advanced example-only workflows.
 - Notebook composition, dependency planning, runtime validation, deterministic
@@ -44,7 +44,11 @@
   passing after generated-chat contract changes. PR #359 review-fix slices
   reported 96 pattern tests, 102 composer/validator tests, and 142
   generator/API-node tests passing; the post-refresh broad unit gate reported
-  622 passed and 4 warnings.
+  622 passed and 4 warnings. Current Wave 4 focused slices report 111
+  composer/validator tests, 143 generator/API-node tests, and 98 pattern tests
+  passing. The Wave 4 broad unit gate reports 634 passed and 4 warnings, and
+  the headed/live web UI gate completed with `gpt-5.4-mini`, working notebook,
+  HTML, and manifest downloads, no browser errors, and advisory-only QA.
 - Stale completed release-plan issues were closed with evidence during the
   release-readiness pass, reducing that older open issue inventory from 49 to
   26 while keeping true residual items open.
@@ -89,8 +93,9 @@
 - The Cloud Run deploy workflow builds and pushes the container image, deploys
   the private service, mounts `OPENAI_API_KEY` from Secret Manager, and checks
   `/health` after deployment.
-- As of the 2026-05-21 issue refresh, the open issue count is 29. #343 and
-  #348 remain open until PR #359 merges.
+- As of the post-PR #359 refresh, #343 and #348 are complete. The remaining
+  generated-output children under #342 are #344, #345, #346, #347, and #349,
+  currently implemented on `codex/chatbot-fidelity-wave4`.
 
 ## Known Issues and Limitations
 
@@ -106,9 +111,9 @@
 - Router fallback/general routing (#60), iterative requirements refinement
   (#202), and the remaining CYOA notebook cell issues are tracked as residual
   follow-up work rather than closed stale items.
-- The canonical graph topology issue (#343) and generated credential/config
-  hardening issue (#348) are still open while PR #359 is pending. Treat further
-  Wave 4 work as blocked on checking what PR #359 closes.
+- Generated-output Wave 4 still needs diff hygiene and a ready PR before #344,
+  #345, #346, #347, and #349 can be closed. The broad unit and headed/live UI
+  artifact gates have passed on `codex/chatbot-fidelity-wave4`.
 - The Cloud Run workflow's private-service health check is sensitive to token
   minting details in GitHub Actions WIF. Do not use `gcloud auth
   print-identity-token --audiences=...` for this workflow's health token; the

--- a/memory-bank/tasks/TASK004-generated-output-quality-wave.md
+++ b/memory-bank/tasks/TASK004-generated-output-quality-wave.md
@@ -14,20 +14,26 @@ aligned before continuing the wave.
 
 Treat generated-output work as a sequence under epic #342. Reliability work
 from #351-#355 is complete. Manifest truth work from #350 is complete. PR #357
-landed broad generated-chat runtime improvements. PR #359 is now open for #343
-and #348 and should merge or receive final review before Wave 4 work begins.
+landed broad generated-chat runtime improvements. PR #359 merged #343/#348, so
+Wave 4 is now active for #344, #345, #346, #347, and #349.
 
 ## Implementation Plan
 
 - Keep #351-#355 closed as completed by PR #356.
 - Keep #350 closed as completed by PR #358.
-- Complete PR #359 for Wave 3 #343/#348.
-- For #343, preserve canonical graph topology from graph/spec metadata into
-  executable notebook code, Mermaid/schema exports, manifests, and QA.
-- For #348, keep standalone pattern LLM snippets self-contained while notebook
-  composition uses centralized `make_llm(...)` configuration.
-- Before working #344-#347 and #349, compare their acceptance criteria against
-  merged PR #357 and pending/merged PR #359.
+- Keep #343/#348 closed as completed by PR #359.
+- Complete Wave 4 on `codex/chatbot-fidelity-wave4` without duplicating PR #357
+  or PR #359 behavior.
+- For #344, make verifier/reviser generated loops operational through canonical
+  draft, safety, revision, route, and bounded retry fields.
+- For #345/#347, keep chatbot execution helpers non-blocking by default while
+  preserving character selection, repeatable same-thread turns, and typed
+  persona/chat memory writes.
+- For #346, use `graph_exports.schema.tool_reachability` as the execution
+  contract and expose a manifest `tool_contract_summary`.
+- For #349, strengthen deterministic QA for chat loops, character gates, memory
+  writers, fake tool wiring, terminal verifier loops, and
+  chatbot/historical/persona domain alignment.
 
 ## Progress Tracking
 
@@ -40,8 +46,9 @@ and #348 and should merge or receive final review before Wave 4 work begins.
 | 4.1 | Close completed runtime reliability issues #351-#355 | Complete | 2026-05-20 | Closed as completed with PR #356 and merge commit `7881a0895de78b3de2a5ebce5c911f6699b21a27`. |
 | 4.2 | Implement manifest/artifact truth for #350 | Complete | 2026-05-20 | PR #358 merged and #350 is closed. |
 | 4.3 | Reconcile generated-chat contract PR #357 with open child issues | Complete | 2026-05-21 | PR #359 folded the #348 config boundary into the #343 branch; remaining Wave 4 issues still need final triage after #359. |
-| 4.4 | Implement canonical graph topology preservation for #343 | In Review | 2026-05-21 | PR #359 on `codex/canonical-graph-topology-343`; review threads addressed and resolved. |
-| 4.5 | Implement remaining #348 follow-up if still needed | In Review | 2026-05-21 | PR #359 implements the standalone `ChatOpenAI(...)` versus notebook `make_llm(...)` boundary. |
+| 4.4 | Implement canonical graph topology preservation for #343 | Complete | 2026-05-21 | PR #359 merged at `d851008ffc5e6ca289c666c5b1c0564b2282f32f`. |
+| 4.5 | Implement remaining #348 follow-up if still needed | Complete | 2026-05-21 | PR #359 implements the standalone `ChatOpenAI(...)` versus notebook `make_llm(...)` boundary. |
+| 4.6 | Implement generated chatbot Wave 4 for #344/#345/#346/#347/#349 | In Progress | 2026-05-21 | Branch `codex/chatbot-fidelity-wave4`; focused slices, broad unit gate, and headed/live UI artifact gate are passing. |
 
 ## Progress Log
 
@@ -71,3 +78,24 @@ and #348 and should merge or receive final review before Wave 4 work begins.
 - The post-refresh broad unit gate
   `python -m pytest tests/unit/ --asyncio-mode=auto -q` passed with 622 tests
   and 4 warnings.
+- PR #359 merged at `d851008ffc5e6ca289c666c5b1c0564b2282f32f`, closing
+  #343/#348.
+- Wave 4 started from updated `main` on `codex/chatbot-fidelity-wave4`.
+- Implemented Wave 4 hardening for non-blocking chatbot helpers, same-thread
+  demo turns, canonical verifier/reviser state writes, persona/memory writes,
+  additive `tool_contract_summary` manifests, unwired ToolNode detection,
+  declared-memory-field writer checks, terminal verifier loop checks, and
+  chatbot/historical/persona domain cues.
+- Focused verification passed:
+  `tests/unit/test_generator_notebook_composer.py tests/unit/test_validators.py`
+  (111 passed),
+  `tests/unit/test_generator_agents.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py --asyncio-mode=auto`
+  (143 passed), and
+  `tests/unit/test_patterns.py tests/unit/test_patterns_utils.py` (98 passed).
+- Broad Wave 4 verification passed:
+  `python -m pytest tests/unit/ --asyncio-mode=auto -q` with 634 passed and 4
+  warnings.
+- Headed/live web UI verification passed with `gpt-5.4-mini` to
+  `./output/wave4-live-chatbot`: notebook, HTML, and manifest downloads worked,
+  no browser console/page errors were observed, and the manifest reported
+  advisory-only QA with zero blocking issues.

--- a/memory-bank/tasks/_index.md
+++ b/memory-bank/tasks/_index.md
@@ -21,5 +21,7 @@
 - Task-level Memory Bank tracking has started with the documentation and
   visualization sync for the checked-in repo architecture bundle, the completed
   1.0 release-readiness branch, the completed Cloud Run deployment hardening
-  lane, and the active generated-output quality wave under epic #342. The
-  current Wave 3 PR is #359 for #343/#348.
+  lane, and the active generated-output quality wave under epic #342. Wave 4 is
+  active on `codex/chatbot-fidelity-wave4` for #344, #345, #346, #347, and
+  #349 after PR #359 merged #343/#348; the focused tests, broad unit gate, and
+  headed/live UI artifact gate are passing before PR publication.

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -32,6 +32,11 @@
   unit verification reported 609 passed. PR #359 review-fix slices reported 96
   pattern tests, 102 composer/validator tests, and 142 generator/API-node tests
   passing; the post-refresh broad unit gate reported 622 passed and 4 warnings.
+  Current Wave 4 focused slices report 111 composer/validator tests, 143
+  generator/API-node tests, and 98 pattern tests passing. The Wave 4 broad unit
+  gate reports 634 passed and 4 warnings, and the headed/live UI gate completed
+  with `gpt-5.4-mini`, working notebook, HTML, and manifest downloads, no
+  browser errors, and advisory-only generated-artifact QA.
 - The CI fatal-error lint gate is `python -m flake8 . --count
   --select=E9,F63,F7,F82 --show-source --statistics`; the broader
   `--exit-zero` flake8 statistics command is informational and still reports

--- a/plans/current-plan.md
+++ b/plans/current-plan.md
@@ -4,9 +4,9 @@
 # Current Plan
 
 ## Objective
-Continue the generated-output quality wave under epic #342 while keeping repo
-context aligned with the merged reliability, manifest-truth, generated-chat
-contract, and current canonical-graph/config PR work.
+Complete Wave 4 under generated-output epic #342 after merged PR #359, focused
+on the remaining generated chatbot fidelity issues #344, #345, #346, #347, and
+#349.
 
 ## Scope
 Included:
@@ -18,30 +18,54 @@ Included:
 
 Excluded:
 - Reopening #351-#355 or #350; those are completed by merged PRs.
-- Starting Wave 4 before PR #359 is merged or explicitly deferred.
-- Duplicating PR #357 or PR #359 behavior while #344-#347 and #349 are still
-  untriaged against current code.
+- Direct commits to `main`; Wave 4 work stays on
+  `codex/chatbot-fidelity-wave4`.
+- Rewriting PR #357 or PR #359 behavior where the current code already has a
+  working generated-chat or canonical-graph contract.
 
 ## Plan
 1. Keep local `main` synced with `origin/main`.
 2. Refresh MemoryBank and plan context for merged PR #356, PR #358, and PR
-   #357.
-3. Track PR #359 on `codex/canonical-graph-topology-343` through final checks
-   and merge readiness.
-4. After PR #359 merges, close or update #343 and #348 based on merge evidence.
-5. Re-triage #344-#347 and #349 against merged PR #357 and PR #359 before
-   opening overlapping follow-up branches.
+   #357, plus merged PR #359 for #343/#348.
+3. Implement Wave 4 on `codex/chatbot-fidelity-wave4`:
+   - #344: operational bounded verifier/reviser routing and structured fields.
+   - #345/#347: non-blocking chatbot helpers, character selection, same-thread
+     repeated turns, and typed persona/chat memory writes.
+   - #346: executable tool claims tied to graph `tool_reachability`, with a
+     manifest `tool_contract_summary` for planned/executable/utility/unsupported
+     tools.
+   - #349: deterministic QA for chat loops, character gates, memory writers,
+     verifier loops, tool wiring, and chatbot/historical/persona domain drift.
+4. Run focused unit gates, then the broad unit suite, diff hygiene checks, and
+   the headed/live web UI gate with `gpt-5.4-mini` when credentials are
+   available.
+5. Open one ready Wave 4 PR that closes #344, #345, #346, #347, and #349 only
+   if tests and live artifact checks support that claim.
 
 ## Validation
 - `gh issue list --state open --limit 200 --json number --jq 'length'`
 - `gh issue list --state open --limit 200 --json number,title`
-- For PR #359 changes, keep focused graph/notebook/QA tests passing, then run
-  `pytest tests/unit/ --asyncio-mode=auto -q` before final merge when time
-  allows.
+- Wave 4 focused gates:
+  - `python -m pytest tests/unit/test_generator_notebook_composer.py tests/unit/test_validators.py -q`
+  - `python -m pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py --asyncio-mode=auto -q`
+  - `python -m pytest tests/unit/test_patterns.py tests/unit/test_patterns_utils.py -q`
+- Final gate: `python -m pytest tests/unit/ --asyncio-mode=auto -q`, `git diff
+  --check`, exact conflict-marker scan, and headed/live UI artifact validation
+  when `OPENAI_API_KEY` is available.
+
+Current Wave 4 verification on `codex/chatbot-fidelity-wave4` has passed the
+focused gates with 111 composer/validator tests, 143 generator/API-node tests,
+and 98 pattern tests. The broad unit gate passed with 634 tests and 4 warnings.
+The headed/live web UI gate used `gpt-5.4-mini` to generate
+`./output/wave4-live-chatbot`; downloads for notebook, HTML, and manifest
+worked, no browser errors were reported, and the manifest ended with advisory
+QA only and zero blocking issues.
 
 ## Completion criteria
-- PR #359 is merged or explicitly deferred with evidence.
-- MemoryBank and plan context reflect current issue/PR state.
-- #344-#347 and #349 have been checked against merged PR #357 and PR #359 before
-  more code is written for those issues.
+- MemoryBank and plan context reflect PR #359 as merged and Wave 4 as active.
+- Generated chatbot notebooks do not block top-to-bottom execution by default.
+- Verifier/reviser, memory, tool reachability, and prompt-faithfulness QA have
+  deterministic coverage.
+- Wave 4 PR is pushed, ready for review, and linked to #344, #345, #346, #347,
+  and #349.
 <!-- repo-agent-bootstrap:managed:end -->

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -388,41 +388,40 @@ def _build_artifact_contract(
     }
 
     zip_members: list[dict[str, Any]] = []
-    zip_path_value = manifest.get("zip_path")
-    if zip_path_value:
-        resolved_zip_path, _ = _resolve_path_within_base(zip_path_value, output_dir)
-        if resolved_zip_path:
-            output_dir_real = os.path.realpath(os.fspath(output_dir))
-            resolved_zip_real = os.path.realpath(os.fspath(resolved_zip_path))
-            if os.path.commonpath(
-                [output_dir_real, resolved_zip_real]
-            ) == output_dir_real and os.path.isfile(resolved_zip_real):
-                with zipfile.ZipFile(resolved_zip_real, "r") as zf:
-                    for member in zf.infolist():
-                        source_entry = standalone_by_filename.get(member.filename)
-                        source_exists = bool(
-                            source_entry and source_entry.get("exists")
-                        )
-                        zip_members.append(
-                            {
-                                "name": member.filename,
-                                "availability": (
-                                    "standalone_and_bundle"
-                                    if source_exists
-                                    else "bundle_only"
-                                ),
-                                "source_manifest_key": (
-                                    source_entry.get("manifest_key")
-                                    if source_entry
-                                    else None
-                                ),
-                                "source_path": (
-                                    source_entry.get("path") if source_entry else None
-                                ),
-                                "source_exists": source_exists,
-                                "size_bytes": member.file_size,
-                            }
-                        )
+    zip_entry = next(
+        (
+            entry
+            for entry in standalone_files
+            if entry.get("manifest_key") == "zip_path"
+            and entry.get("path_type") == "server_local"
+            and entry.get("exists")
+        ),
+        None,
+    )
+    expected_zip_path = Path(
+        os.path.realpath(os.fspath(output_dir / "notebook_bundle.zip"))
+    )
+    if zip_entry and Path(str(zip_entry.get("path", ""))) == expected_zip_path:
+        with zipfile.ZipFile(expected_zip_path, "r") as zf:
+            for member in zf.infolist():
+                source_entry = standalone_by_filename.get(member.filename)
+                source_exists = bool(source_entry and source_entry.get("exists"))
+                zip_members.append(
+                    {
+                        "name": member.filename,
+                        "availability": (
+                            "standalone_and_bundle" if source_exists else "bundle_only"
+                        ),
+                        "source_manifest_key": (
+                            source_entry.get("manifest_key") if source_entry else None
+                        ),
+                        "source_path": (
+                            source_entry.get("path") if source_entry else None
+                        ),
+                        "source_exists": source_exists,
+                        "size_bytes": member.file_size,
+                    }
+                )
 
     return {
         "version": 1,

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -38,7 +38,11 @@ from langgraph_system_generator.generator.architecture_registry import (
     get_default_architecture_registry,
 )
 from langgraph_system_generator.generator.tool_registry import get_tool_registry
-from langgraph_system_generator.qa.summary import build_qa_summary, serialize_qa_report
+from langgraph_system_generator.qa.summary import (
+    build_qa_summary,
+    build_tool_contract_summary,
+    serialize_qa_report,
+)
 from langgraph_system_generator.generator.graph_design_registry import (
     build_graph_exports,
     graph_design_issue_messages,
@@ -280,10 +284,9 @@ def _resolve_path_within_base(
             os.path.realpath(os.path.join(os.fspath(base_resolved), normalized))
         )
     try:
-        if (
-            os.path.commonpath([os.fspath(base_resolved), os.fspath(candidate)])
-            != os.fspath(base_resolved)
-        ):
+        if os.path.commonpath(
+            [os.fspath(base_resolved), os.fspath(candidate)]
+        ) != os.fspath(base_resolved):
             return None, None
     except ValueError:
         return None, None
@@ -391,15 +394,15 @@ def _build_artifact_contract(
         if resolved_zip_path:
             output_dir_real = os.path.realpath(os.fspath(output_dir))
             resolved_zip_real = os.path.realpath(os.fspath(resolved_zip_path))
-            if (
-                os.path.commonpath([output_dir_real, resolved_zip_real])
-                == output_dir_real
-                and os.path.isfile(resolved_zip_real)
-            ):
+            if os.path.commonpath(
+                [output_dir_real, resolved_zip_real]
+            ) == output_dir_real and os.path.isfile(resolved_zip_real):
                 with zipfile.ZipFile(resolved_zip_real, "r") as zf:
                     for member in zf.infolist():
                         source_entry = standalone_by_filename.get(member.filename)
-                        source_exists = bool(source_entry and source_entry.get("exists"))
+                        source_exists = bool(
+                            source_entry and source_entry.get("exists")
+                        )
                         zip_members.append(
                             {
                                 "name": member.filename,
@@ -1519,7 +1522,10 @@ async def generate_artifacts(
         if normalized_requested in ("", "."):
             target_real = base_output_real
         else:
-            if normalized_requested.startswith("..") or f"{os.sep}.." in normalized_requested:
+            if (
+                normalized_requested.startswith("..")
+                or f"{os.sep}.." in normalized_requested
+            ):
                 raise ValueError(
                     "output_dir must reside within the configured base output directory."
                 )
@@ -1600,6 +1606,11 @@ async def generate_artifacts(
     qa_reports = serialized.get("qa_reports") or []
     serialized_qa_reports = [serialize_qa_report(report) for report in qa_reports]
     qa_summary = build_qa_summary(serialized_qa_reports)
+    tool_contract_summary = build_tool_contract_summary(
+        serialized.get("tools_plan") or [],
+        graph_exports,
+        serialized_qa_reports,
+    )
 
     manifest: Dict[str, Any] = {
         "prompt": prompt,
@@ -1614,6 +1625,7 @@ async def generate_artifacts(
         "graph_design_feedback": graph_design_feedback,
         "graph_exports": graph_exports,
         "tool_planning_feedback": tool_planning_feedback,
+        "tool_contract_summary": tool_contract_summary,
         "generation_context_pack": generation_context_pack,
         "notebook_composition_feedback": notebook_composition_feedback,
         "notebook_dependency_plan": notebook_dependency_plan,

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -275,6 +275,45 @@ class NotebookComposer:
             return nodes
         return [node for node in nodes if str(node.get("name") or "") != "finish"]
 
+    def _with_required_pattern_scaffold_nodes(
+        self,
+        nodes: List[Dict[str, Any]],
+        workflow_design: Dict[str, Any],
+    ) -> List[Dict[str, Any]]:
+        """Ensure fallback node cells define handlers referenced by pattern graphs."""
+
+        architecture_type = str(workflow_design.get("architecture_type") or "").lower()
+        required_by_architecture = {
+            "router": [
+                ("router", "Route the chat turn to the next workflow handler."),
+            ],
+            "subagents": [
+                ("supervisor", "Coordinate the generated chatbot subagents."),
+            ],
+            "hybrid": [
+                ("router", "Route direct chatbot turns or delegate to the team."),
+                ("supervisor", "Coordinate the generated chatbot worker team."),
+            ],
+            "autoagent": [
+                ("coordinator", "Coordinate generated chatbot worker agents."),
+            ],
+        }
+        required_nodes = required_by_architecture.get(architecture_type, [])
+        if not required_nodes:
+            return nodes
+
+        existing_names = {
+            str(node.get("name") or "").strip().lower()
+            for node in nodes
+            if isinstance(node, dict)
+        }
+        prepended_nodes: list[Dict[str, Any]] = []
+        for name, purpose in required_nodes:
+            if name not in existing_names:
+                prepended_nodes.append({"name": name, "purpose": purpose})
+                existing_names.add(name)
+        return [*prepended_nodes, *nodes]
+
     @staticmethod
     def _normalize_inline_text(value: Any, fallback: str) -> str:
         """Normalize arbitrary text for safe single-line comments/messages."""
@@ -819,6 +858,17 @@ else:
             "RUN_INTERACTIVE_LOOP = False",
             "RUN_DEMO_TURNS = False",
             "CHARACTER_GENDER = None  # Set to 'male' or 'female' to skip the first-turn prompt.",
+            "ANACHRONISM_TERMS = (",
+            '    "smartphone",',
+            '    "internet",',
+            '    "television",',
+            '    "movie",',
+            '    "star wars",',
+            '    "computer",',
+            '    "airplane",',
+            '    "radio",',
+            '    "electricity",',
+            ")",
             "",
             "# Credentials",
             "# Prefer environment variables over hardcoded secrets in notebooks.",
@@ -965,16 +1015,6 @@ class WorkflowState(MessagesState):
     def _executable_tool_ids(workflow_design: Dict[str, Any] | None) -> set[str]:
         """Return tool IDs whose graph contract claims executable tool wiring."""
 
-        if not workflow_design:
-            return set()
-        graph_exports = workflow_design.get("graph_exports") or {}
-        schema = graph_exports.get("schema") if isinstance(graph_exports, dict) else {}
-        if not isinstance(schema, dict):
-            schema = {}
-        reachability = schema.get("tool_reachability") or workflow_design.get(
-            "tool_reachability",
-            [],
-        )
         executable_paths = {
             "tool_node",
             "manual_loop",
@@ -982,7 +1022,7 @@ class WorkflowState(MessagesState):
             "create_react_agent",
         }
         executable_ids: set[str] = set()
-        for entry in reachability or []:
+        for entry in NotebookComposer._tool_reachability_entries(workflow_design):
             if not isinstance(entry, dict):
                 continue
             execution_path = str(entry.get("execution_path") or "").strip()
@@ -997,6 +1037,24 @@ class WorkflowState(MessagesState):
             if tool_id:
                 executable_ids.add(tool_id)
         return executable_ids
+
+    @staticmethod
+    def _tool_reachability_entries(
+        workflow_design: Dict[str, Any] | None,
+    ) -> list[dict[str, Any]]:
+        """Return graph tool reachability entries when a workflow declares them."""
+
+        if not workflow_design:
+            return []
+        graph_exports = workflow_design.get("graph_exports") or {}
+        schema = graph_exports.get("schema") if isinstance(graph_exports, dict) else {}
+        if not isinstance(schema, dict):
+            schema = {}
+        entries = schema.get("tool_reachability") or workflow_design.get(
+            "tool_reachability",
+            [],
+        )
+        return [entry for entry in entries or [] if isinstance(entry, dict)]
 
     @staticmethod
     def _as_utility_helper_code(tool_code: str) -> str:
@@ -1028,82 +1086,85 @@ class WorkflowState(MessagesState):
     def _strip_tool_import_scaffold(source_lines: list[str]) -> list[str]:
         """Remove local @tool import guards when a generated tool becomes a helper."""
 
-        lines: list[str] = []
-        index = 0
-        while index < len(source_lines):
-            line = source_lines[index]
-            stripped = line.strip()
-            indent = len(line) - len(line.lstrip())
-            if stripped != "try:":
-                lines.append(line)
-                index += 1
+        source = "\n".join(source_lines)
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            return source_lines
+
+        remove_lines: set[int] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try):
                 continue
-
-            body_index = index + 1
-            while (
-                body_index < len(source_lines) and not source_lines[body_index].strip()
-            ):
-                body_index += 1
-            if body_index >= len(source_lines):
-                lines.append(line)
-                index += 1
-                continue
-
-            body_line = source_lines[body_index]
-            body_indent = len(body_line) - len(body_line.lstrip())
-            if (
-                body_indent <= indent
-                or body_line.strip() != "from langchain_core.tools import tool"
-            ):
-                lines.append(line)
-                index += 1
-                continue
-
-            except_index = body_index + 1
-            while (
-                except_index < len(source_lines)
-                and not source_lines[except_index].strip()
-            ):
-                except_index += 1
-            if except_index >= len(source_lines):
-                lines.append(line)
-                index += 1
-                continue
-
-            except_line = source_lines[except_index]
-            except_indent = len(except_line) - len(except_line.lstrip())
-            if except_indent != indent or not except_line.strip().startswith("except "):
-                lines.append(line)
-                index += 1
-                continue
-
-            end_index = except_index + 1
-            except_body: list[str] = []
-            while end_index < len(source_lines):
-                candidate = source_lines[end_index]
-                if candidate.strip():
-                    candidate_indent = len(candidate) - len(candidate.lstrip())
-                    if candidate_indent <= indent:
-                        break
-                except_body.append(candidate)
-                end_index += 1
-
             meaningful_body = [
-                body.strip()
-                for body in except_body
-                if body.strip() and not body.strip().startswith("#")
+                statement
+                for statement in node.body
+                if not (
+                    isinstance(statement, ast.Expr)
+                    and isinstance(statement.value, ast.Constant)
+                    and isinstance(statement.value.value, str)
+                )
             ]
-            if meaningful_body and all(
-                body.startswith("tool =") or body.startswith("pass")
-                for body in meaningful_body
-            ):
-                index = end_index
+            imports_tool = any(
+                isinstance(statement, ast.ImportFrom)
+                and statement.module == "langchain_core.tools"
+                and any(alias.name == "tool" for alias in statement.names)
+                for statement in meaningful_body
+            )
+            if not imports_tool:
                 continue
+            handlers_are_noop = bool(node.handlers) and all(
+                NotebookComposer._handler_only_suppresses_tool_import(handler)
+                for handler in node.handlers
+            )
+            if not handlers_are_noop:
+                continue
+            end_lineno = getattr(node, "end_lineno", node.lineno)
+            remove_lines.update(range(node.lineno, end_lineno + 1))
 
-            lines.append(line)
-            index += 1
+        if remove_lines:
+            return [
+                line
+                for lineno, line in enumerate(source_lines, start=1)
+                if lineno not in remove_lines
+            ]
+        return source_lines
 
-        return lines
+    @staticmethod
+    def _handler_only_suppresses_tool_import(handler: ast.ExceptHandler) -> bool:
+        """Return True for except handlers that only neutralize a missing tool import."""
+
+        meaningful_body = [
+            statement
+            for statement in handler.body
+            if not (
+                isinstance(statement, ast.Expr)
+                and isinstance(statement.value, ast.Constant)
+                and isinstance(statement.value.value, str)
+            )
+        ]
+        if not meaningful_body:
+            return False
+        for statement in meaningful_body:
+            if isinstance(statement, ast.Pass):
+                continue
+            if isinstance(statement, ast.Assign):
+                targets = [
+                    target.id
+                    for target in statement.targets
+                    if isinstance(target, ast.Name)
+                ]
+                if targets == ["tool"] and isinstance(statement.value, ast.Constant):
+                    continue
+            if (
+                isinstance(statement, ast.AnnAssign)
+                and isinstance(statement.target, ast.Name)
+                and statement.target.id == "tool"
+                and isinstance(statement.value, ast.Constant)
+            ):
+                continue
+            return False
+        return True
 
     async def _create_tool_cells(
         self,
@@ -1119,8 +1180,10 @@ class WorkflowState(MessagesState):
                 section="tools",
             )
         ]
-        executable_tool_ids = self._executable_tool_ids(workflow_design)
-        split_by_contract = workflow_design is not None
+        split_by_contract = bool(self._tool_reachability_entries(workflow_design))
+        executable_tool_ids = (
+            self._executable_tool_ids(workflow_design) if split_by_contract else set()
+        )
         executable_tools: list[Dict[str, Any]] = []
         utility_tools: list[Dict[str, Any]] = []
         for tool in tools:
@@ -1429,6 +1492,11 @@ Generate the complete Python function implementation."""
             workflow_design,
             notebook_plan,
         )
+        if is_chatbot_workflow:
+            nodes = self._with_required_pattern_scaffold_nodes(
+                nodes,
+                workflow_design,
+            )
         use_pattern_nodes = (
             architecture_type
             in [
@@ -1707,7 +1775,10 @@ Generate the complete Python function implementation."""
                 [
                     '    draft = str(state.get("draft_response") or state.get("final_response") or last_content)',
                     "    lowered_draft = draft.lower()",
-                    '    anachronism_terms = ("smartphone", "internet", "television", "movie", "star wars", "computer", "airplane")',
+                    '    configured_terms = globals().get("ANACHRONISM_TERMS", (',
+                    '        "smartphone", "internet", "television", "movie", "star wars", "computer", "airplane"',
+                    "    ))",
+                    "    anachronism_terms = tuple(str(term).lower() for term in configured_terms if str(term).strip())",
                     "    findings = [term for term in anachronism_terms if term in lowered_draft]",
                     '    revision_count = int(state.get("revision_count", 0))',
                     "    max_revisions = int(globals().get('MAX_ITERATIONS', 3) or 3)",

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -136,6 +136,26 @@ class NotebookComposer:
         "finish",
         "final",
     }
+    _CHATBOT_STATE_FIELDS: dict[str, str] = {
+        "draft_response": "Draft chatbot response awaiting verification.",
+        "safety_passed": "Whether safety and realism checks passed.",
+        "needs_revision": "Whether the draft requires a bounded revision.",
+        "historical_risk_notes": "Historical anachronism or realism findings.",
+        "realism_notes": "Persona realism notes from verifier nodes.",
+        "revision_instructions": "Concrete instructions for the reviser node.",
+        "revision_count": "Number of revision attempts for the current turn.",
+        "revision_history": "Attempt-by-attempt revision notes.",
+        "verification_passed": "Whether verifier checks accepted the draft.",
+        "final_response": "Accepted final chatbot response.",
+        "turn_count": "Number of completed chat turns for the thread.",
+        "memory_summary": "Short running conversation memory summary.",
+        "conversation_memory": "Thread-scoped multi-turn conversation memory.",
+        "persona_profile": "Selected persona profile for the active character.",
+        "persona": "Selected 18th-century commoner persona.",
+        "persona_choice": "Selected persona choice for the active character.",
+        "selected_gender": "Selected male or female character gender.",
+        "gender_pending": "Whether character selection is still pending.",
+    }
 
     def __init__(
         self,
@@ -200,6 +220,60 @@ class NotebookComposer:
                 continue
             extensions[str(field_name)] = str(description)
         return extensions
+
+    def _augment_chatbot_state_schema(
+        self,
+        workflow_design: Dict[str, Any],
+        notebook_plan: NotebookPlan | None = None,
+    ) -> Dict[str, Any]:
+        """Return state schema plus canonical chatbot/verifier memory fields."""
+
+        state_schema = dict(workflow_design.get("state_schema") or {})
+        if not self._is_chatbot_workflow(workflow_design, notebook_plan):
+            return state_schema
+        for field_name, description in self._CHATBOT_STATE_FIELDS.items():
+            state_schema.setdefault(field_name, description)
+        return state_schema
+
+    def _workflow_state_fields(
+        self,
+        workflow_design: Dict[str, Any],
+        notebook_plan: NotebookPlan | None = None,
+    ) -> set[str]:
+        """Return sanitized state field names expected by generated code."""
+
+        state_schema = self._augment_chatbot_state_schema(
+            workflow_design,
+            notebook_plan,
+        )
+        return {
+            self._safe_identifier(field_name, "field").lower()
+            for field_name in state_schema
+        }
+
+    def _nodes_for_generated_node_cells(
+        self,
+        workflow_design: Dict[str, Any],
+        nodes: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Return nodes that need explicit node-cell implementations."""
+
+        canonical_schema = self._canonical_graph_schema(workflow_design)
+        if not canonical_schema:
+            return nodes
+        architecture_type = str(
+            canonical_schema.get("architecture_type")
+            or workflow_design.get("architecture_type")
+            or ""
+        ).lower()
+        if architecture_type not in {"subagents", "autoagent", "hybrid"}:
+            return nodes
+        node_names = {
+            str(node.get("name") or "") for node in canonical_schema.get("nodes", [])
+        }
+        if "finish" not in node_names:
+            return nodes
+        return [node for node in nodes if str(node.get("name") or "") != "finish"]
 
     @staticmethod
     def _normalize_inline_text(value: Any, fallback: str) -> str:
@@ -463,6 +537,11 @@ class NotebookComposer:
             .lower()
         )
         workflow_design["architecture_type"] = architecture_type
+        if self._is_chatbot_workflow(workflow_design, notebook_plan):
+            workflow_design["state_schema"] = self._augment_chatbot_state_schema(
+                workflow_design,
+                notebook_plan,
+            )
         registration = self.registry.resolve(architecture_type)
         cells: List[CellSpec] = []
         for section_name in registration.section_order:
@@ -737,6 +816,8 @@ else:
             ),
             'THREAD_ID = "lnf-demo-thread"',
             "SHOW_UPDATES = False",
+            "RUN_INTERACTIVE_LOOP = False",
+            "RUN_DEMO_TURNS = False",
             "CHARACTER_GENDER = None  # Set to 'male' or 'female' to skip the first-turn prompt.",
             "",
             "# Credentials",
@@ -817,9 +898,10 @@ else:
         architecture_type = str(
             workflow_design.get("architecture_type", "router")
         ).lower()
+        augmented_state_schema = self._augment_chatbot_state_schema(workflow_design)
         state_schema = self._state_schema_extensions(
             architecture_type,
-            workflow_design.get("state_schema", {}),
+            augmented_state_schema,
         )
 
         # Use pattern library for known architectures
@@ -868,10 +950,166 @@ class WorkflowState(MessagesState):
             CellSpec(cell_type="code", content=state_content, section="state"),
         ]
 
+    @classmethod
+    def _tool_contract_ids(cls, tool: Dict[str, Any]) -> set[str]:
+        """Return normalized identifiers that may link a tool to graph reachability."""
+
+        identifiers = {
+            str(tool.get("tool_id") or "").strip(),
+            str(tool.get("name") or "").strip(),
+            cls._safe_identifier(tool.get("name") or "", "tool"),
+        }
+        return {identifier for identifier in identifiers if identifier}
+
+    @staticmethod
+    def _executable_tool_ids(workflow_design: Dict[str, Any] | None) -> set[str]:
+        """Return tool IDs whose graph contract claims executable tool wiring."""
+
+        if not workflow_design:
+            return set()
+        graph_exports = workflow_design.get("graph_exports") or {}
+        schema = graph_exports.get("schema") if isinstance(graph_exports, dict) else {}
+        if not isinstance(schema, dict):
+            schema = {}
+        reachability = schema.get("tool_reachability") or workflow_design.get(
+            "tool_reachability",
+            [],
+        )
+        executable_paths = {
+            "tool_node",
+            "manual_loop",
+            "create_agent",
+            "create_react_agent",
+        }
+        executable_ids: set[str] = set()
+        for entry in reachability or []:
+            if not isinstance(entry, dict):
+                continue
+            execution_path = str(entry.get("execution_path") or "").strip()
+            if execution_path not in executable_paths:
+                continue
+            tool_id = str(
+                entry.get("tool_id")
+                or entry.get("name")
+                or entry.get("tool_name")
+                or ""
+            ).strip()
+            if tool_id:
+                executable_ids.add(tool_id)
+        return executable_ids
+
+    @staticmethod
+    def _as_utility_helper_code(tool_code: str) -> str:
+        """Render generated helper code without claiming LangChain tool reachability."""
+
+        utility_notice = [
+            "# Utility helper only: this function is not registered as a LangChain tool.",
+            "# The graph contract did not declare an executable tool path for it.",
+        ]
+        source_lines = NotebookComposer._strip_tool_import_scaffold(
+            tool_code.splitlines()
+        )
+        lines: list[str] = []
+        if source_lines and source_lines[0].startswith("# WARNING:"):
+            lines.append(source_lines[0])
+            lines.extend(utility_notice)
+            source_lines = source_lines[1:]
+        else:
+            lines.extend(utility_notice)
+        for line in source_lines:
+            if line.strip() == "@tool":
+                continue
+            if line.strip() == "from langchain_core.tools import tool":
+                continue
+            lines.append(line)
+        return "\n".join(lines).strip() + "\n"
+
+    @staticmethod
+    def _strip_tool_import_scaffold(source_lines: list[str]) -> list[str]:
+        """Remove local @tool import guards when a generated tool becomes a helper."""
+
+        lines: list[str] = []
+        index = 0
+        while index < len(source_lines):
+            line = source_lines[index]
+            stripped = line.strip()
+            indent = len(line) - len(line.lstrip())
+            if stripped != "try:":
+                lines.append(line)
+                index += 1
+                continue
+
+            body_index = index + 1
+            while (
+                body_index < len(source_lines) and not source_lines[body_index].strip()
+            ):
+                body_index += 1
+            if body_index >= len(source_lines):
+                lines.append(line)
+                index += 1
+                continue
+
+            body_line = source_lines[body_index]
+            body_indent = len(body_line) - len(body_line.lstrip())
+            if (
+                body_indent <= indent
+                or body_line.strip() != "from langchain_core.tools import tool"
+            ):
+                lines.append(line)
+                index += 1
+                continue
+
+            except_index = body_index + 1
+            while (
+                except_index < len(source_lines)
+                and not source_lines[except_index].strip()
+            ):
+                except_index += 1
+            if except_index >= len(source_lines):
+                lines.append(line)
+                index += 1
+                continue
+
+            except_line = source_lines[except_index]
+            except_indent = len(except_line) - len(except_line.lstrip())
+            if except_indent != indent or not except_line.strip().startswith("except "):
+                lines.append(line)
+                index += 1
+                continue
+
+            end_index = except_index + 1
+            except_body: list[str] = []
+            while end_index < len(source_lines):
+                candidate = source_lines[end_index]
+                if candidate.strip():
+                    candidate_indent = len(candidate) - len(candidate.lstrip())
+                    if candidate_indent <= indent:
+                        break
+                except_body.append(candidate)
+                end_index += 1
+
+            meaningful_body = [
+                body.strip()
+                for body in except_body
+                if body.strip() and not body.strip().startswith("#")
+            ]
+            if meaningful_body and all(
+                body.startswith("tool =") or body.startswith("pass")
+                for body in meaningful_body
+            ):
+                index = end_index
+                continue
+
+            lines.append(line)
+            index += 1
+
+        return lines
+
     async def _create_tool_cells(
         self,
         tools: List[Dict[str, Any]],
         feedback: NotebookCompositionFeedback,
+        workflow_design: Dict[str, Any] | None = None,
     ) -> List[CellSpec]:
         """Create tool implementation cells with tracked fallback behavior."""
         cells = [
@@ -881,20 +1119,38 @@ class WorkflowState(MessagesState):
                 section="tools",
             )
         ]
+        executable_tool_ids = self._executable_tool_ids(workflow_design)
+        split_by_contract = workflow_design is not None
+        executable_tools: list[Dict[str, Any]] = []
+        utility_tools: list[Dict[str, Any]] = []
+        for tool in tools:
+            tool_ids = self._tool_contract_ids(tool)
+            if not split_by_contract or tool_ids & executable_tool_ids:
+                executable_tools.append(tool)
+            else:
+                utility_tools.append(tool)
 
         async def build_tool_code(
             tool: Dict[str, Any],
+            *,
+            executable: bool,
         ) -> tuple[str, NotebookCompositionFeedback]:
             tool_feedback = NotebookCompositionFeedback()
             tool_code = await self._generate_tool_implementation(
                 tool,
                 feedback=tool_feedback,
             )
+            if not executable:
+                tool_code = self._as_utility_helper_code(tool_code)
             return tool_code, tool_feedback
 
         tool_results = await self._execute_llm_tasks_in_order(
-            tools,
-            build_tool_code,
+            executable_tools,
+            lambda tool: build_tool_code(tool, executable=True),
+        )
+        utility_results = await self._execute_llm_tasks_in_order(
+            utility_tools,
+            lambda tool: build_tool_code(tool, executable=False),
         )
         tool_function_names: list[str] = []
         for tool_code, tool_feedback in tool_results:
@@ -903,6 +1159,9 @@ class WorkflowState(MessagesState):
             tool_function_names.append(
                 self._tool_function_name(tool_code, "unknown_tool")
             )
+        for tool_code, tool_feedback in utility_results:
+            self._merge_feedback(feedback, tool_feedback)
+            cells.append(CellSpec(cell_type="code", content=tool_code, section="tools"))
 
         tool_function_names = [
             name for name in dict.fromkeys(tool_function_names) if name
@@ -1141,13 +1400,16 @@ Generate the complete Python function implementation."""
         "kwargs": kwargs,
     }}'''
 
-        return header + "from langchain_core.tools import tool\n\n@tool\n" + implementation
+        return (
+            header + "from langchain_core.tools import tool\n\n@tool\n" + implementation
+        )
 
     async def _create_node_cells(
         self,
         workflow_design: Dict[str, Any],
         feedback: NotebookCompositionFeedback,
         tools: Optional[List[Dict[str, Any]]] = None,
+        notebook_plan: NotebookPlan | None = None,
     ) -> List[CellSpec]:
         """Create node implementation cells with tracked fallback behavior."""
         cells = [
@@ -1158,23 +1420,49 @@ Generate the complete Python function implementation."""
             )
         ]
 
-        nodes = workflow_design.get("nodes", [])
+        nodes = self._nodes_for_generated_node_cells(
+            workflow_design,
+            list(workflow_design.get("nodes", [])),
+        )
         architecture_type = workflow_design.get("architecture_type", "router")
+        is_chatbot_workflow = self._is_chatbot_workflow(
+            workflow_design,
+            notebook_plan,
+        )
+        use_pattern_nodes = (
+            architecture_type
+            in [
+                "router",
+                "subagents",
+                "hybrid",
+                "autoagent",
+                "deepagents",
+                "critique_loop",
+            ]
+            and not is_chatbot_workflow
+        )
 
         # Check if we should use pattern-based generation
-        if architecture_type in [
-            "router",
-            "subagents",
-            "hybrid",
-            "autoagent",
-            "deepagents",
-            "critique_loop",
-        ]:
+        if use_pattern_nodes:
             # Use pattern library for architecture-specific nodes
             pattern_cells = self._create_pattern_node_cells(
                 nodes, architecture_type, workflow_design, tools=tools
             )
             cells.extend(pattern_cells)
+        elif is_chatbot_workflow:
+            for node in nodes:
+                cells.append(
+                    CellSpec(
+                        cell_type="code",
+                        content=self._generate_node_fallback(
+                            node,
+                            workflow_design,
+                            reason="Chatbot workflows use deterministic contract nodes for memory, verifier, and revision semantics.",
+                            feedback=feedback,
+                        ),
+                        section="nodes",
+                    )
+                )
         else:
             # Use LLM for custom node generation
             async def build_node_code(
@@ -1348,6 +1636,7 @@ Generate the complete Python function implementation."""
             self._normalize_inline_text(node_purpose, safe_node_name)
         )
         lowered_node_context = f"{safe_node_name} {node_purpose}".lower()
+        state_fields = self._workflow_state_fields(workflow_design)
 
         update_lines = [
             "    updates: dict[str, object] = {}",
@@ -1356,6 +1645,12 @@ Generate the complete Python function implementation."""
             f'    node_summary = {node_name_literal} + " completed: " + (last_content or {node_purpose_literal})',
             '    updates["messages"] = messages + [HumanMessage(content=node_summary)]',
         ]
+        written_state_fields: set[str] = {"messages"}
+
+        def add_if_state_field(field_name: str, *lines: str) -> None:
+            if field_name in state_fields and field_name not in written_state_fields:
+                update_lines.extend(lines)
+                written_state_fields.add(field_name)
 
         if architecture_type == "router" and node_name == "router":
             update_lines.extend(
@@ -1410,11 +1705,34 @@ Generate the complete Python function implementation."""
         ):
             update_lines.extend(
                 [
-                    '    updates["needs_revision"] = False',
-                    '    updates["historical_risk_notes"] = ""',
-                    '    updates["realism_notes"] = ""',
-                    '    updates["revision_instructions"] = ""',
-                    '    updates["verification_passed"] = True',
+                    '    draft = str(state.get("draft_response") or state.get("final_response") or last_content)',
+                    "    lowered_draft = draft.lower()",
+                    '    anachronism_terms = ("smartphone", "internet", "television", "movie", "star wars", "computer", "airplane")',
+                    "    findings = [term for term in anachronism_terms if term in lowered_draft]",
+                    '    revision_count = int(state.get("revision_count", 0))',
+                    "    max_revisions = int(globals().get('MAX_ITERATIONS', 3) or 3)",
+                    "    needs_revision = bool(findings) and revision_count < max_revisions",
+                    "    safety_passed = not findings",
+                    "    historical_risk_notes = (",
+                    '        "Potential anachronisms detected: " + ", ".join(findings)',
+                    "        if findings",
+                    '        else "No obvious anachronisms detected."',
+                    "    )",
+                    '    realism_notes = "Checked response against persona and historical-realism constraints."',
+                    "    revision_instructions = (",
+                    '        "Revise the draft to avoid future knowledge or out-of-period references: " + ", ".join(findings)',
+                    "        if needs_revision",
+                    '        else ""',
+                    "    )",
+                    '    updates["safety_passed"] = safety_passed',
+                    '    updates["needs_revision"] = needs_revision',
+                    '    updates["historical_risk_notes"] = historical_risk_notes',
+                    '    updates["realism_notes"] = realism_notes',
+                    '    updates["revision_instructions"] = revision_instructions',
+                    '    updates["verification_passed"] = safety_passed',
+                    '    updates["route"] = "revise" if needs_revision else "accept"',
+                    "    if not needs_revision:",
+                    '        updates["final_response"] = draft',
                 ]
             )
         elif any(marker in lowered_node_context for marker in {"revise", "revision"}):
@@ -1422,11 +1740,151 @@ Generate the complete Python function implementation."""
                 [
                     '    revision_history = list(state.get("revision_history", []))',
                     '    instructions = state.get("revision_instructions", "")',
+                    '    draft = str(state.get("draft_response") or state.get("final_response") or last_content)',
+                    '    revision_count = int(state.get("revision_count", 0)) + 1',
+                    "    revised_draft = (",
+                    '        draft + "\\n\\nRevision note: " + str(instructions or "Keep the answer in-period and in persona.")',
+                    "    )",
                     '    revision_history.append(instructions or "No revision required.")',
+                    '    updates["draft_response"] = revised_draft',
+                    '    updates["revision_count"] = revision_count',
                     '    updates["revision_history"] = revision_history',
                     '    updates["needs_revision"] = False',
+                    '    updates["revision_instructions"] = ""',
+                    '    updates["route"] = "verify"',
                 ]
             )
+        elif any(
+            marker in lowered_node_context
+            for marker in {
+                "persona",
+                "character",
+                "chat",
+                "draft",
+                "response",
+                "commoner",
+                "memory",
+            }
+        ):
+            update_lines.extend(
+                [
+                    '    selected_gender = str(state.get("selected_gender") or state.get("character_sex") or "female").lower()',
+                    '    if selected_gender not in {"male", "female"}:',
+                    '        selected_gender = "female"',
+                    "    persona_profile = {",
+                    '        "gender": selected_gender,',
+                    '        "role": "18th-century conversational character",',
+                    '        "style": "period-appropriate, plainspoken, and historically grounded",',
+                    "    }",
+                    "    draft = node_summary",
+                ]
+            )
+            add_if_state_field(
+                "selected_gender", '    updates["selected_gender"] = selected_gender'
+            )
+            add_if_state_field(
+                "character_sex", '    updates["character_sex"] = selected_gender'
+            )
+            add_if_state_field(
+                "character_gender",
+                '    updates["character_gender"] = selected_gender',
+            )
+            add_if_state_field(
+                "persona_choice",
+                '    updates["persona_choice"] = f"{selected_gender}_commoner"',
+            )
+            add_if_state_field(
+                "persona",
+                '    updates["persona"] = f"{selected_gender}_commoner"',
+            )
+            add_if_state_field(
+                "persona_id",
+                '    updates["persona_id"] = f"{selected_gender}_commoner"',
+            )
+            add_if_state_field(
+                "gender_pending", '    updates["gender_pending"] = False'
+            )
+            add_if_state_field(
+                "persona_profile", '    updates["persona_profile"] = persona_profile'
+            )
+            add_if_state_field(
+                "character_profile",
+                '    updates["character_profile"] = persona_profile',
+            )
+            add_if_state_field(
+                "draft_response", '    updates["draft_response"] = draft'
+            )
+            add_if_state_field(
+                "final_response", '    updates["final_response"] = draft'
+            )
+            add_if_state_field(
+                "turn_count",
+                '    updates["turn_count"] = int(state.get("turn_count", 0)) + 1',
+            )
+            add_if_state_field(
+                "memory_summary",
+                '    updates["memory_summary"] = (',
+                '        str(state.get("memory_summary") or "").strip()',
+                '        + ("\\n" if state.get("memory_summary") else "")',
+                "        + node_summary",
+                "    )[-1200:]",
+            )
+            add_if_state_field(
+                "persona_memory",
+                '    updates["persona_memory"] = (',
+                '        str(state.get("persona_memory") or "").strip()',
+                '        + ("\\n" if state.get("persona_memory") else "")',
+                "        + node_summary",
+                "    )[-1200:]",
+            )
+            add_if_state_field(
+                "conversation_summary",
+                '    updates["conversation_summary"] = (',
+                '        str(state.get("conversation_summary") or "").strip()',
+                '        + ("\\n" if state.get("conversation_summary") else "")',
+                "        + node_summary",
+                "    )[-1200:]",
+            )
+            add_if_state_field(
+                "conversation_memory",
+                '    updates["conversation_memory"] = (',
+                '        str(state.get("conversation_memory") or "").strip()',
+                '        + ("\\n" if state.get("conversation_memory") else "")',
+                "        + node_summary",
+                "    )[-1200:]",
+            )
+            for field_name in sorted(state_fields - written_state_fields):
+                lowered_field = field_name.lower()
+                field_literal = json.dumps(field_name)
+                if "profile" in lowered_field:
+                    update_lines.append(
+                        f"    updates[{field_literal}] = persona_profile"
+                    )
+                    written_state_fields.add(field_name)
+                elif (
+                    "memories" in lowered_field
+                    or "conversation_history" in lowered_field
+                ):
+                    update_lines.append(
+                        f"    updates[{field_literal}] = [node_summary]"
+                    )
+                    written_state_fields.add(field_name)
+                elif "memory" in lowered_field:
+                    update_lines.extend(
+                        [
+                            f"    updates[{field_literal}] = (",
+                            f"        str(state.get({field_literal}) or '').strip()",
+                            f"        + ('\\n' if state.get({field_literal}) else '')",
+                            "        + node_summary",
+                            "    )[-1200:]",
+                        ]
+                    )
+                    written_state_fields.add(field_name)
+                elif "persona" in lowered_field:
+                    update_lines.append(
+                        f'    updates[{field_literal}] = f"{{selected_gender}}_commoner"'
+                    )
+                    written_state_fields.add(field_name)
         else:
             update_lines.extend(
                 [
@@ -1493,9 +1951,7 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
             if name in seen:
                 continue
             seen.add(name)
-            purpose = str(
-                node.get("purpose") or f"Handle {name} requests"
-            ).strip()
+            purpose = str(node.get("purpose") or f"Handle {name} requests").strip()
             specs.append((name, purpose or f"Handle {name} requests"))
 
         if specs:
@@ -2124,9 +2580,7 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
             if not isinstance(conditional_edge, dict):
                 continue
             source = str(
-                conditional_edge.get("from")
-                or conditional_edge.get("source")
-                or ""
+                conditional_edge.get("from") or conditional_edge.get("source") or ""
             ).strip()
             branches = conditional_edge.get("branches")
             if not source or not isinstance(branches, dict) or not branches:
@@ -2174,7 +2628,9 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
             ]
             if not path_entries:
                 continue
-            route_name = f"_route_from_{self._safe_node_identifier(source, 'node')}_{index}"
+            route_name = (
+                f"_route_from_{self._safe_node_identifier(source, 'node')}_{index}"
+            )
             path_map = "{" + ", ".join(path_entries) + "}"
             field_names = spec["field_names"]
             field_tuple = ", ".join(json.dumps(field) for field in field_names)
@@ -2206,7 +2662,9 @@ workflow.add_conditional_edges({json.dumps(source)}, {route_name}, {path_map})""
             and (node, "__end__") not in direct_edge_set
             and node not in route_sources_with_end
         ]
-        direct_edge_pairs.extend((node, "END") for node in terminal_nodes_without_explicit_end)
+        direct_edge_pairs.extend(
+            (node, "END") for node in terminal_nodes_without_explicit_end
+        )
 
         edge_additions = "\n".join(
             f"workflow.add_edge({_target_expr(source)}, {_target_expr(target)})"
@@ -2473,7 +2931,9 @@ graph = workflow.compile(checkpointer=memory)"""
         parts.extend(str(value) for value in workflow_design.values() if value)
         for node in workflow_design.get("nodes", []) or []:
             if isinstance(node, dict):
-                parts.extend(str(node.get(key, "")) for key in ("name", "purpose", "role"))
+                parts.extend(
+                    str(node.get(key, "")) for key in ("name", "purpose", "role")
+                )
         state_schema = workflow_design.get("state_schema", {})
         if isinstance(state_schema, dict):
             for key, value in state_schema.items():
@@ -2534,6 +2994,9 @@ graph = workflow.compile(checkpointer=memory)"""
             workflow_design,
             notebook_plan,
         )
+        state_fields_literal = repr(
+            sorted(self._workflow_state_fields(workflow_design, notebook_plan))
+        )
         first_turn_gender = (
             "    selected_gender = select_character_gender(CHARACTER_GENDER)\n"
             "    if first_message:\n"
@@ -2543,10 +3006,17 @@ graph = workflow.compile(checkpointer=memory)"""
             "        chat_once(first_message, thread_id=thread_id, show_updates=show_updates)"
         )
 
+        next_turn_gender = (
+            "        chat_once(user_input, thread_id=thread_id, character_gender=selected_gender, show_updates=show_updates)"
+            if requires_character
+            else "        chat_once(user_input, thread_id=thread_id, show_updates=show_updates)"
+        )
+
         return f'''from langchain_core.messages import BaseMessage, HumanMessage
 
 
 _MISSING = object()
+WORKFLOW_STATE_FIELDS = set({state_fields_literal})
 
 
 def _find_nested_key(value, target_key: str, default=_MISSING):
@@ -2588,6 +3058,11 @@ def _extract_final_output(state: dict) -> str:
     return ""
 
 
+def _set_state_field(payload: dict, field_name: str, value) -> None:
+    if field_name in WORKFLOW_STATE_FIELDS:
+        payload[field_name] = value
+
+
 def select_character_gender(value: str | None = CHARACTER_GENDER) -> str:
     """Resolve the requested character gender before the first chat turn."""
     if isinstance(value, str):
@@ -2603,10 +3078,34 @@ def select_character_gender(value: str | None = CHARACTER_GENDER) -> str:
 
 def _chat_input(user_text: str, character_gender: str | None = None) -> dict:
     payload: dict[str, object] = {{"messages": [HumanMessage(content=user_text)]}}
+    _set_state_field(payload, "user_message", user_text)
+    _set_state_field(payload, "user_request", user_text)
     if character_gender:
-        payload["selected_gender"] = character_gender
-        payload["gender_pending"] = False
-        payload["persona_profile"] = f"A helpful {{character_gender}} assistant"
+        persona_profile = {{
+            "gender": character_gender,
+            "role": "18th-century conversational character",
+            "style": "period-appropriate, plainspoken, and historically grounded",
+        }}
+        if "selected_gender" in WORKFLOW_STATE_FIELDS:
+            payload["selected_gender"] = character_gender
+        if "character_sex" in WORKFLOW_STATE_FIELDS:
+            payload["character_sex"] = character_gender
+        if "character_gender" in WORKFLOW_STATE_FIELDS:
+            payload["character_gender"] = character_gender
+        if "persona_choice" in WORKFLOW_STATE_FIELDS:
+            payload["persona_choice"] = f"{{character_gender}}_commoner"
+        if "persona" in WORKFLOW_STATE_FIELDS:
+            payload["persona"] = f"{{character_gender}}_commoner"
+        if "persona_id" in WORKFLOW_STATE_FIELDS:
+            payload["persona_id"] = f"{{character_gender}}_commoner"
+        if "gender_pending" in WORKFLOW_STATE_FIELDS:
+            payload["gender_pending"] = False
+        if "needs_character_selection" in WORKFLOW_STATE_FIELDS:
+            payload["needs_character_selection"] = False
+        if "persona_profile" in WORKFLOW_STATE_FIELDS:
+            payload["persona_profile"] = persona_profile
+        if "character_profile" in WORKFLOW_STATE_FIELDS:
+            payload["character_profile"] = persona_profile
     return payload
 
 
@@ -2645,10 +3144,44 @@ def run_chat_loop(
         user_input = input("\\nEnter next message (or type 'quit' to exit): ").strip()
         if user_input.lower() in {{"quit", "exit", "q"}}:
             break
-        chat_once(user_input, thread_id=thread_id, show_updates=show_updates)
+{next_turn_gender}
 
 
-run_chat_loop()'''
+def run_demo_turns(
+    turns: list[str] | None = None,
+    *,
+    thread_id: str = THREAD_ID,
+    character_gender: str | None = None,
+    show_updates: bool = SHOW_UPDATES,
+) -> list[dict]:
+    """Run repeatable same-thread turns without blocking for input."""
+    selected_gender = (
+        select_character_gender(character_gender or CHARACTER_GENDER)
+        if {requires_character!r}
+        else None
+    )
+    states: list[dict] = []
+    for user_text in turns or [
+        "Good day. Who are you?",
+        "What would you think of a smartphone?",
+    ]:
+        states.append(
+            chat_once(
+                user_text,
+                thread_id=thread_id,
+                character_gender=selected_gender,
+                show_updates=show_updates,
+            )
+        )
+    return states
+
+
+if RUN_INTERACTIVE_LOOP:
+    run_chat_loop()
+elif RUN_DEMO_TURNS:
+    run_demo_turns()
+else:
+    print("Chat helpers ready. Call chat_once(...) or run_chat_loop() when ready.")'''
 
     def _create_execution_cells(
         self,
@@ -2779,7 +3312,9 @@ print(final_state)"""
         try:
             ast.parse(content)
         except SyntaxError as exc:
-            location = f"line {exc.lineno}" if exc.lineno is not None else "unknown line"
+            location = (
+                f"line {exc.lineno}" if exc.lineno is not None else "unknown line"
+            )
             return f"{exc.msg} at {location}"
         return None
 

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -46,6 +46,7 @@ from langgraph_system_generator.notebook.runtime import (
 from langgraph_system_generator.qa import NotebookRepairAgent, NotebookValidator
 from langgraph_system_generator.qa.summary import (
     build_qa_summary,
+    build_tool_contract_summary,
     serialize_qa_report,
 )
 from langgraph_system_generator.rag.embeddings import VectorStoreManager
@@ -1116,6 +1117,7 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
     architecture_feedback = state.get("architecture_feedback")
     graph_design_feedback = state.get("graph_design_feedback")
     graph_exports = state.get("graph_exports")
+    tools_plan = state.get("tools_plan")
     tool_planning_feedback = state.get("tool_planning_feedback")
     notebook_composition_feedback = state.get("notebook_composition_feedback")
     notebook_dependency_plan = state.get("notebook_dependency_plan")
@@ -1161,6 +1163,11 @@ async def package_outputs_node(state: GeneratorState) -> Dict[str, Any]:
                 tool_planning_feedback
                 or ToolPlanningFeedback(available_tool_ids=[]).model_dump()
             )
+        ),
+        "tool_contract_summary": build_tool_contract_summary(
+            tools_plan,
+            graph_exports,
+            qa_reports,
         ),
         "generation_context_pack": (
             generation_context_pack.model_dump()

--- a/src/langgraph_system_generator/generator/notebook_composer_registry.py
+++ b/src/langgraph_system_generator/generator/notebook_composer_registry.py
@@ -17,7 +17,9 @@ from langgraph_system_generator.generator.state import (
 from langgraph_system_generator.utils.config import settings
 
 NotebookSectionResult = list[CellSpec] | Awaitable[list[CellSpec]]
-NotebookSectionBuilder = Callable[[Any, "NotebookComposerContext"], NotebookSectionResult]
+NotebookSectionBuilder = Callable[
+    [Any, "NotebookComposerContext"], NotebookSectionResult
+]
 PluginHook = Callable[["NotebookComposerRegistry"], None]
 
 
@@ -52,7 +54,9 @@ def _normalize_string_list(values: Sequence[str] | None) -> list[str]:
     return normalized_values
 
 
-def _normalize_hook_mapping(values: Mapping[str, Sequence[str]] | None) -> dict[str, list[str]]:
+def _normalize_hook_mapping(
+    values: Mapping[str, Sequence[str]] | None,
+) -> dict[str, list[str]]:
     """Return normalized per-section hook mappings."""
 
     normalized: dict[str, list[str]] = {}
@@ -123,7 +127,16 @@ class NotebookComposerRegistry:
     def __init__(self, *, default_section_order: Sequence[str] | None = None):
         self.default_section_order = _normalize_string_list(
             default_section_order
-            or ["intro", "install", "config", "state", "tools", "nodes", "graph", "execution"]
+            or [
+                "intro",
+                "install",
+                "config",
+                "state",
+                "tools",
+                "nodes",
+                "graph",
+                "execution",
+            ]
         )
         self._builders: dict[str, NotebookSectionBuilder] = {}
         self._architectures: dict[str, NotebookComposerArchitectureRegistration] = {}
@@ -131,7 +144,9 @@ class NotebookComposerRegistry:
     def clone(self) -> "NotebookComposerRegistry":
         """Return a shallow clone suitable for per-composer customization."""
 
-        cloned = NotebookComposerRegistry(default_section_order=self.default_section_order)
+        cloned = NotebookComposerRegistry(
+            default_section_order=self.default_section_order
+        )
         cloned._builders = dict(self._builders)
         cloned._architectures = {
             architecture_id: NotebookComposerArchitectureRegistration(
@@ -158,7 +173,9 @@ class NotebookComposerRegistry:
     ) -> None:
         """Register or replace a named section builder."""
 
-        normalized_name = _normalize_builder_name(builder_name, field_name="builder_name")
+        normalized_name = _normalize_builder_name(
+            builder_name, field_name="builder_name"
+        )
         self._builders[normalized_name] = builder
 
     def register(
@@ -268,7 +285,9 @@ class NotebookComposerRegistry:
         return builders
 
 
-def _build_intro_section(composer: Any, context: NotebookComposerContext) -> list[CellSpec]:
+def _build_intro_section(
+    composer: Any, context: NotebookComposerContext
+) -> list[CellSpec]:
     return composer._create_intro_cells(
         context.notebook_plan,
         context.architecture.get("justification"),
@@ -288,7 +307,9 @@ def _build_config_section(
     return composer._create_config_cells(context.dependency_plan, context.feedback)
 
 
-def _build_state_section(composer: Any, context: NotebookComposerContext) -> list[CellSpec]:
+def _build_state_section(
+    composer: Any, context: NotebookComposerContext
+) -> list[CellSpec]:
     return composer._create_state_cells(context.workflow_design)
 
 
@@ -306,7 +327,11 @@ async def _build_tools_section(
     ]
     if not runnable_tools:
         return warning_cells
-    tool_cells = await composer._create_tool_cells(runnable_tools, context.feedback)
+    tool_cells = await composer._create_tool_cells(
+        runnable_tools,
+        context.feedback,
+        workflow_design=context.workflow_design,
+    )
     return [*warning_cells, *tool_cells]
 
 
@@ -318,6 +343,7 @@ async def _build_nodes_section(
         context.workflow_design,
         context.feedback,
         tools=context.tools,
+        notebook_plan=context.notebook_plan,
     )
 
 
@@ -325,6 +351,13 @@ async def _build_router_nodes_section(
     composer: Any,
     context: NotebookComposerContext,
 ) -> list[CellSpec]:
+    if composer._is_chatbot_workflow(context.workflow_design, context.notebook_plan):
+        return await composer._create_node_cells(
+            context.workflow_design,
+            context.feedback,
+            tools=context.tools,
+            notebook_plan=context.notebook_plan,
+        )
     return composer._create_pattern_node_cells(
         context.workflow_design.get("nodes", []),
         "router",
@@ -337,6 +370,13 @@ async def _build_subagents_nodes_section(
     composer: Any,
     context: NotebookComposerContext,
 ) -> list[CellSpec]:
+    if composer._is_chatbot_workflow(context.workflow_design, context.notebook_plan):
+        return await composer._create_node_cells(
+            context.workflow_design,
+            context.feedback,
+            tools=context.tools,
+            notebook_plan=context.notebook_plan,
+        )
     return composer._create_pattern_node_cells(
         context.workflow_design.get("nodes", []),
         "subagents",
@@ -349,6 +389,13 @@ async def _build_hybrid_nodes_section(
     composer: Any,
     context: NotebookComposerContext,
 ) -> list[CellSpec]:
+    if composer._is_chatbot_workflow(context.workflow_design, context.notebook_plan):
+        return await composer._create_node_cells(
+            context.workflow_design,
+            context.feedback,
+            tools=context.tools,
+            notebook_plan=context.notebook_plan,
+        )
     return composer._create_pattern_node_cells(
         context.workflow_design.get("nodes", []),
         "hybrid",
@@ -361,6 +408,13 @@ async def _build_autoagent_nodes_section(
     composer: Any,
     context: NotebookComposerContext,
 ) -> list[CellSpec]:
+    if composer._is_chatbot_workflow(context.workflow_design, context.notebook_plan):
+        return await composer._create_node_cells(
+            context.workflow_design,
+            context.feedback,
+            tools=context.tools,
+            notebook_plan=context.notebook_plan,
+        )
     return composer._create_pattern_node_cells(
         context.workflow_design.get("nodes", []),
         "autoagent",
@@ -385,6 +439,13 @@ async def _build_critique_loop_nodes_section(
     composer: Any,
     context: NotebookComposerContext,
 ) -> list[CellSpec]:
+    if composer._is_chatbot_workflow(context.workflow_design, context.notebook_plan):
+        return await composer._create_node_cells(
+            context.workflow_design,
+            context.feedback,
+            tools=context.tools,
+            notebook_plan=context.notebook_plan,
+        )
     return composer._create_pattern_node_cells(
         context.workflow_design.get("nodes", []),
         "critique_loop",
@@ -393,7 +454,9 @@ async def _build_critique_loop_nodes_section(
     )
 
 
-def _build_graph_section(composer: Any, context: NotebookComposerContext) -> list[CellSpec]:
+def _build_graph_section(
+    composer: Any, context: NotebookComposerContext
+) -> list[CellSpec]:
     return composer._create_graph_cells(
         context.workflow_design,
         context.feedback.resolved_max_iterations or 1,

--- a/src/langgraph_system_generator/patterns/utils.py
+++ b/src/langgraph_system_generator/patterns/utils.py
@@ -90,6 +90,9 @@ def infer_state_field_type(field_name: str, description: str = "") -> str:
     if lowered_name in list_markers or lowered_name.endswith(list_suffixes):
         return "Annotated[List[str], operator.add]"
 
+    if lowered_name.endswith(("_passed", "_pending", "_complete")):
+        return "bool"
+
     dict_markers = {
         "results",
         "task_results",
@@ -98,6 +101,7 @@ def infer_state_field_type(field_name: str, description: str = "") -> str:
         "metadata",
         "payload",
         "context",
+        "profile",
         "profile_data",
         "tool_outputs",
     }
@@ -120,9 +124,15 @@ def infer_state_field_type(field_name: str, description: str = "") -> str:
         "has_",
         "is_",
     }
-    if any(lowered_name == marker or lowered_name.startswith(marker) for marker in bool_markers):
+    if any(
+        lowered_name == marker or lowered_name.startswith(marker)
+        for marker in bool_markers
+    ):
         return "bool"
-    if any(lowered_name.endswith(f"_{marker}") for marker in {"passed", "pending", "complete"}):
+    if any(
+        lowered_name.endswith(f"_{marker}")
+        for marker in {"passed", "pending", "complete"}
+    ):
         return "bool"
 
     int_markers = {

--- a/src/langgraph_system_generator/qa/summary.py
+++ b/src/langgraph_system_generator/qa/summary.py
@@ -134,6 +134,7 @@ def build_tool_contract_summary(
     executable_tools: list[dict[str, Any]] = []
     utility_helpers: list[dict[str, Any]] = []
     unsupported_tools: list[dict[str, Any]] = []
+    unclassified_tools: list[dict[str, Any]] = []
     summarized_ids: set[str] = set()
 
     for tool in planned_tools:
@@ -159,6 +160,9 @@ def build_tool_contract_summary(
             executable_tools.append(summary_entry)
         elif execution_path in utility_paths:
             utility_helpers.append(summary_entry)
+        else:
+            summary_entry["status"] = "missing_contract"
+            unclassified_tools.append(summary_entry)
         if tool_id:
             summarized_ids.add(tool_id)
 
@@ -170,11 +174,6 @@ def build_tool_contract_summary(
             or reachability_entry.get("path")
             or ""
         ).strip()
-        if (
-            execution_path not in executable_paths
-            and execution_path not in utility_paths
-        ):
-            continue
         summary_entry = {
             "tool_id": tool_id,
             "name": reachability_entry.get("name") or tool_id,
@@ -185,8 +184,11 @@ def build_tool_contract_summary(
         }
         if execution_path in executable_paths:
             executable_tools.append(summary_entry)
-        else:
+        elif execution_path in utility_paths:
             utility_helpers.append(summary_entry)
+        else:
+            summary_entry["status"] = "unrecognized_execution_path"
+            unclassified_tools.append(summary_entry)
 
     qa_evidence = _tool_contract_qa_evidence(qa_reports or [])
     return {
@@ -196,11 +198,13 @@ def build_tool_contract_summary(
             "executable": len(executable_tools),
             "utility": len(utility_helpers),
             "unsupported": len(unsupported_tools),
+            "unclassified": len(unclassified_tools),
         },
         "planned_tools": planned_tools,
         "executable_tools": executable_tools,
         "utility_helpers": utility_helpers,
         "unsupported_tools": unsupported_tools,
+        "unclassified_tools": unclassified_tools,
         "qa_evidence": qa_evidence,
         "source_precedence": [
             "graph_exports.schema.tool_reachability",

--- a/src/langgraph_system_generator/qa/summary.py
+++ b/src/langgraph_system_generator/qa/summary.py
@@ -101,6 +101,179 @@ def build_qa_summary(reports: Iterable[QAReport | dict[str, Any]]) -> dict[str, 
     }
 
 
+def build_tool_contract_summary(
+    tools_plan: Iterable[Any] | None,
+    graph_exports: Any | None = None,
+    qa_reports: Iterable[QAReport | dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Summarize planned tools and their honest execution contract."""
+
+    planned_tools = [_tool_payload(tool) for tool in (tools_plan or [])]
+    reachability = _tool_reachability_entries(graph_exports)
+    reachability_by_id = {
+        str(
+            entry.get("tool_id") or entry.get("name") or entry.get("tool_name") or ""
+        ): entry
+        for entry in reachability
+        if entry.get("tool_id") or entry.get("name") or entry.get("tool_name")
+    }
+    executable_paths = {
+        "tool_node",
+        "manual_loop",
+        "create_agent",
+        "create_react_agent",
+    }
+    utility_paths = {
+        "demo_only",
+        "deterministic_node",
+        "omitted",
+        "utility",
+        "local_helper",
+    }
+
+    executable_tools: list[dict[str, Any]] = []
+    utility_helpers: list[dict[str, Any]] = []
+    unsupported_tools: list[dict[str, Any]] = []
+    summarized_ids: set[str] = set()
+
+    for tool in planned_tools:
+        tool_id = str(tool.get("tool_id") or tool.get("name") or "").strip()
+        status = str(tool.get("status") or "ready").strip().lower()
+        reachability_entry = reachability_by_id.get(tool_id, {})
+        execution_path = str(
+            reachability_entry.get("execution_path")
+            or reachability_entry.get("path")
+            or ""
+        ).strip()
+        summary_entry = {
+            "tool_id": tool_id,
+            "name": tool.get("name") or tool_id,
+            "status": status or "ready",
+            "execution_path": execution_path or None,
+            "node": reachability_entry.get("node"),
+            "rationale": reachability_entry.get("rationale") or "",
+        }
+        if status == "unsupported":
+            unsupported_tools.append(summary_entry)
+        elif execution_path in executable_paths:
+            executable_tools.append(summary_entry)
+        elif execution_path in utility_paths:
+            utility_helpers.append(summary_entry)
+        if tool_id:
+            summarized_ids.add(tool_id)
+
+    for tool_id, reachability_entry in reachability_by_id.items():
+        if tool_id in summarized_ids:
+            continue
+        execution_path = str(
+            reachability_entry.get("execution_path")
+            or reachability_entry.get("path")
+            or ""
+        ).strip()
+        if (
+            execution_path not in executable_paths
+            and execution_path not in utility_paths
+        ):
+            continue
+        summary_entry = {
+            "tool_id": tool_id,
+            "name": reachability_entry.get("name") or tool_id,
+            "status": "planned_by_graph",
+            "execution_path": execution_path or None,
+            "node": reachability_entry.get("node"),
+            "rationale": reachability_entry.get("rationale") or "",
+        }
+        if execution_path in executable_paths:
+            executable_tools.append(summary_entry)
+        else:
+            utility_helpers.append(summary_entry)
+
+    qa_evidence = _tool_contract_qa_evidence(qa_reports or [])
+    return {
+        "version": 1,
+        "counts": {
+            "planned": len(planned_tools),
+            "executable": len(executable_tools),
+            "utility": len(utility_helpers),
+            "unsupported": len(unsupported_tools),
+        },
+        "planned_tools": planned_tools,
+        "executable_tools": executable_tools,
+        "utility_helpers": utility_helpers,
+        "unsupported_tools": unsupported_tools,
+        "qa_evidence": qa_evidence,
+        "source_precedence": [
+            "graph_exports.schema.tool_reachability",
+            "tools_plan",
+            "qa_reports.tool_reachability",
+        ],
+    }
+
+
+def _tool_payload(tool: Any) -> dict[str, Any]:
+    """Return a normalized manifest-safe tool payload."""
+
+    if hasattr(tool, "model_dump"):
+        payload = tool.model_dump()
+    elif isinstance(tool, dict):
+        payload = dict(tool)
+    else:
+        payload = {
+            "tool_id": str(getattr(tool, "tool_id", "")),
+            "name": str(getattr(tool, "name", "")),
+            "status": str(getattr(tool, "status", "ready")),
+        }
+    payload.setdefault("status", "ready")
+    return payload
+
+
+def _tool_reachability_entries(graph_exports: Any | None) -> list[dict[str, Any]]:
+    """Extract graph tool reachability metadata from dict or Pydantic exports."""
+
+    if graph_exports is None:
+        return []
+    if hasattr(graph_exports, "model_dump"):
+        payload = graph_exports.model_dump(by_alias=True)
+    elif isinstance(graph_exports, dict):
+        payload = graph_exports
+    else:
+        return []
+
+    schema = payload.get("schema") or payload.get("schema_payload") or {}
+    if hasattr(schema, "model_dump"):
+        schema = schema.model_dump()
+    if not isinstance(schema, dict):
+        return []
+    entries = schema.get("tool_reachability") or payload.get("tool_reachability") or []
+    normalized_entries: list[dict[str, Any]] = []
+    for entry in entries:
+        if hasattr(entry, "model_dump"):
+            normalized_entries.append(entry.model_dump())
+        elif isinstance(entry, dict):
+            normalized_entries.append(dict(entry))
+    return normalized_entries
+
+
+def _tool_contract_qa_evidence(
+    qa_reports: Iterable[QAReport | dict[str, Any]],
+) -> dict[str, Any]:
+    """Collect tool-reachability QA evidence without overriding planner truth."""
+
+    reachable_tools: list[str] = []
+    advisories: list[dict[str, Any]] = []
+    for report in (serialize_qa_report(item) for item in qa_reports):
+        if report.get("rule_id") != "tool_reachability":
+            continue
+        evidence = report.get("evidence") or {}
+        for tool_name in evidence.get("reachable_tools") or []:
+            if tool_name not in reachable_tools:
+                reachable_tools.append(tool_name)
+        for advisory in evidence.get("advisories") or []:
+            if isinstance(advisory, dict):
+                advisories.append(dict(advisory))
+    return {"reachable_tools": reachable_tools, "advisories": advisories}
+
+
 def _build_validation_scope(reports: list[dict[str, Any]]) -> dict[str, list[str]]:
     """Describe what QA reports prove and what remains outside their scope."""
 

--- a/src/langgraph_system_generator/qa/validators.py
+++ b/src/langgraph_system_generator/qa/validators.py
@@ -1081,9 +1081,7 @@ class LangGraphTopologyRule(QAValidationRule):
             if not source or not target:
                 continue
             if not edge.get("conditional"):
-                edge_pairs[(source, target)] = (
-                    edge_pairs.get((source, target), 0) + 1
-                )
+                edge_pairs[(source, target)] = edge_pairs.get((source, target), 0) + 1
             if (
                 source == target
                 and not _is_graph_boundary_symbol(target)
@@ -1592,6 +1590,20 @@ class StateReducerSemanticsRule(QAValidationRule):
                         for key in _dict_string_keys(keyword.value):
                             writer_map.setdefault(key, set()).add(function_name)
 
+        def _record_update_keys(function_name: str, keys: set[str]) -> None:
+            for key in keys:
+                writer_map.setdefault(key, set()).add(function_name)
+
+        def _subscript_string_key(target: ast.AST) -> tuple[str, str] | None:
+            if not isinstance(target, ast.Subscript) or not isinstance(
+                target.value, ast.Name
+            ):
+                return None
+            key = _literal_string(target.slice)
+            if not key:
+                return None
+            return target.value.id, key
+
         def _registered_node_function_names() -> set[str]:
             node_functions: set[str] = set()
             for call in ast.walk(tree):
@@ -1618,7 +1630,27 @@ class StateReducerSemanticsRule(QAValidationRule):
                 continue
             has_state_arg = bool(node.args.args and node.args.args[0].arg == "state")
             is_registered_node = node.name in registered_node_functions
+            local_update_keys: dict[str, set[str]] = {}
             for statement in ast.walk(node):
+                if isinstance(statement, ast.Assign):
+                    for target in statement.targets:
+                        if isinstance(target, ast.Name) and isinstance(
+                            statement.value, (ast.Dict, ast.Call)
+                        ):
+                            local_update_keys.setdefault(target.id, set())
+                        subscript_key = _subscript_string_key(target)
+                        if subscript_key:
+                            variable_name, key = subscript_key
+                            local_update_keys.setdefault(variable_name, set()).add(key)
+                elif isinstance(statement, ast.AnnAssign):
+                    if isinstance(statement.target, ast.Name) and isinstance(
+                        statement.value, (ast.Dict, ast.Call)
+                    ):
+                        local_update_keys.setdefault(statement.target.id, set())
+                    subscript_key = _subscript_string_key(statement.target)
+                    if subscript_key:
+                        variable_name, key = subscript_key
+                        local_update_keys.setdefault(variable_name, set()).add(key)
                 if isinstance(statement, ast.Return):
                     if (
                         is_registered_node
@@ -1640,6 +1672,22 @@ class StateReducerSemanticsRule(QAValidationRule):
                         )
                     if not registered_node_functions or is_registered_node:
                         _record_return_keys(node.name, statement.value)
+                        if isinstance(statement.value, ast.Name):
+                            _record_update_keys(
+                                node.name,
+                                local_update_keys.get(statement.value.id, set()),
+                            )
+                        if isinstance(statement.value, ast.Call) and _call_name(
+                            statement.value.func
+                        ).endswith("Command"):
+                            for keyword in statement.value.keywords:
+                                if keyword.arg == "update" and isinstance(
+                                    keyword.value, ast.Name
+                                ):
+                                    _record_update_keys(
+                                        node.name,
+                                        local_update_keys.get(keyword.value.id, set()),
+                                    )
 
         for field_name, writers in sorted(writer_map.items()):
             field = state_fields.get(field_name)
@@ -1662,6 +1710,32 @@ class StateReducerSemanticsRule(QAValidationRule):
                         "writers": sorted(writers),
                     }
                 )
+
+        memory_field_markers = {
+            "memory",
+            "memories",
+            "persona",
+            "profile",
+            "conversation_history",
+            "turn_count",
+        }
+        for field_name, field in sorted(state_fields.items()):
+            lowered_name = field_name.lower()
+            if field_name == "messages" or field_name in writer_map:
+                continue
+            if not any(marker in lowered_name for marker in memory_field_markers):
+                continue
+            issues.append(
+                {
+                    "code": "declared_memory_field_without_writer",
+                    "message": (
+                        f"State field '{field_name}' is declared for memory/persona "
+                        "behavior but no registered node writes it."
+                    ),
+                    "field": field_name,
+                    **context.resolve_line(field.get("line")),
+                }
+            )
 
         if issues:
             return self.failed_report(
@@ -1731,14 +1805,19 @@ class ToolReachabilityRule(QAValidationRule):
         reachable_tools: set[str] = set()
         bound_tools: set[str] = set()
         list_assignments: dict[str, set[str]] = {}
+        tool_node_tools: dict[str, set[str]] = {}
+        registered_tool_node_vars: set[str] = set()
+        unwired_tool_node_tools: set[str] = set()
         advisories: list[dict[str, object]] = []
 
         for node in ast.walk(tree):
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 decorators = {
-                    _call_name(decorator.func)
-                    if isinstance(decorator, ast.Call)
-                    else _call_name(decorator)
+                    (
+                        _call_name(decorator.func)
+                        if isinstance(decorator, ast.Call)
+                        else _call_name(decorator)
+                    )
                     for decorator in node.decorator_list
                 }
                 docstring = ast.get_docstring(node) or ""
@@ -1821,8 +1900,68 @@ class ToolReachabilityRule(QAValidationRule):
 
         declared_tool_names: set[str] = set()
         for assignment_name, assigned_names in list_assignments.items():
-            if assignment_name.lower() in {"tool", "tools", "tool_list", "available_tools"}:
+            if assignment_name.lower() in {
+                "tool",
+                "tools",
+                "tool_list",
+                "available_tools",
+            }:
                 declared_tool_names.update(assigned_names)
+
+        def _tool_names_from_value(value: ast.AST | None) -> set[str]:
+            if isinstance(value, ast.Name):
+                return set(list_assignments.get(value.id, set()))
+            if isinstance(value, ast.List):
+                return {
+                    name
+                    for name in (_call_name(element) for element in value.elts)
+                    if name
+                }
+            return set()
+
+        def _tool_names_from_tool_node_call(call: ast.Call) -> set[str]:
+            names: set[str] = set()
+            for argument in call.args[:1]:
+                names.update(_tool_names_from_value(argument))
+            tools_keyword = _keyword_value(call, "tools")
+            if tools_keyword is not None:
+                names.update(_tool_names_from_value(tools_keyword))
+            return names
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not (
+                isinstance(node.value, ast.Call)
+                and _call_name(node.value.func).endswith("ToolNode")
+            ):
+                continue
+            tool_names = _tool_names_from_tool_node_call(node.value)
+            for target in node.targets:
+                for target_name in _target_names(target):
+                    tool_node_tools[target_name] = set(tool_names)
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not _call_name(node.func).endswith(".add_node"):
+                continue
+            node_callable = node.args[1] if len(node.args) >= 2 else None
+            if (
+                isinstance(node_callable, ast.Name)
+                and node_callable.id in tool_node_tools
+            ):
+                registered_tool_node_vars.add(node_callable.id)
+            elif isinstance(node_callable, ast.Call) and _call_name(
+                node_callable.func
+            ).endswith("ToolNode"):
+                reachable_tools.update(_tool_names_from_tool_node_call(node_callable))
+
+        for variable_name, tool_names in tool_node_tools.items():
+            if variable_name in registered_tool_node_vars:
+                reachable_tools.update(tool_names)
+            else:
+                unwired_tool_node_tools.update(tool_names)
 
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
@@ -1864,10 +2003,7 @@ class ToolReachabilityRule(QAValidationRule):
                     }
                 )
             elif call_name.endswith("ToolNode"):
-                tool_args.extend(node.args[:1])
-                tools_keyword = _keyword_value(node, "tools")
-                if tools_keyword is not None:
-                    tool_args.append(tools_keyword)
+                continue
             elif call_name in tool_functions:
                 reachable_tools.add(call_name)
             elif call_name.rsplit(".", 1)[0] in tool_functions and call_name.endswith(
@@ -1905,17 +2041,25 @@ class ToolReachabilityRule(QAValidationRule):
         for tool_name in sorted(tool_functions):
             if tool_name not in reachable_tools:
                 code = (
-                    "bound_tool_without_executor"
-                    if tool_name in bound_tools
-                    else "unreachable_tool"
+                    "unwired_tool_node_executor"
+                    if tool_name in unwired_tool_node_tools
+                    else (
+                        "bound_tool_without_executor"
+                        if tool_name in bound_tools
+                        else "unreachable_tool"
+                    )
                 )
                 advisories.append(
                     {
                         "code": code,
                         "message": (
-                            f"Tool '{tool_name}' is bound to a model but not executed by a ToolNode/manual loop."
-                            if code == "bound_tool_without_executor"
-                            else f"Tool '{tool_name}' is defined but not called or passed to a documented tool execution pattern."
+                            f"Tool '{tool_name}' is passed to a ToolNode that is never registered in the graph."
+                            if code == "unwired_tool_node_executor"
+                            else (
+                                f"Tool '{tool_name}' is bound to a model but not executed by a ToolNode/manual loop."
+                                if code == "bound_tool_without_executor"
+                                else f"Tool '{tool_name}' is defined but not called or passed to a documented tool execution pattern."
+                            )
                         ),
                         "tool": tool_name,
                     }
@@ -2000,6 +2144,9 @@ class ChatbotNotebookContractRule(QAValidationRule):
         has_thread_id = "thread_id" in lowered and "THREAD_ID" in content
         has_bad_update_carryover = "current_state = step" in content
         has_second_initial_invoke = "graph.invoke(initial_state" in content
+        has_unconditional_chat_loop = bool(
+            re.search(r"(?m)^\s*run_chat_loop\(\)\s*$", content)
+        )
 
         if not has_chat_loop or not has_input_loop:
             issues.append(
@@ -2043,9 +2190,22 @@ class ChatbotNotebookContractRule(QAValidationRule):
                     "message": "Execution should not rerun initial_state after streaming.",
                 }
             )
+        if has_unconditional_chat_loop and "if RUN_INTERACTIVE_LOOP" not in content:
+            issues.append(
+                {
+                    "code": "blocking_default_chat_loop",
+                    "message": "Top-to-bottom chatbot notebooks should not enter an input loop unless RUN_INTERACTIVE_LOOP is enabled.",
+                }
+            )
 
-        if all(cue in lowered for cue in ("male", "female")) or "selected_gender" in lowered:
-            if "def select_character_gender" not in content or "CHARACTER_GENDER" not in content:
+        if (
+            all(cue in lowered for cue in ("male", "female"))
+            or "selected_gender" in lowered
+        ):
+            if (
+                "def select_character_gender" not in content
+                or "CHARACTER_GENDER" not in content
+            ):
                 issues.append(
                     {
                         "code": "missing_character_gate",
@@ -2054,13 +2214,41 @@ class ChatbotNotebookContractRule(QAValidationRule):
                 )
 
         if any(cue in lowered for cue in self.MEMORY_CUES):
-            if "InMemorySaver" not in content or "checkpointer=memory" not in content:
+            if "InMemorySaver" not in content or "compile(checkpointer=" not in content:
                 issues.append(
                     {
                         "code": "missing_short_term_memory",
                         "message": "Memory-oriented chat notebooks should compile with a checkpointer.",
                     }
                 )
+            memory_write_fields = {
+                "memory_summary",
+                "persona_profile",
+                "character_profile",
+                "turn_count",
+            }
+            for field_name in sorted(memory_write_fields):
+                if field_name not in content:
+                    continue
+                writes_field = any(
+                    pattern in content
+                    for pattern in (
+                        f'updates["{field_name}"]',
+                        f"updates['{field_name}']",
+                        f'payload["{field_name}"]',
+                        f"payload['{field_name}']",
+                        f'"{field_name}":',
+                        f"'{field_name}':",
+                    )
+                )
+                if not writes_field:
+                    issues.append(
+                        {
+                            "code": "declared_memory_field_without_writer",
+                            "message": f"Memory/persona field '{field_name}' is referenced but no generated node/input path writes it.",
+                            "field": field_name,
+                        }
+                    )
 
         if any(cue in lowered for cue in self.VERIFIER_CUES):
             verifier_fields = {
@@ -2069,7 +2257,9 @@ class ChatbotNotebookContractRule(QAValidationRule):
                 "realism_notes",
                 "revision_instructions",
             }
-            if not verifier_fields & set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", content)):
+            if not verifier_fields & set(
+                re.findall(r"[A-Za-z_][A-Za-z0-9_]*", content)
+            ):
                 issues.append(
                     {
                         "code": "missing_structured_verifier_state",
@@ -2081,6 +2271,36 @@ class ChatbotNotebookContractRule(QAValidationRule):
                     {
                         "code": "missing_bounded_revision",
                         "message": "Verifier/reviser loops should include a bounded retry or iteration cap.",
+                    }
+                )
+            has_revision_route = (
+                "add_conditional_edges" in content
+                and "revise" in lowered
+                and ("revision" in lowered or "reviser" in lowered)
+            ) or "Command(" in content
+            terminal_verifier = bool(
+                re.search(
+                    r"add_edge\(\s*[\"'][^\"']*verif[^\"']*[\"']\s*,\s*(END|[\"']END[\"'])",
+                    content,
+                )
+            )
+            has_verifier_node = bool(
+                re.search(r"def\s+\w*verif\w*_node", lowered)
+                or re.search(r"add_node\(\s*[\"'][^\"']*verif", lowered)
+            )
+            has_reviser_node = bool(
+                re.search(r"def\s+\w*revis\w*_node", lowered)
+                or re.search(r"add_node\(\s*[\"'][^\"']*revis", lowered)
+            )
+            if (
+                has_verifier_node
+                and has_reviser_node
+                and (terminal_verifier or not has_revision_route)
+            ):
+                issues.append(
+                    {
+                        "code": "missing_executable_verifier_loop",
+                        "message": "Verifier/reviser notebooks should route failed drafts to a reviser before accepting or ending.",
                     }
                 )
 
@@ -2110,6 +2330,9 @@ class DomainArchitectureAlignmentRule(QAValidationRule):
     repairable = False
 
     DOMAIN_CUES = {
+        "chatbot": {"chatbot", "chat", "conversation", "turn", "message"},
+        "historical": {"historical", "century", "commoner", "anachronism", "period"},
+        "persona": {"persona", "character", "male", "female", "gender", "roleplay"},
         "museum": {"museum", "artifact", "catalog", "archive", "collection"},
         "incident": {"incident", "outage", "sre", "remediation", "alert"},
         "support": {"support", "customer", "ticket", "escalation", "case"},
@@ -2117,6 +2340,9 @@ class DomainArchitectureAlignmentRule(QAValidationRule):
         "data": {"data", "dataset", "schema", "validation", "catalog"},
     }
     HIGH_SIGNAL_CUES = {
+        "chatbot": {"chatbot", "turn-taking"},
+        "historical": {"historical", "century", "commoner", "anachronism"},
+        "persona": {"persona", "character"},
         "museum": {"museum", "artifact"},
         "incident": {"incident", "outage", "remediation"},
         "support": {"ticket", "escalation"},
@@ -2126,6 +2352,11 @@ class DomainArchitectureAlignmentRule(QAValidationRule):
     GENERIC_NODE_PATTERN = re.compile(
         r"^(specialist|worker|agent|subagent|node|default)_?\d*$"
     )
+    OFF_DOMAIN_CHATBOT_FALLBACK_NODES = {
+        "data_processor",
+        "schema_validator",
+        "researcher",
+    }
 
     def validate(self, context: NotebookValidationContext) -> Optional[QAReport]:
         content = "\n".join(_cell_source(cell) for cell in context.notebook.cells)
@@ -2137,6 +2368,12 @@ class DomainArchitectureAlignmentRule(QAValidationRule):
             if len(content_tokens & cues) >= 2
             or bool(content_tokens & self.HIGH_SIGNAL_CUES.get(domain, set()))
         )
+        if {"chatbot", "historical", "persona"} & set(matched_domains):
+            strong_data_terms = {"dataset", "database", "analytics", "tabular"}
+            if not content_tokens & strong_data_terms:
+                matched_domains = [
+                    domain for domain in matched_domains if domain != "data"
+                ]
         if not matched_domains:
             return self.passed_report(
                 "No strong domain-specific cues required architecture-name alignment.",
@@ -2159,20 +2396,32 @@ class DomainArchitectureAlignmentRule(QAValidationRule):
 
         for node in ast.walk(tree):
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                location = context.resolve_line(getattr(node, "lineno", None))
+                if location.get("cell_section") == "tools":
+                    continue
                 function_name = node.name.removesuffix("_node")
-                if self.GENERIC_NODE_PATTERN.match(function_name):
+                if self.GENERIC_NODE_PATTERN.match(function_name) or (
+                    function_name in self.OFF_DOMAIN_CHATBOT_FALLBACK_NODES
+                    and {"chatbot", "historical", "persona"} & set(matched_domains)
+                ):
                     generic_nodes.append(
                         {
                             "identifier": function_name,
                             "kind": "function",
-                            **context.resolve_line(getattr(node, "lineno", None)),
+                            **location,
                         }
                     )
             elif isinstance(node, ast.Call) and _call_name(node.func).endswith(
                 ".add_node"
             ):
                 node_name = _literal_string(node.args[0]) if node.args else None
-                if node_name and self.GENERIC_NODE_PATTERN.match(node_name):
+                if node_name and (
+                    self.GENERIC_NODE_PATTERN.match(node_name)
+                    or (
+                        node_name in self.OFF_DOMAIN_CHATBOT_FALLBACK_NODES
+                        and {"chatbot", "historical", "persona"} & set(matched_domains)
+                    )
+                ):
                     generic_nodes.append(
                         {
                             "identifier": node_name,

--- a/src/langgraph_system_generator/qa/validators.py
+++ b/src/langgraph_system_generator/qa/validators.py
@@ -1560,6 +1560,29 @@ class StateReducerSemanticsRule(QAValidationRule):
 
         writer_map: dict[str, set[str]] = {}
 
+        def _command_symbol_names() -> set[str]:
+            command_names = {"Command"}
+            for module_node in ast.walk(tree):
+                if not isinstance(module_node, ast.ImportFrom):
+                    continue
+                if module_node.module not in {"langgraph.types", "langgraph.graph"}:
+                    continue
+                for alias in module_node.names:
+                    if alias.name == "Command":
+                        command_names.add(alias.asname or alias.name)
+            return command_names
+
+        command_symbol_names = _command_symbol_names()
+
+        def _is_command_call(value: ast.AST | None) -> bool:
+            if not isinstance(value, ast.Call):
+                return False
+            if isinstance(value.func, ast.Name):
+                return value.func.id in command_symbol_names
+            if isinstance(value.func, ast.Attribute):
+                return value.func.attr == "Command"
+            return False
+
         def _is_state_name(node: ast.AST | None) -> bool:
             return isinstance(node, ast.Name) and node.id == "state"
 
@@ -1582,9 +1605,7 @@ class StateReducerSemanticsRule(QAValidationRule):
                 for key in _dict_string_keys(value):
                     writer_map.setdefault(key, set()).add(function_name)
                 return
-            if isinstance(value, ast.Call) and _call_name(value.func).endswith(
-                "Command"
-            ):
+            if _is_command_call(value):
                 for keyword in value.keywords:
                     if keyword.arg == "update" and isinstance(keyword.value, ast.Dict):
                         for key in _dict_string_keys(keyword.value):
@@ -1593,6 +1614,27 @@ class StateReducerSemanticsRule(QAValidationRule):
         def _record_update_keys(function_name: str, keys: set[str]) -> None:
             for key in keys:
                 writer_map.setdefault(key, set()).add(function_name)
+
+        def _local_update_keys_from_call(call: ast.Call) -> tuple[str, set[str]] | None:
+            if not isinstance(call.func, ast.Attribute):
+                return None
+            if not isinstance(call.func.value, ast.Name):
+                return None
+            variable_name = call.func.value.id
+            method_name = call.func.attr
+            keys: set[str] = set()
+            if method_name == "update":
+                for arg in call.args:
+                    if isinstance(arg, ast.Dict):
+                        keys.update(_dict_string_keys(arg))
+                keys.update(keyword.arg for keyword in call.keywords if keyword.arg)
+            elif method_name == "setdefault" and call.args:
+                key = _literal_string(call.args[0])
+                if key:
+                    keys.add(key)
+            if not keys:
+                return None
+            return variable_name, keys
 
         def _subscript_string_key(target: ast.AST) -> tuple[str, str] | None:
             if not isinstance(target, ast.Subscript) or not isinstance(
@@ -1637,7 +1679,9 @@ class StateReducerSemanticsRule(QAValidationRule):
                         if isinstance(target, ast.Name) and isinstance(
                             statement.value, (ast.Dict, ast.Call)
                         ):
-                            local_update_keys.setdefault(target.id, set())
+                            local_update_keys.setdefault(target.id, set()).update(
+                                _dict_string_keys(statement.value)
+                            )
                         subscript_key = _subscript_string_key(target)
                         if subscript_key:
                             variable_name, key = subscript_key
@@ -1646,11 +1690,21 @@ class StateReducerSemanticsRule(QAValidationRule):
                     if isinstance(statement.target, ast.Name) and isinstance(
                         statement.value, (ast.Dict, ast.Call)
                     ):
-                        local_update_keys.setdefault(statement.target.id, set())
+                        local_update_keys.setdefault(
+                            statement.target.id,
+                            set(),
+                        ).update(_dict_string_keys(statement.value))
                     subscript_key = _subscript_string_key(statement.target)
                     if subscript_key:
                         variable_name, key = subscript_key
                         local_update_keys.setdefault(variable_name, set()).add(key)
+                elif isinstance(statement, ast.Expr) and isinstance(
+                    statement.value, ast.Call
+                ):
+                    call_update_keys = _local_update_keys_from_call(statement.value)
+                    if call_update_keys:
+                        variable_name, keys = call_update_keys
+                        local_update_keys.setdefault(variable_name, set()).update(keys)
                 if isinstance(statement, ast.Return):
                     if (
                         is_registered_node
@@ -1677,9 +1731,7 @@ class StateReducerSemanticsRule(QAValidationRule):
                                 node.name,
                                 local_update_keys.get(statement.value.id, set()),
                             )
-                        if isinstance(statement.value, ast.Call) and _call_name(
-                            statement.value.func
-                        ).endswith("Command"):
+                        if _is_command_call(statement.value):
                             for keyword in statement.value.keywords:
                                 if keyword.arg == "update" and isinstance(
                                     keyword.value, ast.Name

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -594,6 +594,43 @@ async def test_generate_artifacts_surfaces_tool_planning_feedback_as_warnings(
             "available_tool_ids": ["web_search", "http_client"],
             "warnings": ["Tool planning used heuristic fallback inference."],
         }
+        result["tools_plan"] = [
+            {
+                "tool_id": "web_search",
+                "name": "Web Search",
+                "category": "search",
+                "purpose": "Search current context.",
+                "configuration": {},
+                "packages": [],
+                "provider_env_vars": [],
+                "status": "ready",
+                "warnings": [],
+            },
+            {
+                "tool_id": "swarm_tool",
+                "name": "Swarm Tool",
+                "category": "external",
+                "purpose": "Unsupported suggested tool.",
+                "configuration": {},
+                "packages": [],
+                "provider_env_vars": [],
+                "status": "unsupported",
+                "warnings": [],
+            },
+        ]
+        result["graph_exports"] = {
+            "mermaid": "",
+            "schema": {
+                "tool_reachability": [
+                    {
+                        "tool_id": "web_search",
+                        "execution_path": "tool_node",
+                        "node": "tools",
+                        "rationale": "Executed by ToolNode.",
+                    }
+                ]
+            },
+        }
         return result
 
     monkeypatch.setattr(
@@ -615,6 +652,16 @@ async def test_generate_artifacts_surfaces_tool_planning_feedback_as_warnings(
     assert "tool_planning_environment" in warning_codes
     assert "tool_planning_dependency" in warning_codes
     assert artifacts["manifest"]["tool_planning_feedback"]["fallback_used"] is True
+    assert artifacts["manifest"]["tool_contract_summary"]["counts"] == {
+        "planned": 2,
+        "executable": 1,
+        "utility": 0,
+        "unsupported": 1,
+    }
+    assert (
+        artifacts["manifest"]["tool_contract_summary"]["executable_tools"][0]["tool_id"]
+        == "web_search"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -657,6 +657,7 @@ async def test_generate_artifacts_surfaces_tool_planning_feedback_as_warnings(
         "executable": 1,
         "utility": 0,
         "unsupported": 1,
+        "unclassified": 0,
     }
     assert (
         artifacts["manifest"]["tool_contract_summary"]["executable_tools"][0]["tool_id"]

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -1490,6 +1490,7 @@ async def test_package_outputs_node_manifest_fields():
         "executable": 1,
         "utility": 1,
         "unsupported": 1,
+        "unclassified": 0,
     }
     assert (
         manifest["tool_contract_summary"]["executable_tools"][0]["tool_id"]
@@ -1537,8 +1538,26 @@ def test_tool_contract_summary_treats_deterministic_nodes_as_utilities():
         "executable": 0,
         "utility": 1,
         "unsupported": 0,
+        "unclassified": 0,
     }
     assert summary["utility_helpers"][0]["tool_id"] == "schema_validator"
+
+
+def test_tool_contract_summary_classifies_missing_reachability_contract():
+    summary = build_tool_contract_summary(
+        [{"tool_id": "context_lookup", "name": "Context Lookup"}],
+        {},
+    )
+
+    assert summary["counts"] == {
+        "planned": 1,
+        "executable": 0,
+        "utility": 0,
+        "unsupported": 0,
+        "unclassified": 1,
+    }
+    assert summary["unclassified_tools"][0]["tool_id"] == "context_lookup"
+    assert summary["unclassified_tools"][0]["status"] == "missing_contract"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_nodes_additional.py
+++ b/tests/unit/test_generator_nodes_additional.py
@@ -45,10 +45,12 @@ from langgraph_system_generator.generator.state import (
     QAReport,
     QARepairFeedback,
     ToolPlanningFeedback,
+    ToolSpec,
     bounded_constraints_reducer,
     bounded_docs_context_reducer,
 )
 from langgraph_system_generator.qa.registry import RepairRoutineRegistration
+from langgraph_system_generator.qa.summary import build_tool_contract_summary
 from langgraph_system_generator.qa.validators import (
     NotebookValidationContext,
     QAValidationRule,
@@ -1404,12 +1406,47 @@ async def test_package_outputs_node_manifest_fields():
             schema={
                 "entry_point": "router",
                 "terminal_nodes": ["finish"],
+                "tool_reachability": [
+                    {
+                        "tool_id": "web_search",
+                        "execution_path": "tool_node",
+                        "node": "tools",
+                        "rationale": "Executed by ToolNode.",
+                    },
+                    {
+                        "tool_id": "schema_validator",
+                        "execution_path": "omitted",
+                        "node": None,
+                        "rationale": "Classified as a local utility.",
+                    },
+                ],
                 "validation_summary": {
                     "errors": ["Duplicate node id 'router'."],
                     "warnings": ["Recovered using deterministic hybrid fallback."],
                 },
             },
         ),
+        "tools_plan": [
+            ToolSpec(
+                tool_id="web_search",
+                name="Web Search",
+                category="search",
+                purpose="Search current context.",
+            ),
+            ToolSpec(
+                tool_id="schema_validator",
+                name="Schema Validator",
+                category="validation",
+                purpose="Validate local schema data.",
+            ),
+            ToolSpec(
+                tool_id="unsupported_tool",
+                name="Unsupported Tool",
+                category="external",
+                purpose="Unsupported external dependency.",
+                status="unsupported",
+            ),
+        ],
         "tool_planning_feedback": ToolPlanningFeedback(
             fallback_used=True,
             fallback_reason="Tool planning used heuristic fallback inference.",
@@ -1448,6 +1485,24 @@ async def test_package_outputs_node_manifest_fields():
     assert manifest["graph_design_feedback"]["fallback_used"] is True
     assert "flowchart TD" in manifest["graph_exports"]["mermaid"]
     assert manifest["tool_planning_feedback"]["fallback_used"] is True
+    assert manifest["tool_contract_summary"]["counts"] == {
+        "planned": 3,
+        "executable": 1,
+        "utility": 1,
+        "unsupported": 1,
+    }
+    assert (
+        manifest["tool_contract_summary"]["executable_tools"][0]["tool_id"]
+        == "web_search"
+    )
+    assert (
+        manifest["tool_contract_summary"]["utility_helpers"][0]["tool_id"]
+        == "schema_validator"
+    )
+    assert (
+        manifest["tool_contract_summary"]["unsupported_tools"][0]["tool_id"]
+        == "unsupported_tool"
+    )
     assert (
         manifest["generation_context_pack"]["notebook_contract"][
             "compiled_graph_variable"
@@ -1459,6 +1514,31 @@ async def test_package_outputs_node_manifest_fields():
     assert "requests" in manifest["notebook_dependency_plan"]["packages"]
     assert manifest["qa_repair_feedback"]["repair_attempts"] == 1
     assert result["generation_complete"] is True
+
+
+def test_tool_contract_summary_treats_deterministic_nodes_as_utilities():
+    summary = build_tool_contract_summary(
+        [{"tool_id": "schema_validator", "name": "Schema Validator"}],
+        {
+            "schema": {
+                "tool_reachability": [
+                    {
+                        "tool_id": "schema_validator",
+                        "execution_path": "deterministic_node",
+                        "rationale": "Used as deterministic validation helper.",
+                    }
+                ]
+            }
+        },
+    )
+
+    assert summary["counts"] == {
+        "planned": 1,
+        "executable": 0,
+        "utility": 1,
+        "unsupported": 0,
+    }
+    assert summary["utility_helpers"][0]["tool_id"] == "schema_validator"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -240,11 +240,23 @@ async def test_chatbot_notebook_emits_interactive_chat_contract(
             "state_schema": {
                 "messages": "Conversation messages",
                 "selected_gender": "Selected male or female character gender",
+                "character_sex": "Selected character sex alias",
                 "gender_pending": "Whether the character selection is pending",
                 "turn_count": "Number of chat turns",
+                "memory_summary": "Short memory summary",
+                "conversation_memory": "Thread-scoped chat memory",
+                "persona": "Selected persona alias",
+                "persona_choice": "Selected persona choice",
+                "selected_persona": "Selected persona alias from live graph design",
+                "thread_memory": "Thread memory alias from live graph design",
                 "retrieved_memories": "Conversation memories retrieved",
+                "persona_profile": "Selected character profile",
+                "character_profile": "Selected character profile alias",
                 "historical_verification": "Structured historical check payload",
+                "draft_response": "Draft chatbot response",
+                "safety_passed": "Whether safety and realism checks passed",
                 "needs_revision": "Whether the response must be revised",
+                "revision_count": "Number of revision attempts",
                 "revision_history": "Revision history",
                 "final_response": "Final chatbot response",
             },
@@ -267,9 +279,10 @@ async def test_chatbot_notebook_emits_interactive_chat_contract(
         for cell in composition.cells
         if cell.section == "config" and cell.cell_type == "code"
     )
-    assert 'CHARACTER_GENDER = None' in config_code
+    assert "CHARACTER_GENDER = None" in config_code
     assert 'THREAD_ID = "lnf-demo-thread"' in config_code
     assert "SHOW_UPDATES = False" in config_code
+    assert "RUN_INTERACTIVE_LOOP = False" in config_code
 
     state_code = next(
         cell.content
@@ -277,12 +290,41 @@ async def test_chatbot_notebook_emits_interactive_chat_contract(
         if cell.section == "state" and cell.cell_type == "code"
     )
     assert "selected_gender: str" in state_code
+    assert "character_sex: str" in state_code
     assert "gender_pending: bool" in state_code
     assert "turn_count: int" in state_code
+    assert "memory_summary: str" in state_code
+    assert "conversation_memory: str" in state_code
+    assert "persona: str" in state_code
+    assert "persona_choice: str" in state_code
+    assert "selected_persona: str" in state_code
+    assert "thread_memory: str" in state_code
     assert "retrieved_memories: Annotated[List[str], operator.add]" in state_code
+    assert "persona_profile: Dict[str, object]" in state_code
+    assert "character_profile: Dict[str, object]" in state_code
     assert "historical_verification: Dict[str, object]" in state_code
+    assert "draft_response: str" in state_code
+    assert "safety_passed: bool" in state_code
     assert "needs_revision: bool" in state_code
+    assert "revision_count: int" in state_code
     assert "revision_history: Annotated[List[str], operator.add]" in state_code
+
+    node_code = "\n\n".join(
+        cell.content
+        for cell in composition.cells
+        if cell.section == "nodes" and cell.cell_type == "code"
+    )
+    assert 'updates["draft_response"]' in node_code
+    assert 'updates["persona_profile"]' in node_code
+    assert 'updates["persona"]' in node_code
+    assert 'updates["persona_choice"]' in node_code
+    assert 'updates["selected_persona"]' in node_code
+    assert 'updates["memory_summary"]' in node_code
+    assert 'updates["conversation_memory"]' in node_code
+    assert 'updates["thread_memory"]' in node_code
+    assert 'updates["safety_passed"]' in node_code
+    assert 'updates["revision_count"]' in node_code
+    assert 'updates["revision_instructions"]' in node_code
 
     execution_code = next(
         cell.content
@@ -296,6 +338,17 @@ async def test_chatbot_notebook_emits_interactive_chat_contract(
     assert 'stream_mode = "updates" if show_updates else "values"' in execution_code
     assert "graph.get_state(config).values" in execution_code
     assert "def select_character_gender" in execution_code
+    assert "WORKFLOW_STATE_FIELDS" in execution_code
+    assert 'payload["character_sex"] = character_gender' in execution_code
+    assert (
+        'payload["persona_choice"] = f"{character_gender}_commoner"' in execution_code
+    )
+    assert 'payload["persona"] = f"{character_gender}_commoner"' in execution_code
+    assert 'payload["character_profile"] = persona_profile' in execution_code
+    assert "def run_demo_turns(" in execution_code
+    assert "if RUN_INTERACTIVE_LOOP:" in execution_code
+    assert "elif RUN_DEMO_TURNS:" in execution_code
+    assert "\nrun_chat_loop()" not in execution_code
     assert "current_state = step" not in execution_code
     assert "graph.invoke(initial_state" not in execution_code
     ast.parse(execution_code)
@@ -638,8 +691,7 @@ async def test_compose_notebook_sanitizes_provider_env_vars_for_config_code(
     assert "os.environ[name] = value" in config_cells[0]
     assert "def make_llm(" in config_cells[0]
     assert (
-        'ENV_123_SERVICE_KEY = _load_env_var("ENV_123_SERVICE_KEY")'
-        in config_cells[0]
+        'ENV_123_SERVICE_KEY = _load_env_var("ENV_123_SERVICE_KEY")' in config_cells[0]
     )
     ast.parse(config_cells[0])
 
@@ -842,10 +894,7 @@ async def test_compose_notebook_sections_and_packages(
         and "MODEL =" in cell.content
     ]
     assert config_cells
-    assert (
-        'OPENAI_API_KEY = _load_env_var("OPENAI_API_KEY")'
-        in config_cells[0].content
-    )
+    assert 'OPENAI_API_KEY = _load_env_var("OPENAI_API_KEY")' in config_cells[0].content
     assert "from google.colab import userdata" in config_cells[0].content
     assert "from getpass import getpass" in config_cells[0].content
     assert "def make_llm(" in config_cells[0].content
@@ -1502,8 +1551,13 @@ async def test_compose_notebook_hybrid_terminal_finish_is_not_duplicated(
     assert code.count("def finish_node") == 1
     assert code.count('workflow.add_node("finish", finish_node)') == 1
     assert 'workflow.add_node("gender_setup", gender_setup_node)' in code
-    assert 'workflow.add_node("anachronism_verifier", anachronism_verifier_node)' in code
-    assert 'workflow.add_node("believability_verifier", believability_verifier_node)' in code
+    assert (
+        'workflow.add_node("anachronism_verifier", anachronism_verifier_node)' in code
+    )
+    assert (
+        'workflow.add_node("believability_verifier", believability_verifier_node)'
+        in code
+    )
     assert 'workflow.add_edge("finish", "finish")' not in code
     ast.parse(code)
 
@@ -1953,6 +2007,48 @@ async def test_tool_cells_emit_decorated_tools_and_tool_node(
     ast.parse(tool_code)
 
 
+def test_utility_helper_conversion_removes_local_tool_import_guard():
+    generated_code = """
+def schema_validator(payload: dict) -> dict:
+    try:
+        from langchain_core.tools import tool
+    except Exception:
+        tool = None  # Allows immediate execution without LangChain.
+
+    return {"valid": isinstance(payload, dict)}
+"""
+
+    helper_code = composer_module.NotebookComposer._as_utility_helper_code(
+        generated_code
+    )
+
+    assert "@tool" not in helper_code
+    assert "langchain_core.tools" not in helper_code
+    assert "tool = None" not in helper_code
+    assert "try:\n    except" not in helper_code
+    ast.parse(helper_code)
+
+
+def test_deterministic_node_tool_path_is_not_executable_tool_contract():
+    executable_ids = composer_module.NotebookComposer._executable_tool_ids(
+        {
+            "graph_exports": {
+                "schema": {
+                    "tool_reachability": [
+                        {
+                            "tool_id": "schema_validator",
+                            "execution_path": "deterministic_node",
+                        },
+                        {"tool_id": "web_search", "execution_path": "tool_node"},
+                    ]
+                }
+            }
+        }
+    )
+
+    assert executable_ids == {"web_search"}
+
+
 @pytest.mark.asyncio
 async def test_generate_node_implementation_rejects_invalid_python_and_falls_back(
     monkeypatch: pytest.MonkeyPatch,
@@ -2041,11 +2137,16 @@ def test_verifier_and_reviser_fallbacks_emit_structured_revision_state(
     workflow_design = {
         "architecture_type": "custom",
         "state_schema": {
+            "draft_response": "Draft response awaiting verification",
+            "safety_passed": "Whether safety and realism checks passed",
             "needs_revision": "Whether revision is required",
             "historical_risk_notes": "Historical risk notes",
             "realism_notes": "Realism notes",
             "revision_instructions": "Instructions for reviser",
+            "revision_count": "Bounded revision count",
             "revision_history": "Revision history",
+            "final_response": "Accepted final response",
+            "route": "Revision route",
         },
         "nodes": [
             {"name": "historical_verifier", "purpose": "Verify anachronisms"},
@@ -2062,11 +2163,23 @@ def test_verifier_and_reviser_fallbacks_emit_structured_revision_state(
         workflow_design,
     )
 
-    assert 'updates["needs_revision"] = False' in verifier_code
-    assert 'updates["historical_risk_notes"] = ""' in verifier_code
-    assert 'updates["realism_notes"] = ""' in verifier_code
-    assert 'updates["revision_instructions"] = ""' in verifier_code
+    assert 'draft = str(state.get("draft_response")' in verifier_code
+    assert 'updates["safety_passed"] = safety_passed' in verifier_code
+    assert 'updates["needs_revision"] = needs_revision' in verifier_code
+    assert 'updates["historical_risk_notes"] = historical_risk_notes' in verifier_code
+    assert 'updates["realism_notes"] = realism_notes' in verifier_code
+    assert 'updates["revision_instructions"] = revision_instructions' in verifier_code
+    assert (
+        'updates["route"] = "revise" if needs_revision else "accept"' in verifier_code
+    )
+    assert 'updates["final_response"] = draft' in verifier_code
+    assert '"smartphone"' in verifier_code
+    assert '"star wars"' in verifier_code
+    assert 'revision_count = int(state.get("revision_count", 0)) + 1' in reviser_code
+    assert 'updates["draft_response"] = revised_draft' in reviser_code
+    assert 'updates["revision_count"] = revision_count' in reviser_code
     assert 'updates["revision_history"] = revision_history' in reviser_code
+    assert 'updates["route"] = "verify"' in reviser_code
     compile(verifier_code, "<verifier_fallback>", "exec")
     compile(reviser_code, "<reviser_fallback>", "exec")
 
@@ -2202,9 +2315,15 @@ async def test_compose_notebook_renders_canonical_hybrid_graph_contract(
     ]
     assert graph_cells
     graph_code = graph_cells[-1].content
+    all_code = "\n\n".join(
+        cell.content for cell in composition.cells if cell.cell_type == "code"
+    )
 
     assert "CANONICAL_GRAPH_SPEC" in graph_code
-    assert 'workflow.add_edge("persona_specialist", "historical_verifier")' in graph_code
+    assert all_code.count("def finish_node") == 1
+    assert (
+        'workflow.add_edge("persona_specialist", "historical_verifier")' in graph_code
+    )
     assert (
         'workflow.add_edge("revision_specialist", "historical_verifier")'
         not in graph_code
@@ -2302,7 +2421,9 @@ async def test_compose_notebook_custom_canonical_graph_uses_lowercase_refs_and_s
 def test_generate_canonical_graph_code_omits_checkpointer_when_disabled():
     """Canonical notebook graph code should honor checkpointing=false."""
 
-    composer = composer_module.NotebookComposer.__new__(composer_module.NotebookComposer)
+    composer = composer_module.NotebookComposer.__new__(
+        composer_module.NotebookComposer
+    )
     schema = {
         "architecture_type": "custom",
         "nodes": [

--- a/tests/unit/test_generator_notebook_composer.py
+++ b/tests/unit/test_generator_notebook_composer.py
@@ -280,6 +280,7 @@ async def test_chatbot_notebook_emits_interactive_chat_contract(
         if cell.section == "config" and cell.cell_type == "code"
     )
     assert "CHARACTER_GENDER = None" in config_code
+    assert "ANACHRONISM_TERMS = (" in config_code
     assert 'THREAD_ID = "lnf-demo-thread"' in config_code
     assert "SHOW_UPDATES = False" in config_code
     assert "RUN_INTERACTIVE_LOOP = False" in config_code
@@ -2007,6 +2008,35 @@ async def test_tool_cells_emit_decorated_tools_and_tool_node(
     ast.parse(tool_code)
 
 
+@pytest.mark.asyncio
+async def test_tool_cells_keep_tools_executable_when_reachability_contract_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+    feedback = composer_module.NotebookCompositionFeedback()
+
+    cells = await composer._create_tool_cells(
+        [
+            {
+                "tool_id": "context_lookup",
+                "name": "Context Lookup",
+                "purpose": "Lookup conversational context.",
+                "category": "validation",
+            }
+        ],
+        feedback,
+        workflow_design={"architecture_type": "hybrid", "nodes": []},
+    )
+    tool_code = "\n\n".join(cell.content for cell in cells if cell.cell_type == "code")
+
+    assert "@tool" in tool_code
+    assert "TOOLS = [Context_Lookup]" in tool_code
+    assert "ToolNode(TOOLS, handle_tool_errors=True)" in tool_code
+    assert "Utility helper only" not in tool_code
+    ast.parse(tool_code)
+
+
 def test_utility_helper_conversion_removes_local_tool_import_guard():
     generated_code = """
 def schema_validator(payload: dict) -> dict:
@@ -2173,6 +2203,7 @@ def test_verifier_and_reviser_fallbacks_emit_structured_revision_state(
         'updates["route"] = "revise" if needs_revision else "accept"' in verifier_code
     )
     assert 'updates["final_response"] = draft' in verifier_code
+    assert 'globals().get("ANACHRONISM_TERMS", (' in verifier_code
     assert '"smartphone"' in verifier_code
     assert '"star wars"' in verifier_code
     assert 'revision_count = int(state.get("revision_count", 0)) + 1' in reviser_code
@@ -2204,6 +2235,29 @@ def test_graph_fallback_uses_sanitized_function_references(
     assert 'workflow.add_node("start node", start_node_node)' in graph_code
     assert 'workflow.add_node("9 result-node", _9_result_node_node)' in graph_code
     compile(graph_code, "<graph_fallback>", "exec")
+
+
+def test_chatbot_fallback_nodes_include_pattern_scaffold_handlers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(composer_module, "ChatOpenAI", DummyLLM)
+    composer = composer_module.NotebookComposer()
+    workflow_design = {
+        "architecture_type": "hybrid",
+        "state_schema": {"messages": "Conversation messages"},
+        "nodes": [
+            {"name": "persona_specialist", "purpose": "Draft in persona"},
+            {"name": "historical_verifier", "purpose": "Verify realism"},
+        ],
+    }
+
+    nodes = composer._with_required_pattern_scaffold_nodes(
+        workflow_design["nodes"],
+        workflow_design,
+    )
+
+    assert [node["name"] for node in nodes[:2]] == ["router", "supervisor"]
+    assert "persona_specialist" in {node["name"] for node in nodes}
 
 
 def test_graph_fallback_lowers_command_routes_to_conditional_edges(

--- a/tests/unit/test_notebook_outputs.py
+++ b/tests/unit/test_notebook_outputs.py
@@ -267,6 +267,25 @@ async def test_manifest_artifact_contract_marks_standalone_files_and_zip_members
     )
 
 
+def test_artifact_contract_does_not_inspect_nonstandard_manifest_zip(tmp_path: Path):
+    """Only the generator-owned bundle name is inspected for ZIP members."""
+    import langgraph_system_generator.cli as cli_module
+
+    output_dir = tmp_path / "artifact_contract"
+    output_dir.mkdir()
+    alternate_zip = output_dir / "user_named_bundle.zip"
+    with zipfile.ZipFile(alternate_zip, "w") as zf:
+        zf.writestr("unexpected.txt", "not a generated bundle member")
+
+    contract = cli_module._build_artifact_contract(
+        {"zip_path": str(alternate_zip)},
+        output_dir,
+    )
+
+    assert contract["standalone_files"][0]["exists"] is True
+    assert contract["zip_members"] == []
+
+
 @pytest.mark.asyncio
 async def test_generate_all_formats(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Test that all formats are generated when formats=None."""

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -785,6 +785,42 @@ workflow.add_node("router", router_node)
     assert "copy_state" not in report.evidence["writer_map"].get("route", [])
 
 
+def test_state_reducer_semantics_rule_flags_declared_memory_field_without_writer(
+    tmp_notebook_path: Path,
+):
+    notebook = new_notebook()
+    notebook.cells.append(
+        new_code_cell(
+            """from langgraph.graph import MessagesState, StateGraph
+
+class WorkflowState(MessagesState):
+    memory_summary: str
+    persona_profile: dict
+    final_response: str
+
+def persona_node(state: WorkflowState) -> dict:
+    updates = {}
+    updates["persona_profile"] = {"name": "demo"}
+    updates["final_response"] = "Good day."
+    return updates
+
+workflow = StateGraph(WorkflowState)
+workflow.add_node("persona", persona_node)
+""",
+            metadata={"section": "state"},
+        )
+    )
+    _write_notebook(tmp_notebook_path, notebook)
+
+    reports = NotebookValidator().validate_all(tmp_notebook_path)
+    report = _report_by_name(reports, "State Reducer Semantics")
+    issue_codes = {issue["code"] for issue in report.evidence["issues"]}
+
+    assert report.passed is False
+    assert "declared_memory_field_without_writer" in issue_codes
+    assert report.evidence["writer_map"]["persona_profile"] == ["persona_node"]
+
+
 def test_tool_reachability_rule_flags_unbound_placeholder_tools(
     tmp_notebook_path: Path,
 ):
@@ -972,6 +1008,74 @@ workflow.add_node("specialist_1", specialist_1_node)
     assert report.evidence["generic_nodes"]
 
 
+def test_domain_architecture_alignment_rule_prioritizes_chatbot_domain_cues(
+    tmp_notebook_path: Path,
+):
+    notebook = new_notebook()
+    notebook.cells.extend(
+        [
+            new_markdown_cell(
+                "18th century chatbot persona workflow with schema validation notes."
+            ),
+            new_code_cell(
+                """from langgraph.graph import StateGraph
+
+def persona_node(state):
+    return {"final_response": "Good day."}
+
+workflow = StateGraph(dict)
+workflow.add_node("persona", persona_node)
+""",
+                metadata={"section": "graph"},
+            ),
+        ]
+    )
+    _write_notebook(tmp_notebook_path, notebook)
+
+    report = DomainArchitectureAlignmentRule().validate(
+        NotebookValidator()._context_from_path(tmp_notebook_path)
+    )
+
+    assert report is not None
+    assert report.passed is True
+    assert {"chatbot", "historical", "persona"}.issubset(
+        set(report.evidence["matched_domains"])
+    )
+    assert "data" not in report.evidence["matched_domains"]
+
+
+def test_domain_architecture_alignment_rule_rejects_generic_chatbot_workers(
+    tmp_notebook_path: Path,
+):
+    notebook = new_notebook()
+    notebook.cells.extend(
+        [
+            new_markdown_cell("18th century chatbot persona with memory."),
+            new_code_cell(
+                """from langgraph.graph import StateGraph
+
+def data_processor_node(state):
+    return {"final_response": "processed"}
+
+workflow = StateGraph(dict)
+workflow.add_node("data_processor", data_processor_node)
+""",
+                metadata={"section": "graph"},
+            ),
+        ]
+    )
+    _write_notebook(tmp_notebook_path, notebook)
+
+    report = DomainArchitectureAlignmentRule().validate(
+        NotebookValidator()._context_from_path(tmp_notebook_path)
+    )
+
+    assert report is not None
+    assert report.passed is False
+    assert "chatbot" in report.evidence["matched_domains"]
+    assert report.evidence["generic_nodes"][0]["identifier"] == "data_processor"
+
+
 def test_tool_reachability_rule_requires_executor_for_bound_tools(
     tmp_notebook_path: Path,
 ):
@@ -1039,6 +1143,7 @@ def lookup_context(query: str) -> str:
 
 tools = [lookup_context]
 tool_node = ToolNode(tools, handle_tool_errors=True)
+workflow.add_node("tools", tool_node)
 """,
             metadata={"section": "tools"},
         )
@@ -1049,6 +1154,36 @@ tool_node = ToolNode(tools, handle_tool_errors=True)
     report = _report_by_name(reports, "Tool Reachability")
 
     assert report.passed is True
+
+
+def test_tool_reachability_rule_rejects_unwired_tool_node_executor(
+    tmp_notebook_path: Path,
+):
+    notebook = new_notebook()
+    notebook.cells.append(
+        new_code_cell(
+            """from langchain_core.tools import tool
+from langgraph.prebuilt import ToolNode
+
+@tool
+def lookup_context(query: str) -> str:
+    \"\"\"Lookup context.\"\"\"
+    return query
+
+tools = [lookup_context]
+tool_node = ToolNode(tools, handle_tool_errors=True)
+""",
+            metadata={"section": "tools"},
+        )
+    )
+    _write_notebook(tmp_notebook_path, notebook)
+
+    reports = NotebookValidator().validate_all(tmp_notebook_path)
+    report = _report_by_name(reports, "Tool Reachability")
+    issue_codes = {issue["code"] for issue in report.evidence["advisories"]}
+
+    assert report.passed is False
+    assert "unwired_tool_node_executor" in issue_codes
 
 
 def test_tool_reachability_rule_accepts_create_agent_executor(
@@ -1162,15 +1297,17 @@ THREAD_ID = "lnf-demo-thread"
 CHARACTER_GENDER = None
 MAX_ITERATIONS = 3
 SHOW_UPDATES = False
+RUN_INTERACTIVE_LOOP = False
 
 workflow = StateGraph(dict)
-memory = InMemorySaver()
-graph = workflow.compile(checkpointer=memory)
+checkpointer = InMemorySaver()
+graph = workflow.compile(checkpointer=checkpointer)
 
 needs_revision = False
 historical_risk_notes = ""
 realism_notes = ""
 revision_instructions = ""
+revision_count = 0
 
 def select_character_gender(value: str | None = CHARACTER_GENDER) -> str:
     return value or "female"
@@ -1193,6 +1330,9 @@ def run_chat_loop() -> None:
         if user_input.lower() in {"quit", "exit", "q"}:
             break
         chat_once(user_input)
+
+if RUN_INTERACTIVE_LOOP:
+    run_chat_loop()
 """,
                 metadata={"section": "execution"},
             ),
@@ -1226,15 +1366,17 @@ THREAD_ID = "lnf-demo-thread"
 CHARACTER_GENDER = None
 MAX_ITERATIONS = 3
 SHOW_UPDATES = False
+RUN_INTERACTIVE_LOOP = False
 
 workflow = StateGraph(dict)
-memory = InMemorySaver()
-graph = workflow.compile(checkpointer=memory)
+checkpointer = InMemorySaver()
+graph = workflow.compile(checkpointer=checkpointer)
 
 needs_revision = False
 historical_risk_notes = ""
 realism_notes = ""
 revision_instructions = ""
+revision_count = 0
 
 def select_character_gender(value: str | None = CHARACTER_GENDER) -> str:
     return value or "female"
@@ -1263,6 +1405,9 @@ def run_chat_loop() -> None:
         if user_input.lower() in {"quit", "exit", "q"}:
             break
         chat_once(user_input)
+
+if RUN_INTERACTIVE_LOOP:
+    run_chat_loop()
 """,
                 metadata={"section": "execution"},
             ),
@@ -1276,6 +1421,152 @@ def run_chat_loop() -> None:
 
     assert report is not None
     assert report.passed is True
+
+
+def test_chatbot_contract_rule_flags_blocking_default_interactive_loop(
+    tmp_notebook_path: Path,
+):
+    notebook = new_notebook()
+    notebook.cells.extend(
+        [
+            new_markdown_cell(
+                "Interactive chatbot character with male/female persona, memory, verification, and revision."
+            ),
+            new_code_cell(
+                """from langchain_core.messages import HumanMessage
+from langgraph.graph import StateGraph
+from langgraph.checkpoint.memory import InMemorySaver
+
+THREAD_ID = "lnf-demo-thread"
+CHARACTER_GENDER = None
+MAX_ITERATIONS = 3
+SHOW_UPDATES = False
+
+workflow = StateGraph(dict)
+checkpointer = InMemorySaver()
+graph = workflow.compile(checkpointer=checkpointer)
+
+needs_revision = False
+revision_instructions = ""
+revision_count = 0
+
+def select_character_gender(value: str | None = CHARACTER_GENDER) -> str:
+    return value or "female"
+
+def chat_once(user_text: str, *, thread_id: str = THREAD_ID) -> dict:
+    config = {"configurable": {"thread_id": thread_id}, "recursion_limit": 25}
+    latest_state = {}
+    for state in graph.stream(
+        {"messages": [HumanMessage(content=user_text)]},
+        config,
+        stream_mode="values",
+    ):
+        latest_state = state
+    final_state = graph.get_state(config).values
+    return final_state or latest_state
+
+def run_chat_loop() -> None:
+    select_character_gender()
+    while True:
+        user_input = input("Enter next message (or type 'quit' to exit): ")
+        if user_input.lower() in {"quit", "exit", "q"}:
+            break
+        chat_once(user_input)
+
+run_chat_loop()
+""",
+                metadata={"section": "execution"},
+            ),
+        ]
+    )
+    _write_notebook(tmp_notebook_path, notebook)
+
+    report = ChatbotNotebookContractRule().validate(
+        NotebookValidator()._context_from_path(tmp_notebook_path)
+    )
+    issue_codes = {issue["code"] for issue in report.evidence["issues"]}
+
+    assert report is not None
+    assert report.passed is False
+    assert "blocking_default_chat_loop" in issue_codes
+
+
+def test_chatbot_contract_rule_flags_terminal_verifier_reviser_prose_nodes(
+    tmp_notebook_path: Path,
+):
+    notebook = new_notebook()
+    notebook.cells.extend(
+        [
+            new_markdown_cell(
+                "Interactive chatbot with historical verifier and reviser."
+            ),
+            new_code_cell(
+                """from langchain_core.messages import HumanMessage
+from langgraph.graph import END, StateGraph
+from langgraph.checkpoint.memory import InMemorySaver
+
+THREAD_ID = "lnf-demo-thread"
+CHARACTER_GENDER = None
+MAX_ITERATIONS = 3
+RUN_INTERACTIVE_LOOP = False
+needs_revision = False
+historical_risk_notes = ""
+realism_notes = ""
+revision_instructions = ""
+revision_count = 0
+
+def select_character_gender(value: str | None = CHARACTER_GENDER) -> str:
+    return value or "female"
+
+def historical_verifier_node(state):
+    return {"needs_revision": False, "revision_instructions": ""}
+
+def revision_specialist_node(state):
+    return {"revision_count": state.get("revision_count", 0) + 1}
+
+def chat_once(user_text: str, *, thread_id: str = THREAD_ID) -> dict:
+    config = {"configurable": {"thread_id": thread_id}, "recursion_limit": 25}
+    latest_state = {}
+    for state in graph.stream(
+        {"messages": [HumanMessage(content=user_text)]},
+        config,
+        stream_mode="values",
+    ):
+        latest_state = state
+    final_state = graph.get_state(config).values
+    return final_state or latest_state
+
+def run_chat_loop() -> None:
+    while True:
+        user_input = input("Enter next message (or type 'quit' to exit): ")
+        if user_input.lower() in {"quit", "exit", "q"}:
+            break
+        chat_once(user_input)
+
+workflow = StateGraph(dict)
+workflow.add_node("historical_verifier", historical_verifier_node)
+workflow.add_node("revision_specialist", revision_specialist_node)
+workflow.add_edge("historical_verifier", END)
+checkpointer = InMemorySaver()
+graph = workflow.compile(checkpointer=checkpointer)
+
+if RUN_INTERACTIVE_LOOP:
+    run_chat_loop()
+""",
+                metadata={"section": "graph"},
+            ),
+        ]
+    )
+    _write_notebook(tmp_notebook_path, notebook)
+
+    report = ChatbotNotebookContractRule().validate(
+        NotebookValidator()._context_from_path(tmp_notebook_path)
+    )
+    issue_codes = {issue["code"] for issue in report.evidence["issues"]}
+
+    assert report is not None
+    assert report.passed is False
+    assert "missing_executable_verifier_loop" in issue_codes
 
 
 def test_invocation_config_rule_requires_thread_id_and_recursion_limit(

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -821,6 +821,75 @@ workflow.add_node("persona", persona_node)
     assert report.evidence["writer_map"]["persona_profile"] == ["persona_node"]
 
 
+def test_state_reducer_semantics_rule_tracks_update_methods_and_command_alias(
+    tmp_notebook_path: Path,
+):
+    notebook = new_notebook()
+    notebook.cells.append(
+        new_code_cell(
+            """from langgraph.graph import MessagesState, StateGraph
+from langgraph.types import Command as GraphCommand
+
+class WorkflowState(MessagesState):
+    memory_summary: str
+    persona_profile: dict
+
+def persona_node(state: WorkflowState):
+    updates = {}
+    updates.update({"memory_summary": "remembered"})
+    updates.setdefault("persona_profile", {"name": "demo"})
+    return GraphCommand(update=updates, goto="done")
+
+workflow = StateGraph(WorkflowState)
+workflow.add_node("persona", persona_node)
+""",
+            metadata={"section": "state"},
+        )
+    )
+    _write_notebook(tmp_notebook_path, notebook)
+
+    reports = NotebookValidator().validate_all(tmp_notebook_path)
+    report = _report_by_name(reports, "State Reducer Semantics")
+
+    assert report.passed is True
+    assert report.evidence["writer_map"]["memory_summary"] == ["persona_node"]
+    assert report.evidence["writer_map"]["persona_profile"] == ["persona_node"]
+
+
+def test_state_reducer_semantics_rule_does_not_treat_custom_command_as_langgraph(
+    tmp_notebook_path: Path,
+):
+    notebook = new_notebook()
+    notebook.cells.append(
+        new_code_cell(
+            """from langgraph.graph import MessagesState, StateGraph
+
+class WorkflowState(MessagesState):
+    memory_summary: str
+
+class AuditCommand:
+    def __init__(self, update: dict):
+        self.update = update
+
+def memory_node(state: WorkflowState):
+    return AuditCommand(update={"memory_summary": "not a LangGraph Command"})
+
+workflow = StateGraph(WorkflowState)
+workflow.add_node("memory", memory_node)
+""",
+            metadata={"section": "state"},
+        )
+    )
+    _write_notebook(tmp_notebook_path, notebook)
+
+    reports = NotebookValidator().validate_all(tmp_notebook_path)
+    report = _report_by_name(reports, "State Reducer Semantics")
+    issue_codes = {issue["code"] for issue in report.evidence["issues"]}
+
+    assert report.passed is False
+    assert "declared_memory_field_without_writer" in issue_codes
+
+
 def test_tool_reachability_rule_flags_unbound_placeholder_tools(
     tmp_notebook_path: Path,
 ):


### PR DESCRIPTION
## Summary
- hardens generated chatbot notebooks for the remaining Wave 4 generated-output issues under #342
- makes verifier/reviser loops executable with canonical revision fields and bounded routing
- keeps chat helpers non-blocking by default while preserving same-thread turns, character selection, and persona/chat memory writes
- classifies generated tools by the graph reachability contract and exposes a manifest `tool_contract_summary`
- strengthens deterministic QA for chat loops, memory writers, fake tool wiring, terminal verifier/reviser prose, and chatbot/historical/persona domain drift

Closes #344.
Closes #345.
Closes #346.
Closes #347.
Closes #349.

## Verification
- `python -m pytest tests/unit/test_generator_notebook_composer.py tests/unit/test_validators.py -q` -> 111 passed
- `python -m pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py --asyncio-mode=auto -q` -> 143 passed, 3 warnings
- `python -m pytest tests/unit/test_patterns.py tests/unit/test_patterns_utils.py -q` -> 98 passed
- `python -m pytest tests/unit/ --asyncio-mode=auto -q` -> 634 passed, 4 warnings
- `python -m pytest tests/unit/test_documentation_coverage.py -q` -> 5 passed
- `git diff --check`
- exact conflict-marker scan with `rg -n "^(<<<<<<<|=======|>>>>>>>)" .`
- headed/live web UI generation with `gpt-5.4-mini` to `./output/wave4-live-chatbot`: notebook, HTML, and manifest downloads worked; browser console/page errors were empty; manifest QA was advisory-only with zero blocking issues

## Notes
- This PR does not close #342 directly. After merge, #342 can be closed if all #343-#350 children are confirmed closed.
- #334 and #335 remain active as downstream runtime outer-agent architecture work.
