### PR TITLE
Modernize pattern dispatch and intake dialogs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,9 @@ Important patterns:
 - `constraints` and `docs_context` are accumulated lists with bounded,
   latest-unique reducers.
 - `requirements_feedback` is advisory metadata from intake. It should surface fallback/gap/conflict guidance without replacing `constraints` as the downstream source of truth.
+- `requirements_messages` is optional multi-turn intake context. When present,
+  `RequirementsAnalyst.analyze_dialog(...)` should refine constraints across
+  turns while keeping legacy single-prompt generation compatible.
 - `architecture_feedback` is advisory metadata from architecture selection. It should surface fallback, tradeoff, and validation guidance without replacing `architecture_type` or `selected_patterns` as the downstream contract.
 - `tools_plan` stays the backward-compatible downstream tool payload, while `tool_planning_feedback` carries fallback, environment, and dependency advisories for manifests and notebook warning surfaces.
 - `generated_cells` is authoritative for the current repair iteration and is
@@ -229,6 +232,15 @@ aligned when changing notebook assembly behavior:
   notebook-scoped helpers explicitly with `use_notebook_helper=True` so node
   code calls `make_llm(...)` and leaves model/API-base settings centralized in
   the config cell
+- router pattern snippets should include a fallback/general route for greetings,
+  unsupported requests, and unclear routing decisions unless a composed
+  architecture supplies a stricter canonical graph contract
+- supervisor/subagent pattern snippets should use `Send(...)` fan-out when
+  dispatching multiple independent specialists and should keep result fields
+  reducer-backed
+- critique-loop snippets may opt into LangGraph static interrupts with
+  `require_human_approval=True`, compiling with `interrupt_before=["revise"]`
+  and a checkpointer
 - generated chatbot notebooks must remain non-blocking on top-to-bottom
   execution by default; interactive input loops should run only when the
   notebook-level `RUN_INTERACTIVE_LOOP` flag is enabled, while `chat_once(...)`

--- a/README.md
+++ b/README.md
@@ -245,8 +245,11 @@ curl -X POST http://localhost:8000/generate \
   }'
 ```
 
-Request fields are `prompt`, `mode`, `output_dir`, `formats`, `model`,
-`custom_endpoint`, `temperature`, `max_tokens`, and `agent_type`.
+Request fields are `prompt`, `messages`, `mode`, `output_dir`, `formats`,
+`model`, `custom_endpoint`, `temperature`, `max_tokens`, and `agent_type`.
+Use `prompt` for the legacy single-turn request shape. Use `messages` for an
+iterative requirements dialog; when `prompt` is omitted, the API derives the
+generation prompt from the latest user message.
 
 Current API request model snapshot:
 
@@ -254,6 +257,7 @@ Current API request model snapshot:
 classDiagram
   class GenerationRequest {
     prompt : Optional[str]
+    messages : Optional[list[DialogMessage]]
     mode : Optional[GenerationMode]
     output_dir : Optional[str]
     formats : Optional[list[str]]
@@ -262,6 +266,10 @@ classDiagram
     temperature : Optional[float]
     max_tokens : Optional[int]
     agent_type : Optional[str]
+  }
+  class DialogMessage {
+    role : Literal["system", "user", "assistant"]
+    content : str
   }
 ```
 

--- a/docs/LIBRARY_FLOW_ANALYSIS.md
+++ b/docs/LIBRARY_FLOW_ANALYSIS.md
@@ -53,16 +53,16 @@ graph TD
 *   **Routing/File**: `src/langgraph_system_generator/cli.py`
 *   **Core Logic**: `cli.generate_artifacts` calls `graph.create_generator_graph().ainvoke(...)`
 *   **Data Flow**:
-    *   **Writes**: `user_prompt` (Initial State)
+    *   **Writes**: `user_prompt` and optional `requirements_messages` (Initial State)
 
 ### Step 2: Requirement Analysis (Intake)
-*   **Goal**: Analyze the user's raw prompt to extract structured constraints and requirements.
+*   **Goal**: Analyze the user's raw prompt or multi-turn requirements dialog to extract structured constraints and requirements.
 *   **Graph Node**: `intake`
 *   **Routing/File**: `src/langgraph_system_generator/generator/nodes.py` -> `intake_node`
-*   **Core Logic**: `src/langgraph_system_generator/generator/agents/requirements_analyst.py` -> `RequirementsAnalyst.analyze`
+*   **Core Logic**: `src/langgraph_system_generator/generator/agents/requirements_analyst.py` -> `RequirementsAnalyst.analyze` / `RequirementsAnalyst.analyze_dialog`
 *   **Data Flow**:
-    *   **Reads**: `user_prompt`
-    *   **Writes**: `constraints` (List[Constraint])
+    *   **Reads**: `user_prompt`, optional `requirements_messages`, and prior `constraints`
+    *   **Writes**: `constraints` (List[Constraint]), `requirements_feedback`
 
 ### Step 3: Context Retrieval (RAG)
 *   **Goal**: Retrieve relevant documentation and patterns from the vector store to inform design.
@@ -144,7 +144,8 @@ The `GeneratorState` acts as the central data bus. Below is the mapping of how d
 
 | State Key | Type | Populated By (Node) | Consumed By (Node) |
 | :--- | :--- | :--- | :--- |
-| **user_prompt** | `str` | CLI (Init) | `intake`, `rag_retrieval` |
+| **user_prompt** | `str` | CLI/API (Init) | `intake`, `rag_retrieval` |
+| **requirements_messages** | `Optional[List[Dict[str, str]]]` | API/CLI (Init) | `intake` |
 | **constraints** | `List[Constraint]` | `intake` | `architecture_selection`, `graph_design`, `tooling_plan` |
 | **docs_context** | `List[DocSnippet]` | `rag_retrieval` | `architecture_selection` |
 | **selected_patterns** | `Dict` | `architecture_selection` | `graph_design`, `notebook_assembly` |

--- a/docs/diagrams/generator-stage-state-map.md
+++ b/docs/diagrams/generator-stage-state-map.md
@@ -48,14 +48,14 @@ flowchart LR
   `qa_repair_feedback`.
 - Increment: `repair_attempts`.
 - Finalize: `artifacts_manifest`, `generation_complete`, `error_message`.
-- Inputs/config: `user_prompt`, `uploaded_files`, `generation_config`,
-  `generation_mode`.
+- Inputs/config: `user_prompt`, optional `requirements_messages`,
+  `uploaded_files`, `generation_config`, `generation_mode`.
 
 ## State Write Ledger
 
 | State field(s) | Written by | Semantics |
 | --- | --- | --- |
-| `constraints`, `requirements_feedback` | `intake_node` | Extracted requirements plus advisory intake feedback. |
+| `constraints`, `requirements_feedback` | `intake_node` | Extracted requirements plus advisory intake feedback; optional `requirements_messages` lets live intake refine constraints across dialog turns. |
 | `docs_context` | `rag_retrieval_node` | Retrieved snippets; falls back to `[]` when RAG fails. |
 | `selected_patterns`, `architecture_type`, `architecture_justification`, `architecture_feedback` | `architecture_selection_node` | Single-writer architecture decision, rationale, and selector feedback. |
 | `workflow_design`, `graph_design_feedback`, `graph_exports`, `notebook_plan` | `graph_design_node` | Typed graph design unpacked into backward-compatible workflow payload plus Mermaid/schema exports. |

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -24,6 +24,8 @@ Those generators now emit LangGraph code in the current docs-aligned style:
 ### RouterPattern
 
 Use when a request should be handled by exactly one specialist.
+Generated router snippets include a `fallback` route by default for greetings,
+generic chat, unsupported requests, and unclear routing decisions.
 
 ```python
 from langgraph_system_generator.patterns import RouterPattern
@@ -41,6 +43,9 @@ code = RouterPattern.generate_complete_example(
 ### SubagentsPattern
 
 Use when a supervisor must coordinate multiple specialists over several steps.
+Generated supervisor graphs support Send-based fan-out when multiple
+specialists can work independently, while `task_results` remains reducer-backed
+for map-reduce style accumulation.
 
 ```python
 from langgraph_system_generator.patterns import SubagentsPattern
@@ -95,6 +100,11 @@ code = CritiqueLoopPattern.generate_complete_example(
 In human-feedback mode the generated example includes a `collect_human_feedback`
 callback that you can replace with a UI approval flow, moderation queue, or
 external review service.
+
+For notebook or application flows that should pause before revision, pass
+`require_human_approval=True` to `generate_graph_code(...)` or
+`generate_complete_example(...)`; the generated graph compiles with
+`interrupt_before=["revise"]` and an in-memory checkpointer.
 
 Only inject trusted application callbacks into workflow state. Do not source
 the human feedback handler from user input, persisted checkpoints, or other
@@ -309,6 +319,8 @@ class RouterPattern:
         routes: List[str],
         llm_model: str = "gpt-5-mini",
         use_structured_output: bool = True,
+        include_fallback: bool = True,
+        fallback_route: str = "fallback",
     ) -> str
     
     @staticmethod
@@ -323,12 +335,16 @@ class RouterPattern:
         routes: List[str],
         entry_point: str = "router",
         use_conditional_edges: bool = True,
+        include_fallback: bool = True,
+        fallback_route: str = "fallback",
     ) -> str
     
     @staticmethod
     def generate_complete_example(
         routes: List[str],
         route_purposes: Optional[Dict[str, str]] = None,
+        include_fallback: bool = True,
+        fallback_route: str = "fallback",
     ) -> str
 ```
 
@@ -415,6 +431,7 @@ class CritiqueLoopPattern:
         max_revisions: int = 3,
         min_quality_score: float = 0.8,
         failure_conditions: Optional[Dict[str, Any]] = None,
+        require_human_approval: bool = False,
     ) -> str
 
     @staticmethod
@@ -427,6 +444,7 @@ class CritiqueLoopPattern:
         use_structured_output: bool = True,
         feedback_source: str = "automated",
         failure_conditions: Optional[Dict[str, Any]] = None,
+        require_human_approval: bool = False,
     ) -> str
 ```
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -31,11 +31,17 @@
 - PR #359 merged Wave 3 #343/#348. It preserves canonical graph/spec topology in
   generated notebooks, manifests, and QA, and keeps standalone pattern LLM
   snippets separate from notebook `make_llm(...)` cells.
-- Wave 4 is active on `codex/chatbot-fidelity-wave4` for #344, #345, #346,
-  #347, and #349. The branch hardens existing generated-chat behavior rather
-  than replacing PR #357/#359: non-blocking chat helpers, same-thread turns,
-  canonical verifier/reviser fields, memory writers, tool contract summaries,
-  and prompt-faithfulness/domain QA.
+- PR #360 merged Wave 4 at
+  `89da744e3f4b232eebf6ce4802ecee6537b02c8f`, closing #344, #345, #346,
+  #347, #349, and generated-output epic #342. Generated chatbot notebooks now
+  have non-blocking chat helpers, same-thread demo turns, canonical
+  verifier/reviser fields, memory writers, tool contract summaries, and
+  prompt-faithfulness/domain QA.
+- Wave 5 is active on `codex/pattern-intake-modernization-wave5` for #60, #63,
+  #64, and #202. The branch modernizes residual LangGraph pattern/intake
+  behavior: router fallback/general routes, critique-loop static interrupts,
+  Send-based subagent fan-out, and multi-turn requirements refinement through
+  the API/intake state contract.
 - `memory-bank/systemPatterns.md` was updated to document the actual repo
   architecture instead of template bullets.
 - The API layer includes guarded output-path resolution and bounded async job
@@ -89,11 +95,10 @@
 
 ## Immediate Next Steps
 
-- Open the ready Wave 4 PR from `codex/chatbot-fidelity-wave4` for #344, #345,
-  #346, #347, and #349. The branch has passed focused tests, the broad unit
-  gate, and headed/live UI artifact validation.
-- After Wave 4 lands, close epic #342 only if all children #343-#350 are closed;
-  keep #334/#335 active as downstream runtime outer-agent architecture work.
+- Complete and open the ready Wave 5 PR from
+  `codex/pattern-intake-modernization-wave5` for #60, #63, #64, and #202.
+- Keep #334/#335 active as downstream runtime outer-agent architecture work
+  after generated-output epic #342.
 - Keep public docs, examples, and onboarding copy aligned with the current
   CLI/API contract.
 - Keep contributor-facing LangGraph/LangChain skills and LNF custom agents
@@ -151,8 +156,7 @@
 - The post-refresh broad unit gate was
   `python -m pytest tests/unit/ --asyncio-mode=auto -q` with 622 passed and 4
   warnings.
-- Current Wave 4 focused verification on `codex/chatbot-fidelity-wave4` has
-  passed:
+- Wave 4 focused verification on `codex/chatbot-fidelity-wave4` passed:
   `python -m pytest tests/unit/test_generator_notebook_composer.py tests/unit/test_validators.py -q`
   with 111 passed,
   `python -m pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py --asyncio-mode=auto -q`
@@ -166,3 +170,11 @@
   `./output/wave4-live-chatbot`; required artifact downloads worked, the
   browser reported no console or page errors, and the manifest reported
   advisory QA only with zero blocking issues.
+- Current Wave 5 focused verification has passed:
+  `python -m pytest tests/unit/test_patterns.py tests/patterns/test_router.py tests/patterns/test_critique_loops.py -q`
+  with 167 passed, and
+  `python -m pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes.py tests/unit/test_cli_api.py --asyncio-mode=auto -q`
+  with 115 passed.
+- The Wave 5 broad unit gate
+  `python -m pytest tests/unit/ --asyncio-mode=auto -q` passed with 646 tests
+  and 4 warnings.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -178,3 +178,9 @@
 - The Wave 5 broad unit gate
   `python -m pytest tests/unit/ --asyncio-mode=auto -q` passed with 646 tests
   and 4 warnings.
+- After the PR #361 CI build surfaced a stale integration assertion, the updated
+  integration slice
+  `python -m pytest tests/integration/test_pattern_code_generation.py --asyncio-mode=auto -q`
+  passed with 8 tests, and the full local CI-style gate
+  `python -m pytest --asyncio-mode=auto -q` passed with 764 passed, 3 skipped,
+  and 4 warnings.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -16,10 +16,15 @@
   standalone files and ZIP members, and include QA validation-scope wording for
   runtime smoke tests.
 - Generated chatbot notebooks include stronger runtime affordances from PR #357
-  and current Wave 4 work, including chat-loop execution helpers, character
-  selection, executable-tool wiring, verifier/reviser fallbacks, memory checks,
-  non-blocking top-to-bottom chat execution, and centralized generated LLM
-  configuration patterns.
+  and PR #360, including chat-loop execution helpers, character selection,
+  executable-tool wiring, verifier/reviser fallbacks, memory checks,
+  non-blocking top-to-bottom chat execution, prompt-faithfulness/domain QA, and
+  centralized generated LLM configuration patterns.
+- Wave 5 pattern/intake modernization is active on
+  `codex/pattern-intake-modernization-wave5`: router snippets now emit a
+  fallback/general route, subagent snippets emit Send-based parallel fan-out
+  contracts, critique-loop snippets can compile with `interrupt_before` on the
+  revise node, and API/intake state can carry multi-turn requirements dialogs.
 - PR #359 merged #343/#348 with canonical graph/spec rendering, manifest and QA
   graph-contract preservation, and explicit standalone-versus-notebook LLM
   initialization boundaries.
@@ -48,7 +53,11 @@
   composer/validator tests, 143 generator/API-node tests, and 98 pattern tests
   passing. The Wave 4 broad unit gate reports 634 passed and 4 warnings, and
   the headed/live web UI gate completed with `gpt-5.4-mini`, working notebook,
-  HTML, and manifest downloads, no browser errors, and advisory-only QA.
+  HTML, and manifest downloads, no browser errors, and advisory-only QA. PR
+  #360 merged at `89da744e3f4b232eebf6ce4802ecee6537b02c8f`, closing the
+  remaining generated-output child issues and epic #342. Current Wave 5 focused
+  slices report 167 pattern tests and 115 generator/API-node tests passing; the
+  Wave 5 broad unit gate reports 646 passed and 4 warnings.
 - Stale completed release-plan issues were closed with evidence during the
   release-readiness pass, reducing that older open issue inventory from 49 to
   26 while keeping true residual items open.
@@ -70,9 +79,9 @@
 - Production Cloud Run deployment uses an authenticated health-check path. The
   deploy job mints a Cloud Run ID token through `google-github-actions/auth`
   with the deployed service URL as the token audience.
-- Generated-output quality epic #342 remains active. Issue #350 is closed, but
-  #343-#349 remain open; PR #357 may satisfy parts of #344-#348 and should be
-  checked before additional implementation.
+- Generated-output quality epic #342 is closed as completed by PRs #358, #359,
+  and #360. Runtime outer-agent follow-ups #334/#335 remain separate downstream
+  work.
 
 ## Current Status
 
@@ -93,9 +102,9 @@
 - The Cloud Run deploy workflow builds and pushes the container image, deploys
   the private service, mounts `OPENAI_API_KEY` from Secret Manager, and checks
   `/health` after deployment.
-- As of the post-PR #359 refresh, #343 and #348 are complete. The remaining
-  generated-output children under #342 are #344, #345, #346, #347, and #349,
-  currently implemented on `codex/chatbot-fidelity-wave4`.
+- As of the post-PR #360 refresh, generated-output epic #342 and children
+  #343-#350 are complete. Wave 5 is active for residual pattern/intake
+  modernization issues #60, #63, #64, and #202.
 
 ## Known Issues and Limitations
 
@@ -108,12 +117,10 @@
 - Full-extra packaging smoke tests are intentionally opt-in because they install
   the broad notebook/RAG/export dependency set into a fresh virtual
   environment.
-- Router fallback/general routing (#60), iterative requirements refinement
-  (#202), and the remaining CYOA notebook cell issues are tracked as residual
-  follow-up work rather than closed stale items.
-- Generated-output Wave 4 still needs diff hygiene and a ready PR before #344,
-  #345, #346, #347, and #349 can be closed. The broad unit and headed/live UI
-  artifact gates have passed on `codex/chatbot-fidelity-wave4`.
+- Router fallback/general routing (#60), critique-loop human approval
+  interrupts (#63), Send-based subagent dispatch (#64), iterative requirements
+  refinement (#202), and the remaining CYOA notebook cell issues are tracked as
+  residual follow-up work rather than closed stale items.
 - The Cloud Run workflow's private-service health check is sensitive to token
   minting details in GitHub Actions WIF. Do not use `gcloud auth
   print-identity-token --audiences=...` for this workflow's health token; the

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -57,7 +57,9 @@
   #360 merged at `89da744e3f4b232eebf6ce4802ecee6537b02c8f`, closing the
   remaining generated-output child issues and epic #342. Current Wave 5 focused
   slices report 167 pattern tests and 115 generator/API-node tests passing; the
-  Wave 5 broad unit gate reports 646 passed and 4 warnings.
+  Wave 5 broad unit gate reports 646 passed and 4 warnings. After updating a
+  stale integration assertion from Command routing to Send fan-out, the full
+  local CI-style gate reports 764 passed, 3 skipped, and 4 warnings.
 - Stale completed release-plan issues were closed with evidence during the
   release-readiness pass, reducing that older open issue inventory from 49 to
   26 while keeping true residual items open.

--- a/memory-bank/tasks/TASK004-generated-output-quality-wave.md
+++ b/memory-bank/tasks/TASK004-generated-output-quality-wave.md
@@ -1,8 +1,8 @@
 # TASK004 - Generated-Output Quality Wave
 
-**Status:** In Progress
+**Status:** Complete
 **Added:** 2026-05-20
-**Updated:** 2026-05-21
+**Updated:** 2026-05-22
 
 ## Original Request
 
@@ -14,8 +14,8 @@ aligned before continuing the wave.
 
 Treat generated-output work as a sequence under epic #342. Reliability work
 from #351-#355 is complete. Manifest truth work from #350 is complete. PR #357
-landed broad generated-chat runtime improvements. PR #359 merged #343/#348, so
-Wave 4 is now active for #344, #345, #346, #347, and #349.
+landed broad generated-chat runtime improvements. PR #359 merged #343/#348, and
+PR #360 completed Wave 4 for #344, #345, #346, #347, and #349.
 
 ## Implementation Plan
 
@@ -37,7 +37,7 @@ Wave 4 is now active for #344, #345, #346, #347, and #349.
 
 ## Progress Tracking
 
-**Overall Status:** In Progress
+**Overall Status:** Complete
 
 ### Subtasks
 
@@ -48,7 +48,7 @@ Wave 4 is now active for #344, #345, #346, #347, and #349.
 | 4.3 | Reconcile generated-chat contract PR #357 with open child issues | Complete | 2026-05-21 | PR #359 folded the #348 config boundary into the #343 branch; remaining Wave 4 issues still need final triage after #359. |
 | 4.4 | Implement canonical graph topology preservation for #343 | Complete | 2026-05-21 | PR #359 merged at `d851008ffc5e6ca289c666c5b1c0564b2282f32f`. |
 | 4.5 | Implement remaining #348 follow-up if still needed | Complete | 2026-05-21 | PR #359 implements the standalone `ChatOpenAI(...)` versus notebook `make_llm(...)` boundary. |
-| 4.6 | Implement generated chatbot Wave 4 for #344/#345/#346/#347/#349 | In Progress | 2026-05-21 | Branch `codex/chatbot-fidelity-wave4`; focused slices, broad unit gate, and headed/live UI artifact gate are passing. |
+| 4.6 | Implement generated chatbot Wave 4 for #344/#345/#346/#347/#349 | Complete | 2026-05-22 | PR #360 merged at `89da744e3f4b232eebf6ce4802ecee6537b02c8f`, closing the remaining generated-output children and epic #342. |
 
 ## Progress Log
 
@@ -99,3 +99,10 @@ Wave 4 is now active for #344, #345, #346, #347, and #349.
   `./output/wave4-live-chatbot`: notebook, HTML, and manifest downloads worked,
   no browser console/page errors were observed, and the manifest reported
   advisory-only QA with zero blocking issues.
+
+### 2026-05-22
+
+- PR #360 merged at `89da744e3f4b232eebf6ce4802ecee6537b02c8f`, closing #344,
+  #345, #346, #347, #349, and epic #342.
+- Generated-output quality work is now complete. Remaining runtime outer-agent
+  follow-ups #334/#335 stay active as a separate downstream architecture lane.

--- a/memory-bank/tasks/TASK005-pattern-intake-modernization-wave.md
+++ b/memory-bank/tasks/TASK005-pattern-intake-modernization-wave.md
@@ -1,0 +1,69 @@
+# TASK005 - Pattern/Intake Modernization Wave
+
+**Status:** In Progress
+**Added:** 2026-05-22
+**Updated:** 2026-05-22
+
+## Original Request
+
+After PR #360 merged the generated-output wave, continue with Wave 5 on
+autopilot and open a new ready PR when complete.
+
+## Thought Process
+
+Wave 5 should address the residual LangGraph pattern/intake issues without
+reopening generated-output epic #342. The focused scope is #60, #63, #64, and
+#202:
+
+- #60: router fallback/general route.
+- #63: human-in-the-loop critique breakpoint through current LangGraph static
+  interrupt patterns.
+- #64: Send-based map-reduce subagent dispatch.
+- #202: iterative multi-turn requirements refinement.
+
+## Implementation Plan
+
+- Create `codex/pattern-intake-modernization-wave5` from updated `main`.
+- Add router fallback/general routing while preserving existing standalone and
+  notebook-composed pattern contracts.
+- Add critique-loop `require_human_approval` graph generation that compiles with
+  `interrupt_before=["revise"]` and checkpointing.
+- Convert supervisor/subagent graph snippets to explicit Send-based fan-out
+  while keeping bounded iteration and reducer-backed result accumulation.
+- Add optional API/intake dialog messages so live requirements extraction can
+  refine constraints across turns.
+- Update focused tests for emitted pattern code, intake dialog refinement, and
+  API dialog request handling.
+
+## Progress Tracking
+
+**Overall Status:** In Progress
+
+### Subtasks
+
+| ID | Description | Status | Updated | Notes |
+|----|-------------|--------|---------|-------|
+| 5.1 | Refresh main and branch for Wave 5 | Complete | 2026-05-22 | Branch `codex/pattern-intake-modernization-wave5` from merged PR #360 main. |
+| 5.2 | Implement router fallback/general route for #60 | Complete | 2026-05-22 | Router literals, prompts, graph wiring, notebook composer, and stub cells include fallback route support. |
+| 5.3 | Implement critique-loop HITL interrupt for #63 | Complete | 2026-05-22 | `generate_graph_code(require_human_approval=True)` emits `interrupt_before=["revise"]`. |
+| 5.4 | Implement Send fan-out subagents for #64 | Complete | 2026-05-22 | Supervisor decisions carry `next_agents`; graph routers return `Send(...)` fan-out. |
+| 5.5 | Implement iterative requirements refinement for #202 | Complete | 2026-05-22 | API `messages` and state `requirements_messages` feed `RequirementsAnalyst.analyze_dialog(...)`. |
+| 5.6 | Run verification and open ready PR | In Progress | 2026-05-22 | Focused pattern and generator/API slices plus broad unit gate are passing; PR publication pending. |
+
+## Progress Log
+
+### 2026-05-22
+
+- PR #360 was verified merged at
+  `89da744e3f4b232eebf6ce4802ecee6537b02c8f`; generated-output epic #342 is
+  closed.
+- Wave 5 started on `codex/pattern-intake-modernization-wave5`.
+- Focused verification passed:
+  `python -m pytest tests/unit/test_patterns.py tests/patterns/test_router.py tests/patterns/test_critique_loops.py -q`
+  with 167 passed.
+- Focused generator/API verification passed:
+  `python -m pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes.py tests/unit/test_cli_api.py --asyncio-mode=auto -q`
+  with 115 passed.
+- Broad unit verification passed:
+  `python -m pytest tests/unit/ --asyncio-mode=auto -q` with 646 passed and 4
+  warnings.

--- a/memory-bank/tasks/TASK005-pattern-intake-modernization-wave.md
+++ b/memory-bank/tasks/TASK005-pattern-intake-modernization-wave.md
@@ -48,7 +48,7 @@ reopening generated-output epic #342. The focused scope is #60, #63, #64, and
 | 5.3 | Implement critique-loop HITL interrupt for #63 | Complete | 2026-05-22 | `generate_graph_code(require_human_approval=True)` emits `interrupt_before=["revise"]`. |
 | 5.4 | Implement Send fan-out subagents for #64 | Complete | 2026-05-22 | Supervisor decisions carry `next_agents`; graph routers return `Send(...)` fan-out. |
 | 5.5 | Implement iterative requirements refinement for #202 | Complete | 2026-05-22 | API `messages` and state `requirements_messages` feed `RequirementsAnalyst.analyze_dialog(...)`. |
-| 5.6 | Run verification and open ready PR | In Progress | 2026-05-22 | Focused pattern and generator/API slices plus broad unit gate are passing; PR publication pending. |
+| 5.6 | Run verification and open ready PR | In Progress | 2026-05-22 | Focused slices, broad unit gate, integration slice, and full local CI-style pytest are passing; PR #361 is open. |
 
 ## Progress Log
 
@@ -66,4 +66,11 @@ reopening generated-output epic #342. The focused scope is #60, #63, #64, and
   with 115 passed.
 - Broad unit verification passed:
   `python -m pytest tests/unit/ --asyncio-mode=auto -q` with 646 passed and 4
+  warnings.
+- After PR #361 CI found a stale integration assertion, the targeted integration
+  slice passed:
+  `python -m pytest tests/integration/test_pattern_code_generation.py --asyncio-mode=auto -q`
+  with 8 passed.
+- Full local CI-style pytest passed:
+  `python -m pytest --asyncio-mode=auto -q` with 764 passed, 3 skipped, and 4
   warnings.

--- a/memory-bank/tasks/_index.md
+++ b/memory-bank/tasks/_index.md
@@ -2,13 +2,14 @@
 
 ## In Progress
 
-- [TASK004 - Generated-output quality wave](TASK004-generated-output-quality-wave.md)
+- [TASK005 - Pattern/intake modernization wave](TASK005-pattern-intake-modernization-wave.md)
 
 ## Completed
 
 - [TASK001 - Repo architecture visualizer docs sync](TASK001-repo-architecture-visualizer-docs-sync.md)
 - [TASK002 - 1.0 release readiness implementation](TASK002-1-0-release-readiness.md)
 - [TASK003 - Cloud Run deployment and live QA hardening](TASK003-cloud-run-deployment-live-qa.md)
+- [TASK004 - Generated-output quality wave](TASK004-generated-output-quality-wave.md)
 
 ## Current State
 
@@ -18,10 +19,10 @@
   - `TASK002-1-0-release-readiness.md`
   - `TASK003-cloud-run-deployment-live-qa.md`
   - `TASK004-generated-output-quality-wave.md`
+  - `TASK005-pattern-intake-modernization-wave.md`
 - Task-level Memory Bank tracking has started with the documentation and
   visualization sync for the checked-in repo architecture bundle, the completed
   1.0 release-readiness branch, the completed Cloud Run deployment hardening
-  lane, and the active generated-output quality wave under epic #342. Wave 4 is
-  active on `codex/chatbot-fidelity-wave4` for #344, #345, #346, #347, and
-  #349 after PR #359 merged #343/#348; the focused tests, broad unit gate, and
-  headed/live UI artifact gate are passing before PR publication.
+  lane, the completed generated-output quality wave under epic #342, and the
+  active Wave 5 pattern/intake modernization branch for #60, #63, #64, and
+  #202. PR #360 closed the remaining generated-output child issues and #342.

--- a/plans/current-plan.md
+++ b/plans/current-plan.md
@@ -59,7 +59,10 @@ Excluded:
 Current Wave 5 focused verification on
 `codex/pattern-intake-modernization-wave5` has passed the pattern gate with 167
 tests and the generator/API-node gate with 115 tests. The broad unit gate
-passed with 646 tests and 4 warnings.
+passed with 646 tests and 4 warnings. After updating a stale integration
+assertion from Command routing to Send fan-out, the full local CI-style gate
+`python -m pytest --asyncio-mode=auto -q` passed with 764 passed, 3 skipped,
+and 4 warnings.
 
 ## Completion criteria
 - MemoryBank and plan context reflect PR #360 as merged, #342 as closed, and

--- a/plans/current-plan.md
+++ b/plans/current-plan.md
@@ -4,9 +4,8 @@
 # Current Plan
 
 ## Objective
-Complete Wave 4 under generated-output epic #342 after merged PR #359, focused
-on the remaining generated chatbot fidelity issues #344, #345, #346, #347, and
-#349.
+Complete Wave 5 after merged PR #360, focused on the residual LangGraph
+pattern/intake issues #60, #63, #64, and #202.
 
 ## Scope
 Included:
@@ -15,57 +14,57 @@ Included:
 - `memory-bank/progress.md`
 - `memory-bank/tasks/_index.md`
 - `memory-bank/tasks/TASK004-generated-output-quality-wave.md`
+- `memory-bank/tasks/TASK005-pattern-intake-modernization-wave.md`
+- `src/langgraph_system_generator/patterns/router.py`
+- `src/langgraph_system_generator/patterns/subagents.py`
+- `src/langgraph_system_generator/patterns/hybrid.py`
+- `src/langgraph_system_generator/patterns/critique_loops.py`
+- `src/langgraph_system_generator/generator/agents/requirements_analyst.py`
+- `src/langgraph_system_generator/generator/nodes.py`
+- `src/langgraph_system_generator/api/server.py`
 
 Excluded:
-- Reopening #351-#355 or #350; those are completed by merged PRs.
-- Direct commits to `main`; Wave 4 work stays on
-  `codex/chatbot-fidelity-wave4`.
-- Rewriting PR #357 or PR #359 behavior where the current code already has a
-  working generated-chat or canonical-graph contract.
+- Reopening #351-#355, #343-#350, or #342; those are completed by merged PRs.
+- Direct commits to `main`; Wave 5 work stays on
+  `codex/pattern-intake-modernization-wave5`.
+- Expanding into #334/#335 runtime outer-agent architecture work or the CYOA
+  notebook cluster.
 
 ## Plan
 1. Keep local `main` synced with `origin/main`.
-2. Refresh MemoryBank and plan context for merged PR #356, PR #358, and PR
-   #357, plus merged PR #359 for #343/#348.
-3. Implement Wave 4 on `codex/chatbot-fidelity-wave4`:
-   - #344: operational bounded verifier/reviser routing and structured fields.
-   - #345/#347: non-blocking chatbot helpers, character selection, same-thread
-     repeated turns, and typed persona/chat memory writes.
-   - #346: executable tool claims tied to graph `tool_reachability`, with a
-     manifest `tool_contract_summary` for planned/executable/utility/unsupported
-     tools.
-   - #349: deterministic QA for chat loops, character gates, memory writers,
-     verifier loops, tool wiring, and chatbot/historical/persona domain drift.
-4. Run focused unit gates, then the broad unit suite, diff hygiene checks, and
-   the headed/live web UI gate with `gpt-5.4-mini` when credentials are
-   available.
-5. Open one ready Wave 4 PR that closes #344, #345, #346, #347, and #349 only
-   if tests and live artifact checks support that claim.
+2. Refresh MemoryBank and plan context for merged PR #360 and closed epic #342.
+3. Implement Wave 5 on `codex/pattern-intake-modernization-wave5`:
+   - #60: router fallback/general route in RouteDecision literals, prompts,
+     generated route nodes, graph wiring, and notebook/stub assembly paths.
+   - #63: critique-loop `require_human_approval` support using LangGraph static
+     interrupts before `revise`.
+   - #64: Send-based subagent map-reduce dispatch with `next_agents` state and
+     reducer-backed result accumulation.
+   - #202: optional API/intake dialog messages that refine requirements across
+     turns while preserving legacy prompt compatibility.
+4. Run focused pattern and generator/API gates, then the broad unit suite, diff
+   hygiene checks, and exact conflict-marker scan.
+5. Open one ready Wave 5 PR that closes #60, #63, #64, and #202 only if tests
+   support that claim.
 
 ## Validation
 - `gh issue list --state open --limit 200 --json number --jq 'length'`
 - `gh issue list --state open --limit 200 --json number,title`
-- Wave 4 focused gates:
-  - `python -m pytest tests/unit/test_generator_notebook_composer.py tests/unit/test_validators.py -q`
-  - `python -m pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes_additional.py tests/unit/test_cli_api.py --asyncio-mode=auto -q`
-  - `python -m pytest tests/unit/test_patterns.py tests/unit/test_patterns_utils.py -q`
+- Wave 5 focused gates:
+  - `python -m pytest tests/unit/test_patterns.py tests/patterns/test_router.py tests/patterns/test_critique_loops.py -q`
+  - `python -m pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes.py tests/unit/test_cli_api.py --asyncio-mode=auto -q`
 - Final gate: `python -m pytest tests/unit/ --asyncio-mode=auto -q`, `git diff
-  --check`, exact conflict-marker scan, and headed/live UI artifact validation
-  when `OPENAI_API_KEY` is available.
+  --check`, and exact conflict-marker scan.
 
-Current Wave 4 verification on `codex/chatbot-fidelity-wave4` has passed the
-focused gates with 111 composer/validator tests, 143 generator/API-node tests,
-and 98 pattern tests. The broad unit gate passed with 634 tests and 4 warnings.
-The headed/live web UI gate used `gpt-5.4-mini` to generate
-`./output/wave4-live-chatbot`; downloads for notebook, HTML, and manifest
-worked, no browser errors were reported, and the manifest ended with advisory
-QA only and zero blocking issues.
+Current Wave 5 focused verification on
+`codex/pattern-intake-modernization-wave5` has passed the pattern gate with 167
+tests and the generator/API-node gate with 115 tests. The broad unit gate
+passed with 646 tests and 4 warnings.
 
 ## Completion criteria
-- MemoryBank and plan context reflect PR #359 as merged and Wave 4 as active.
-- Generated chatbot notebooks do not block top-to-bottom execution by default.
-- Verifier/reviser, memory, tool reachability, and prompt-faithfulness QA have
-  deterministic coverage.
-- Wave 4 PR is pushed, ready for review, and linked to #344, #345, #346, #347,
-  and #349.
+- MemoryBank and plan context reflect PR #360 as merged, #342 as closed, and
+  Wave 5 as active.
+- Router, critique-loop, subagent, hybrid, API, and intake contracts have
+  deterministic tests for the new behavior.
+- Wave 5 PR is pushed, ready for review, and linked to #60, #63, #64, and #202.
 <!-- repo-agent-bootstrap:managed:end -->

--- a/src/langgraph_system_generator/api/server.py
+++ b/src/langgraph_system_generator/api/server.py
@@ -7,13 +7,13 @@ from contextlib import asynccontextmanager
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 from urllib.parse import urlparse
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import FileResponse, HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from langgraph_system_generator import __version__
 from langgraph_system_generator.constants import _BASE_OUTPUT, resolve_under_base
@@ -217,7 +217,10 @@ def _validate_advanced_options(
 
     if normalized_custom_endpoint:
         parsed_endpoint = urlparse(normalized_custom_endpoint)
-        if parsed_endpoint.scheme not in {"http", "https"} or not parsed_endpoint.hostname:
+        if (
+            parsed_endpoint.scheme not in {"http", "https"}
+            or not parsed_endpoint.hostname
+        ):
             raise HTTPException(
                 status_code=400,
                 detail="custom_endpoint must be a valid http or https URL with a hostname.",
@@ -245,13 +248,58 @@ def _normalize_request(request: "GenerationRequest") -> "GenerationRequest":
         }
     )
 
+
+def _request_dialog_messages(
+    request: "GenerationRequest",
+) -> list[dict[str, str]] | None:
+    """Return normalized dialog messages for iterative requirements refinement."""
+
+    if not request.messages:
+        return None
+    return [message.model_dump() for message in request.messages]
+
+
+def _request_prompt(request: "GenerationRequest") -> str:
+    """Return the single prompt value used by legacy generation surfaces."""
+
+    if request.prompt:
+        return request.prompt
+    messages = request.messages or []
+    for message in reversed(messages):
+        if message.role == "user":
+            return message.content
+    return messages[-1].content if messages else ""
+
+
+class DialogMessage(BaseModel):
+    """One requirements dialog turn accepted by the API."""
+
+    role: Literal["system", "user", "assistant"] = Field(
+        description="Dialog role for this requirements turn."
+    )
+    content: str = Field(
+        ...,
+        description="Message content for this requirements turn.",
+        max_length=5000,
+    )
+
+
 class GenerationRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    prompt: str = Field(
-        ...,
+    prompt: Optional[str] = Field(
+        default=None,
         description="User prompt describing the desired system",
         max_length=5000,
+    )
+    messages: Optional[list[DialogMessage]] = Field(
+        default=None,
+        description=(
+            "Optional multi-turn requirements dialog. When provided, live intake "
+            "refines constraints across these turns while prompt remains the "
+            "legacy request summary."
+        ),
+        max_length=50,
     )
     mode: GenerationMode = Field(
         default="stub",
@@ -299,6 +347,14 @@ class GenerationRequest(BaseModel):
         default=None,
         description="Type of agent architecture (router, subagents, hybrid, autoagent, deepagents, etc.) when overriding auto-detection.",
     )
+
+    @model_validator(mode="after")
+    def _require_prompt_or_messages(self) -> "GenerationRequest":
+        """Require either a legacy prompt or at least one dialog message."""
+
+        if not (self.prompt and self.prompt.strip()) and not self.messages:
+            raise ValueError("Either prompt or messages must be provided.")
+        return self
 
 
 class GenerationResponse(BaseModel):
@@ -368,6 +424,8 @@ async def chrome_devtools_endpoint():
 async def generate_notebook(request: GenerationRequest) -> GenerationResponse:
     """Generate notebook artifacts via the generator pipeline."""
     normalized_request = _normalize_request(request)
+    prompt = _request_prompt(normalized_request)
+    requirements_messages = _request_dialog_messages(normalized_request)
 
     # Use the secure path resolution function
     output_path = _resolve_output_dir(request.output_dir)
@@ -375,7 +433,7 @@ async def generate_notebook(request: GenerationRequest) -> GenerationResponse:
     async with _generation_slot():
         try:
             artifacts: GenerationArtifacts = await generate_artifacts(
-                request.prompt,
+                prompt,
                 output_dir=str(output_path),
                 mode=request.mode,
                 formats=request.formats,
@@ -384,6 +442,7 @@ async def generate_notebook(request: GenerationRequest) -> GenerationResponse:
                 max_tokens=request.max_tokens,
                 agent_type=normalized_request.agent_type,
                 custom_endpoint=normalized_request.custom_endpoint,
+                requirements_messages=requirements_messages,
             )
             return GenerationResponse(
                 success=True,
@@ -419,7 +478,7 @@ async def start_async_generation(
 
     Returns:
         GenerationStartResponse with job_id and stream_url
-        
+
     Raises:
         HTTPException 503: When concurrent generation limit is reached
     """
@@ -475,7 +534,7 @@ async def _run_generation_with_progress(
 
     This function orchestrates the generation process and emits progress events
     to the SSE stream. It wraps generate_artifacts() and adds instrumentation.
-    
+
     Uses the API admission controller to limit concurrent generations and prevent
     resource exhaustion.
 
@@ -494,7 +553,9 @@ async def _run_generation_with_progress(
         # Run generation
         emit_node_progress(job_id, "generation", 10, "Initializing generator...")
 
-        def progress_callback(event: Any, percentage: int | None = None, message: str | None = None) -> None:
+        def progress_callback(
+            event: Any, percentage: int | None = None, message: str | None = None
+        ) -> None:
             """Forward progress to SSE stream."""
             if isinstance(event, dict):
                 event_type = event.get("event", "progress")
@@ -522,8 +583,10 @@ async def _run_generation_with_progress(
 
             emit_node_progress(job_id, str(event), int(percentage or 0), message or "")
 
+        prompt = _request_prompt(request)
+        requirements_messages = _request_dialog_messages(request)
         artifacts: GenerationArtifacts = await generate_artifacts(
-            request.prompt,
+            prompt,
             output_dir=str(output_path),
             mode=request.mode,
             formats=request.formats,
@@ -532,6 +595,7 @@ async def _run_generation_with_progress(
             max_tokens=request.max_tokens,
             agent_type=request.agent_type,
             custom_endpoint=request.custom_endpoint,
+            requirements_messages=requirements_messages,
             progress_callback=progress_callback,
         )
 

--- a/src/langgraph_system_generator/api/server.py
+++ b/src/langgraph_system_generator/api/server.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import FileResponse, HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from langgraph_system_generator import __version__
 from langgraph_system_generator.constants import _BASE_OUTPUT, resolve_under_base
@@ -262,13 +262,17 @@ def _request_dialog_messages(
 def _request_prompt(request: "GenerationRequest") -> str:
     """Return the single prompt value used by legacy generation surfaces."""
 
-    if request.prompt:
-        return request.prompt
+    prompt = request.prompt or ""
+    if prompt.strip():
+        return prompt
     messages = request.messages or []
     for message in reversed(messages):
-        if message.role == "user":
+        if message.role == "user" and message.content.strip():
             return message.content
-    return messages[-1].content if messages else ""
+    for message in reversed(messages):
+        if message.content.strip():
+            return message.content
+    return ""
 
 
 class DialogMessage(BaseModel):
@@ -280,8 +284,18 @@ class DialogMessage(BaseModel):
     content: str = Field(
         ...,
         description="Message content for this requirements turn.",
+        min_length=1,
         max_length=5000,
     )
+
+    @field_validator("content")
+    @classmethod
+    def _validate_non_whitespace_content(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError(
+                "Message content must include non-whitespace characters."
+            )
+        return value
 
 
 class GenerationRequest(BaseModel):

--- a/src/langgraph_system_generator/cli.py
+++ b/src/langgraph_system_generator/cli.py
@@ -181,11 +181,13 @@ def _default_state(
     prompt: str,
     generation_config: GenerationConfig | None = None,
     generation_mode: GenerationMode = "live",
+    requirements_messages: List[Dict[str, str]] | None = None,
 ) -> Dict[str, Any]:
     """Return a baseline GeneratorState payload."""
 
     return {
         "user_prompt": prompt,
+        "requirements_messages": requirements_messages,
         "uploaded_files": None,
         "constraints": [],
         "requirements_feedback": RequirementsFeedback(
@@ -1137,6 +1139,7 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
             "search": "Search for information",
             "analyze": "Analyze data and identify patterns",
             "summarize": "Condense content into summaries",
+            "fallback": "Handle general, unsupported, or unclear requests safely.",
         }
 
         # State
@@ -1158,7 +1161,7 @@ def _build_stub_result(prompt: str, agent_type: str | None = None) -> Dict[str, 
         )
 
         # Route nodes
-        for route in routes:
+        for route in [*routes, "fallback"]:
             cells.append(
                 CellSpec(
                     cell_type="code",
@@ -1464,6 +1467,7 @@ async def generate_artifacts(
     max_tokens: int | None = None,
     agent_type: str | None = None,
     custom_endpoint: str | None = None,
+    requirements_messages: List[Dict[str, str]] | None = None,
     progress_callback: Any | None = None,
 ) -> GenerationArtifacts:
     """Generate notebook artifacts either in stub or live mode.
@@ -1482,6 +1486,7 @@ async def generate_artifacts(
         max_tokens: Maximum tokens for LLM response (optional)
         agent_type: Type of agent architecture (optional, auto-detected if not specified)
         custom_endpoint: Custom API endpoint URL (optional)
+        requirements_messages: Optional dialog turns for iterative requirements refinement.
         progress_callback: Optional callback function(node, percentage, message) for progress tracking
     """
 
@@ -1566,7 +1571,12 @@ async def generate_artifacts(
         tracker.finish("graph_init", "Generator graph created.", percentage=15)
         tracker.start("graph_invoke", "Invoking generator graph...", percentage=18)
         result = await graph.ainvoke(
-            _default_state(prompt, generation_config, generation_mode="live")
+            _default_state(
+                prompt,
+                generation_config,
+                generation_mode="live",
+                requirements_messages=requirements_messages,
+            )
         )
         tracker.finish("graph_invoke", "Generator graph completed.", percentage=60)
     else:

--- a/src/langgraph_system_generator/generator/agents/notebook_composer.py
+++ b/src/langgraph_system_generator/generator/agents/notebook_composer.py
@@ -2190,6 +2190,13 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
         if architecture_type == "router":
             route_specs = self._router_route_specs(nodes, workflow_design)
             routes = [name for name, _ in route_specs]
+            fallback_route_spec = (
+                "fallback",
+                "Handle general, unsupported, or unclear requests safely.",
+            )
+            if fallback_route_spec[0] not in routes:
+                route_specs = [*route_specs, fallback_route_spec]
+                routes = [name for name, _ in route_specs]
 
             # Generate router node
             router_code = RouterPattern.generate_router_node_code(
@@ -2430,6 +2437,8 @@ def {safe_node_identifier}_node(state: WorkflowState) -> WorkflowState:
             routes = [
                 name for name, _ in self._router_route_specs(nodes, workflow_design)
             ]
+            if "fallback" not in routes:
+                routes.append("fallback")
             graph_code = RouterPattern.generate_graph_code(routes)
         elif architecture_type == "subagents":
             subagents = [

--- a/src/langgraph_system_generator/generator/agents/requirements_analyst.py
+++ b/src/langgraph_system_generator/generator/agents/requirements_analyst.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import logging
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Mapping, Sequence, Set
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
@@ -36,6 +37,7 @@ MISSING_INPUT_SUGGESTIONS = {
     "environment": "Describe the target environment, such as Colab, local Jupyter, deployment target, or required libraries.",
 }
 
+
 class RequirementsAnalyst:
     """Extracts structured constraints from user prompt."""
 
@@ -55,7 +57,7 @@ class RequirementsAnalyst:
         """Return the current ordered registry of supported constraint types."""
         return build_constraint_type_registry(settings.requirements_constraint_types)
 
-    def _build_analysis_prompt(self) -> SystemMessage:
+    def _build_analysis_prompt(self, *, dialog_mode: bool = False) -> SystemMessage:
         """Return the system prompt used for requirements extraction."""
 
         type_lines = []
@@ -81,17 +83,99 @@ class RequirementsAnalyst:
                 '      "confidence": 0.0,\n'
                 '      "explanation": "why this constraint was extracted"\n'
                 "    }\n"
-                "  ]\n"
+                "  ],\n"
+                '  "clarification_questions": ["question to ask only if needed"]\n'
                 "}\n\n"
                 "Rules:\n"
                 "- Use only the available constraint types listed above.\n"
                 "- Omit any constraint type that is not justified by the prompt.\n"
+                "- Preserve prior constraints unless the latest dialog turn clearly supersedes them.\n"
                 "- Priority is 1 (low) to 5 (high). Goals are usually priority 5.\n"
                 "- Confidence is optional and should be between 0.0 and 1.0.\n"
                 "- Explanations should be short and actionable.\n"
                 "- Return valid JSON only."
+                + (
+                    "\n- Treat the input as a multi-turn requirements dialog. "
+                    "Combine the latest user request with earlier turns and prior constraints."
+                    if dialog_mode
+                    else ""
+                )
             )
         )
+
+    def _normalize_dialog_messages(
+        self,
+        messages: Sequence[Mapping[str, Any] | str | Any],
+    ) -> List[Dict[str, str]]:
+        """Normalize supported dialog message shapes into role/content dictionaries."""
+
+        normalized: List[Dict[str, str]] = []
+        for message in messages:
+            if isinstance(message, str):
+                role = "user"
+                content = message
+            elif isinstance(message, Mapping):
+                role = str(message.get("role") or message.get("type") or "user")
+                content = str(message.get("content") or "")
+            else:
+                role = str(
+                    getattr(message, "role", None)
+                    or getattr(message, "type", None)
+                    or message.__class__.__name__
+                )
+                content = str(getattr(message, "content", ""))
+
+            role = role.strip().lower() or "user"
+            content = content.strip()
+            if content:
+                normalized.append({"role": role, "content": content})
+
+        return normalized
+
+    def _dialog_to_prompt(self, messages: Sequence[Dict[str, str]]) -> str:
+        """Render dialog turns into a compact model-facing transcript."""
+
+        if not messages:
+            return ""
+        return "\n".join(
+            f"{message['role']}: {message['content']}" for message in messages
+        )
+
+    def _constraint_merge_key(self, constraint: Constraint) -> tuple[str, str]:
+        """Return the key used to de-duplicate constraints across dialog turns."""
+
+        return (
+            normalize_constraint_type(constraint.type),
+            constraint.value.strip().lower(),
+        )
+
+    def _merge_constraints(
+        self,
+        prior_constraints: Sequence[Constraint] | None,
+        extracted_constraints: Sequence[Constraint],
+    ) -> tuple[List[Constraint], List[str]]:
+        """Merge prior and newly extracted constraints with latest unique semantics."""
+
+        prior = list(prior_constraints or [])
+        extracted = list(extracted_constraints)
+        merged: List[Constraint] = []
+        seen: set[tuple[str, str]] = set()
+        for constraint in [*prior, *extracted]:
+            key = self._constraint_merge_key(constraint)
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(constraint)
+
+        changes: List[str] = []
+        if prior:
+            changes.append(f"Retained {len(prior)} prior constraint(s).")
+        if extracted:
+            changes.append(f"Added or refreshed {len(extracted)} dialog constraint(s).")
+        if not prior and not extracted:
+            changes.append("No constraints were extracted from the dialog.")
+
+        return merged, changes
 
     def _parse_constraints_payload(self, payload: Any) -> List[Constraint]:
         """Convert model JSON into a list of constraints."""
@@ -102,7 +186,9 @@ class RequirementsAnalyst:
             elif {"type", "value"}.issubset(payload):
                 payload = [payload]
             else:
-                raise ValueError("Requirements payload did not contain a constraints array.")
+                raise ValueError(
+                    "Requirements payload did not contain a constraints array."
+                )
 
         if not isinstance(payload, list):
             raise ValueError("Requirements payload must be a list of constraints.")
@@ -114,7 +200,9 @@ class RequirementsAnalyst:
             raw_type = item.get("type")
             normalized_type = normalize_constraint_type(raw_type)
             if not normalized_type:
-                raise ValueError("Each extracted constraint must include a non-empty type.")
+                raise ValueError(
+                    "Each extracted constraint must include a non-empty type."
+                )
             if normalized_type not in self.constraint_types:
                 raise ValueError(
                     f"Unsupported constraint type '{raw_type}'. "
@@ -144,6 +232,23 @@ class RequirementsAnalyst:
             ),
         )
 
+    def _extract_clarification_questions(self, payload: Any) -> List[str]:
+        """Return optional clarification questions from a model payload."""
+
+        if not isinstance(payload, dict):
+            return []
+        raw_questions = payload.get("clarification_questions") or []
+        if isinstance(raw_questions, str):
+            raw_questions = [raw_questions]
+        if not isinstance(raw_questions, list):
+            return []
+        questions: List[str] = []
+        for raw_question in raw_questions:
+            question = str(raw_question or "").strip()
+            if question and question not in questions:
+                questions.append(question)
+        return questions
+
     def _detect_conflicts(self, constraints: List[Constraint]) -> List[str]:
         """Return conflicts where the same constraint type has divergent values."""
 
@@ -164,8 +269,14 @@ class RequirementsAnalyst:
     def _missing_core_inputs(self, constraints: List[Constraint]) -> List[str]:
         """Return missing core requirement categories."""
 
-        present = {normalize_constraint_type(constraint.type) for constraint in constraints}
-        return [constraint_type for constraint_type in CORE_CONSTRAINT_TYPES if constraint_type not in present]
+        present = {
+            normalize_constraint_type(constraint.type) for constraint in constraints
+        }
+        return [
+            constraint_type
+            for constraint_type in CORE_CONSTRAINT_TYPES
+            if constraint_type not in present
+        ]
 
     def _build_feedback(
         self,
@@ -173,6 +284,9 @@ class RequirementsAnalyst:
         *,
         fallback_used: bool,
         fallback_reason: str | None,
+        dialog_turn_count: int = 1,
+        clarification_questions: List[str] | None = None,
+        constraint_changes: List[str] | None = None,
     ) -> RequirementsFeedback:
         """Build structured advisory feedback from parsed constraints."""
 
@@ -192,6 +306,8 @@ class RequirementsAnalyst:
             suggestions.append(
                 "Resolve conflicting prompt instructions so the generator can pick a single interpretation."
             )
+        for question in clarification_questions or []:
+            suggestions.append(f"Clarify: {question}")
 
         return RequirementsFeedback(
             fallback_used=fallback_used,
@@ -200,6 +316,9 @@ class RequirementsAnalyst:
             conflicts=conflicts,
             suggestions=suggestions,
             available_constraint_types=list(self.constraint_types),
+            dialog_turn_count=max(dialog_turn_count, 1),
+            clarification_questions=list(clarification_questions or []),
+            constraint_changes=list(constraint_changes or []),
         )
 
     async def analyze(self, prompt: str) -> RequirementsAnalysis:
@@ -211,12 +330,18 @@ class RequirementsAnalyst:
 
         fallback_used = False
         fallback_reason: str | None = None
+        clarification_questions: List[str] = []
 
         try:
             constraints_data = extract_json_from_llm_response(response.content)
+            clarification_questions = self._extract_clarification_questions(
+                constraints_data
+            )
             constraints = self._parse_constraints_payload(constraints_data)
             if not constraints:
-                raise ValueError("No constraints were extracted from the model response.")
+                raise ValueError(
+                    "No constraints were extracted from the model response."
+                )
         except (ValueError, KeyError, TypeError) as exc:
             fallback_used = True
             fallback_reason = f"Requirements extraction fallback used: {exc}"
@@ -227,5 +352,75 @@ class RequirementsAnalyst:
             constraints,
             fallback_used=fallback_used,
             fallback_reason=fallback_reason,
+            clarification_questions=clarification_questions,
+        )
+        return RequirementsAnalysis(constraints=constraints, feedback=feedback)
+
+    async def analyze_dialog(
+        self,
+        messages: Sequence[Mapping[str, Any] | str | Any],
+        *,
+        existing_constraints: Sequence[Constraint] | None = None,
+    ) -> RequirementsAnalysis:
+        """Extract and refine constraints from a multi-turn requirements dialog."""
+
+        normalized_messages = self._normalize_dialog_messages(messages)
+        dialog_text = self._dialog_to_prompt(normalized_messages)
+        if not dialog_text:
+            return await self.analyze("")
+
+        prior_payload = [
+            constraint.model_dump(mode="json")
+            for constraint in (existing_constraints or [])
+        ]
+        user_message = HumanMessage(
+            content=(
+                "Requirements dialog transcript:\n"
+                f"{dialog_text}\n\n"
+                "Prior constraints already accepted by the generator:\n"
+                f"{json.dumps(prior_payload, indent=2)}\n\n"
+                "Return the full refined constraint set that should drive generation."
+            )
+        )
+        response = await self.llm.ainvoke(
+            [self._build_analysis_prompt(dialog_mode=True), user_message]
+        )
+
+        fallback_used = False
+        fallback_reason: str | None = None
+        clarification_questions: List[str] = []
+
+        try:
+            constraints_data = extract_json_from_llm_response(response.content)
+            clarification_questions = self._extract_clarification_questions(
+                constraints_data
+            )
+            parsed_constraints = self._parse_constraints_payload(constraints_data)
+            if not parsed_constraints and not existing_constraints:
+                raise ValueError(
+                    "No constraints were extracted from the model response."
+                )
+        except (ValueError, KeyError, TypeError) as exc:
+            fallback_used = True
+            fallback_reason = f"Requirements dialog fallback used: {exc}"
+            logger.warning(fallback_reason)
+            parsed_constraints = [self._fallback_constraint(dialog_text)]
+
+        constraints, changes = self._merge_constraints(
+            existing_constraints,
+            parsed_constraints,
+        )
+        if len(normalized_messages) > 1 and not clarification_questions:
+            changes.append(
+                f"Analyzed {len(normalized_messages)} dialog turn(s) for refinement."
+            )
+
+        feedback = self._build_feedback(
+            constraints,
+            fallback_used=fallback_used,
+            fallback_reason=fallback_reason,
+            dialog_turn_count=len(normalized_messages),
+            clarification_questions=clarification_questions,
+            constraint_changes=changes,
         )
         return RequirementsAnalysis(constraints=constraints, feedback=feedback)

--- a/src/langgraph_system_generator/generator/nodes.py
+++ b/src/langgraph_system_generator/generator/nodes.py
@@ -442,7 +442,14 @@ async def intake_node(state: GeneratorState) -> Dict[str, Any]:
         Updated state with extracted constraints
     """
     analyst = RequirementsAnalyst(model_config=_resolve_model_config(state))
-    analysis = await analyst.analyze(state["user_prompt"])
+    requirements_messages = state.get("requirements_messages") or []
+    if requirements_messages:
+        analysis = await analyst.analyze_dialog(
+            requirements_messages,
+            existing_constraints=state.get("constraints") or [],
+        )
+    else:
+        analysis = await analyst.analyze(state["user_prompt"])
 
     return {
         "constraints": analysis.constraints,

--- a/src/langgraph_system_generator/generator/state.py
+++ b/src/langgraph_system_generator/generator/state.py
@@ -148,6 +148,19 @@ class RequirementsFeedback(BaseModel):
         default_factory=list,
         description="Constraint types available to the analyst for the current request.",
     )
+    dialog_turn_count: int = Field(
+        default=1,
+        ge=1,
+        description="Number of prompt/dialog turns considered during extraction.",
+    )
+    clarification_questions: List[str] = Field(
+        default_factory=list,
+        description="Clarifying questions surfaced when dialog requirements remain underspecified.",
+    )
+    constraint_changes: List[str] = Field(
+        default_factory=list,
+        description="Short summary of how this extraction added, retained, or conflicted with prior constraints.",
+    )
 
 
 class RequirementsAnalysis(BaseModel):
@@ -825,6 +838,7 @@ class GeneratorState(TypedDict):
 
     # Input
     user_prompt: str
+    requirements_messages: Optional[List[Dict[str, str]]]
     uploaded_files: Optional[List[str]]
 
     # Extracted requirements

--- a/src/langgraph_system_generator/patterns/critique_loops.py
+++ b/src/langgraph_system_generator/patterns/critique_loops.py
@@ -173,9 +173,7 @@ Return a polished draft that can be reviewed and revised."""
     ) -> str:
         """Generate code for critique/review node."""
         if feedback_source not in {"automated", "human"}:
-            raise ValueError(
-                "feedback_source must be either 'automated' or 'human'"
-            )
+            raise ValueError("feedback_source must be either 'automated' or 'human'")
 
         if model_config is None:
             config = ModelConfig()
@@ -496,12 +494,18 @@ Address the critique directly while preserving good parts of the draft."""
         max_revisions: int = 5,
         min_quality_score: float = 0.8,
         failure_conditions: Optional[dict[str, Any]] = None,
+        require_human_approval: bool = False,
     ) -> str:
         """Generate the graph wiring for the critique loop."""
         conditional_helper = CritiqueLoopPattern.generate_conditional_edge_code(
             max_revisions=max_revisions,
             min_quality_score=min_quality_score,
             failure_conditions=failure_conditions,
+        )
+        compile_args = (
+            'checkpointer=checkpointer, interrupt_before=["revise"]'
+            if require_human_approval
+            else "checkpointer=checkpointer"
         )
         return textwrap.dedent(
             f'''from langgraph.checkpoint.memory import InMemorySaver
@@ -569,7 +573,7 @@ workflow.add_conditional_edges(
 workflow.add_edge("revise", "critique")
 workflow.add_edge("finalize", END)
 
-graph = workflow.compile(checkpointer=checkpointer)
+graph = workflow.compile({compile_args})
 '''
         )
 
@@ -583,6 +587,7 @@ graph = workflow.compile(checkpointer=checkpointer)
         use_structured_output: bool = True,
         feedback_source: str = "automated",
         failure_conditions: Optional[dict[str, Any]] = None,
+        require_human_approval: bool = False,
     ) -> str:
         """Generate a complete, runnable critique-revise loop example."""
         if criteria is None:
@@ -618,6 +623,7 @@ graph = workflow.compile(checkpointer=checkpointer)
             max_revisions=max_revisions,
             min_quality_score=min_quality_score,
             failure_conditions=failure_conditions,
+            require_human_approval=require_human_approval,
         )
 
         human_feedback_example = ""
@@ -639,7 +645,9 @@ def collect_human_feedback(
         ),
     }
 '''
-            human_state_fields = '\n        "human_feedback_handler": collect_human_feedback,'
+            human_state_fields = (
+                '\n        "human_feedback_handler": collect_human_feedback,'
+            )
 
         failure_state_fields = ""
         if failure_conditions:

--- a/src/langgraph_system_generator/patterns/hybrid.py
+++ b/src/langgraph_system_generator/patterns/hybrid.py
@@ -55,6 +55,7 @@ class WorkflowState(TypedDict, total=False):
     route_reasoning: str
     route_history: Annotated[List[str], operator.add]
     next_agent: str
+    next_agents: List[str]
     instructions: str
     iterations: int
     dispatch_log: Annotated[List[str], operator.add]
@@ -76,6 +77,7 @@ class WorkflowState(TypedDict, total=False):
             routes=routes,
             model_config=model_config,
             use_notebook_helper=use_notebook_helper,
+            include_fallback=False,
         )
 
     @staticmethod
@@ -168,9 +170,35 @@ class WorkflowState(TypedDict, total=False):
         direct_route_labels = ", ".join(
             double_quoted_literal(label) for label, _ in direct_specialist_specs
         )
+        supervisor_route_map = ",\n        ".join(
+            [
+                f"{double_quoted_literal(label)}: {double_quoted_literal(node_name)}"
+                for label, node_name in team_worker_specs
+            ]
+            + [
+                f"{double_quoted_literal(node_name)}: {double_quoted_literal(node_name)}"
+                for _, node_name in team_worker_specs
+            ]
+            + ['"FINISH": "finish"', '"finish": "finish"']
+        )
+        worker_nodes_literal = (
+            "{"
+            + ", ".join(
+                double_quoted_literal(node_name) for _, node_name in team_worker_specs
+            )
+            + "}"
+        )
+        supervisor_path_map = ", ".join(
+            [
+                f"{double_quoted_literal(node_name)}: {double_quoted_literal(node_name)}"
+                for _, node_name in team_worker_specs
+            ]
+            + ['"finish": "finish"']
+        )
 
         return f'''from langgraph.graph import END, START, StateGraph
 from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.types import Send
 
 
 def route_from_router(state: WorkflowState) -> str:
@@ -199,6 +227,29 @@ def finish_node(state: WorkflowState) -> dict:
     }}
 
 
+def supervisor_router(state: WorkflowState):
+    """Fan out to selected worker nodes or finish the hybrid workflow."""
+    route_map = {{
+        {supervisor_route_map}
+    }}
+    worker_nodes = {worker_nodes_literal}
+    requested_agents = state.get("next_agents") or []
+    if not requested_agents and state.get("next_agent"):
+        requested_agents = [state.get("next_agent")]
+
+    destinations = []
+    for agent_name in requested_agents:
+        target = route_map.get(agent_name)
+        if target == "finish":
+            return "finish"
+        if target in worker_nodes and target not in destinations:
+            destinations.append(target)
+
+    if not destinations:
+        return "finish"
+    return [Send(destination, state) for destination in destinations]
+
+
 workflow = StateGraph(WorkflowState)
 checkpointer = InMemorySaver()
 
@@ -213,6 +264,11 @@ workflow.add_conditional_edges(
     "router",
     route_from_router,
     {{{router_branch_map}}},
+)
+workflow.add_conditional_edges(
+    "supervisor",
+    supervisor_router,
+    {{{supervisor_path_map}}},
 )
 {direct_finish_edges}
 {worker_return_edges}

--- a/src/langgraph_system_generator/patterns/router.py
+++ b/src/langgraph_system_generator/patterns/router.py
@@ -13,10 +13,20 @@ from langgraph_system_generator.patterns.utils import (
 from langgraph_system_generator.utils.config import ModelConfig
 
 
-def _route_specs(routes: List[str]) -> List[tuple[str, str]]:
+def _route_specs(
+    routes: List[str],
+    *,
+    include_fallback: bool = True,
+    fallback_route: str = "fallback",
+) -> List[tuple[str, str]]:
     """Return ``(label, node_name)`` pairs for generated routes."""
     values = routes or ["default"]
-    return [(route, sanitize_identifier(route)) for route in values]
+    labels: List[str] = []
+    for route in [*values, *(["fallback"] if include_fallback else [])]:
+        label = fallback_route if route == "fallback" else route
+        if label not in labels:
+            labels.append(label)
+    return [(route, sanitize_identifier(route)) for route in labels]
 
 
 class RouterPattern:
@@ -58,6 +68,8 @@ class WorkflowState(TypedDict, total=False):
         model_config: Optional[Union[ModelConfig, dict]] = None,
         use_structured_output: bool = True,
         use_notebook_helper: bool = False,
+        include_fallback: bool = True,
+        fallback_route: str = "fallback",
     ) -> str:
         """Generate a router node that returns ``Command``."""
         if model_config is None:
@@ -67,10 +79,19 @@ class WorkflowState(TypedDict, total=False):
         else:
             config = model_config
 
-        specs = _route_specs(routes)
+        specs = _route_specs(
+            routes,
+            include_fallback=include_fallback,
+            fallback_route=fallback_route,
+        )
         route_literals = ", ".join(double_quoted_literal(label) for label, _ in specs)
         route_help = "\n".join(
-            f"- {label}: Handle {label}-specific requests." for label, _ in specs
+            (
+                f"- {label}: Handle unclear, conversational, unsupported, or out-of-domain requests."
+                if label == fallback_route
+                else f"- {label}: Handle {label}-specific requests."
+            )
+            for label, _ in specs
         )
         route_names = ", ".join(label for label, _ in specs)
         llm_init = build_llm_init(
@@ -124,6 +145,7 @@ def router_node(state: WorkflowState, window_size: int = 5) -> WorkflowState:
     system_prompt = SystemMessage(content="""You are a routing classifier.
 Analyze the recent conversation and select the most appropriate route.
 Resolve coreferences such as "it", "that", and "the one" using the conversation history.
+Use the {fallback_route} route for greetings, generic chat, unsupported requests, missing-tool requests, or anything that does not clearly belong to a specialist.
 Respond using the provided RouteDecision schema.""")
 
     classification_prompt = f"""Analyze the following conversation and determine which route should handle the user's latest request.
@@ -169,6 +191,7 @@ def router_node(state: WorkflowState, window_size: int = 5) -> WorkflowState:
     system_prompt = SystemMessage(content=f"""You are a routing classifier.
 Analyze the recent conversation and select the appropriate route from: {route_names}
 Resolve coreferences such as "it", "that", and "the one" using the conversation history.
+Use {fallback_route} for greetings, generic chat, unsupported requests, missing-tool requests, or anything that does not clearly belong to a specialist.
 Respond with ONLY the route name.""")
     
     user_prompt = HumanMessage(content=f"""Recent conversation (last {{window_size}} messages):
@@ -182,11 +205,11 @@ Route:""")
     selected_route = response.content.strip().lower()
     
     # Validate route
-    valid_routes = [r.lower() for r in routes]
+    valid_routes = [r.lower() for r in {repr([label for label, _ in specs])}]
     if not valid_routes:
         raise ValueError("Router configuration must include at least one route.")
     if selected_route not in valid_routes:
-        selected_route = valid_routes[0]  # Default to first route
+        selected_route = {double_quoted_literal(fallback_route)}  # Safe general route
     
     return {{
         "route": selected_route,
@@ -248,9 +271,15 @@ Responsibility:
         routes: List[str],
         entry_point: str = "router",
         use_conditional_edges: bool = True,
+        include_fallback: bool = True,
+        fallback_route: str = "fallback",
     ) -> str:
         """Generate a graph using dynamic ``Command``-based routing."""
-        specs = _route_specs(routes)
+        specs = _route_specs(
+            routes,
+            include_fallback=include_fallback,
+            fallback_route=fallback_route,
+        )
         entry_node = sanitize_identifier(entry_point or "router")
         node_additions = "\n".join(
             f'workflow.add_node("{node_name}", {node_name}_node)'
@@ -282,7 +311,7 @@ def route_decision(state: WorkflowState) -> str:
     """Determine next node based on router decision."""
     route = state.get("route", "")
     {route_conditions}
-    return END
+    return {double_quoted_literal(sanitize_identifier(fallback_route)) if include_fallback else "END"}
 
 
 # Create graph
@@ -316,7 +345,7 @@ graph = workflow.compile(checkpointer=memory)'''
 from langgraph.checkpoint.memory import InMemorySaver
 
 workflow = StateGraph(WorkflowState)
-memory = InMemorySaver()
+checkpointer = InMemorySaver()
 
 # Add router node
 workflow.add_node('router', router_node)
@@ -334,12 +363,22 @@ graph = workflow.compile(checkpointer=checkpointer)"""
         routes: List[str],
         route_purposes: Optional[Dict[str, str]] = None,
         model_config: Optional[Union[ModelConfig, dict]] = None,
+        include_fallback: bool = True,
+        fallback_route: str = "fallback",
     ) -> str:
         """Generate a full runnable router example."""
-        specs = _route_specs(routes)
+        specs = _route_specs(
+            routes,
+            include_fallback=include_fallback,
+            fallback_route=fallback_route,
+        )
         if route_purposes is None:
             route_purposes = {
-                label: f"Handle {label}-related tasks with clear specialist reasoning."
+                label: (
+                    "Handle general, unsupported, or unclear requests safely."
+                    if label == fallback_route
+                    else f"Handle {label}-related tasks with clear specialist reasoning."
+                )
                 for label, _ in specs
             }
 
@@ -347,13 +386,19 @@ graph = workflow.compile(checkpointer=checkpointer)"""
         router_code = RouterPattern.generate_router_node_code(
             [label for label, _ in specs],
             model_config=model_config,
+            include_fallback=include_fallback,
+            fallback_route=fallback_route,
         )
         route_nodes = "\n\n".join(
             RouterPattern.generate_route_node_code(
                 label,
                 route_purposes.get(
                     label,
-                    f"Handle {label}-related tasks with clear specialist reasoning.",
+                    (
+                        "Handle general, unsupported, or unclear requests safely."
+                        if label == fallback_route
+                        else f"Handle {label}-related tasks with clear specialist reasoning."
+                    ),
                 ),
                 model_config=model_config,
             )
@@ -361,6 +406,8 @@ graph = workflow.compile(checkpointer=checkpointer)"""
         )
         graph_code = RouterPattern.generate_graph_code(
             [label for label, _ in specs],
+            include_fallback=include_fallback,
+            fallback_route=fallback_route,
         )
 
         return f'''"""Router Pattern Example."""

--- a/src/langgraph_system_generator/patterns/router.py
+++ b/src/langgraph_system_generator/patterns/router.py
@@ -71,7 +71,7 @@ class WorkflowState(TypedDict, total=False):
         include_fallback: bool = True,
         fallback_route: str = "fallback",
     ) -> str:
-        """Generate a router node that returns ``Command``."""
+        """Generate a router node that returns state updates."""
         if model_config is None:
             config = ModelConfig()
         elif isinstance(model_config, dict):
@@ -107,7 +107,6 @@ class WorkflowState(TypedDict, total=False):
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
-from langgraph.types import Command
 from pydantic import BaseModel, Field
 
 

--- a/src/langgraph_system_generator/patterns/subagents.py
+++ b/src/langgraph_system_generator/patterns/subagents.py
@@ -45,6 +45,7 @@ class WorkflowState(TypedDict, total=False):
 
     messages: Annotated[List[BaseMessage], add_messages]
     next_agent: str
+    next_agents: List[str]
     instructions: str
     iterations: int
     dispatch_log: Annotated[List[str], operator.add]
@@ -60,7 +61,7 @@ class WorkflowState(TypedDict, total=False):
         use_structured_output: bool = True,
         use_notebook_helper: bool = False,
     ) -> str:
-        """Generate a supervisor node that routes with ``Command``."""
+        """Generate a supervisor node that prepares Send-based fan-out routing."""
         if model_config is None:
             config = ModelConfig()
         elif isinstance(model_config, dict):
@@ -70,14 +71,9 @@ class WorkflowState(TypedDict, total=False):
 
         specs = _agent_specs(subagents)
         if subagent_descriptions is None:
-            subagent_descriptions = {
-                label: f"{label} specialist" for label, _ in specs
-            }
+            subagent_descriptions = {label: f"{label} specialist" for label, _ in specs}
 
         agent_literals = ", ".join(double_quoted_literal(label) for label, _ in specs)
-        goto_literals = ", ".join(
-            [double_quoted_literal(node_name) for _, node_name in specs] + ['"finish"']
-        )
         route_map_lines = ",\n        ".join(
             f"{double_quoted_literal(label)}: {double_quoted_literal(node_name)}"
             for label, node_name in specs
@@ -95,30 +91,29 @@ class WorkflowState(TypedDict, total=False):
         )
 
         if use_structured_output:
-            return f'''from typing import Literal
+            return f'''from typing import List, Literal
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
-from langgraph.types import Command
 from pydantic import BaseModel, Field
 
 
 class SupervisorDecision(BaseModel):
-    """Typed supervisor routing decision."""
+    """Typed supervisor routing decision with optional parallel fan-out."""
 
-    next_agent: Literal[{agent_literals}, "FINISH"] = Field(
-        description="Which specialist should work next, or FINISH when done."
+    next: List[Literal[{agent_literals}, "FINISH"]] = Field(
+        description="One or more specialists that can work next, or FINISH when done."
     )
     instructions: str = Field(
-        description="Concrete next-step instructions for the selected specialist."
+        description="Concrete next-step instructions for the selected specialist(s)."
     )
     reasoning: str = Field(
         description="Why this next step is the best choice right now."
     )
 
 
-def supervisor_node(state: WorkflowState) -> Command[Literal[{goto_literals}]]:
-    """Choose the next specialist and pass along instructions."""
+def supervisor_node(state: WorkflowState) -> dict:
+    """Choose the next specialist batch and pass along instructions."""
     route_map = {{
         {route_map_lines}
     }}
@@ -126,14 +121,12 @@ def supervisor_node(state: WorkflowState) -> Command[Literal[{goto_literals}]]:
     results = state.get("task_results", {{}})
     iterations = state.get("iterations", 0)
     if iterations >= MAX_ITERATIONS:
-        return Command(
-            update={{
-                "next_agent": "FINISH",
-                "instructions": "Maximum iterations reached; synthesize the work so far.",
-                "dispatch_log": ["Supervisor stopped after reaching MAX_ITERATIONS."],
-            }},
-            goto="finish",
-        )
+        return {{
+            "next_agent": "FINISH",
+            "next_agents": ["FINISH"],
+            "instructions": "Maximum iterations reached; synthesize the work so far.",
+            "dispatch_log": ["Supervisor stopped after reaching MAX_ITERATIONS."],
+        }}
     llm = {llm_init}
 
     result_summary = "\\n".join(
@@ -147,6 +140,9 @@ def supervisor_node(state: WorkflowState) -> Command[Literal[{goto_literals}]]:
 
 Available specialists:
 {agent_overview}
+
+Select one or more specialists when their work can proceed independently.
+Select FINISH only when the accumulated results are ready to synthesize.
 """
         ),
         HumanMessage(
@@ -155,72 +151,90 @@ Available specialists:
         ),
     ])
 
-    target = "finish" if decision.next_agent == "FINISH" else route_map[decision.next_agent]
-    return Command(
-        update={{
-            "next_agent": decision.next_agent,
-            "instructions": decision.instructions,
-            "iterations": iterations + (0 if decision.next_agent == "FINISH" else 1),
-            "dispatch_log": [
-                f"Supervisor -> {{decision.next_agent}}: {{decision.reasoning}}"
-            ],
-            "messages": [
-                AIMessage(
-                    content=f"Supervisor selected {{decision.next_agent}}. {{decision.instructions}}"
-                )
-            ],
-        }},
-        goto=target,
-    )'''
+    selected_agents = []
+    finish_requested = False
+    for agent_name in decision.next:
+        if agent_name == "FINISH":
+            finish_requested = True
+            continue
+        if agent_name in route_map and agent_name not in selected_agents:
+            selected_agents.append(agent_name)
+
+    if finish_requested or not selected_agents:
+        next_agents = ["FINISH"]
+    else:
+        next_agents = selected_agents
+
+    dispatch_targets = ", ".join(next_agents)
+    return {{
+        "next_agent": next_agents[0],
+        "next_agents": next_agents,
+        "instructions": decision.instructions,
+        "iterations": iterations + (0 if next_agents == ["FINISH"] else 1),
+        "dispatch_log": [
+            f"Supervisor -> {{dispatch_targets}}: {{decision.reasoning}}"
+        ],
+        "messages": [
+            AIMessage(
+                content=f"Supervisor selected {{dispatch_targets}}. {{decision.instructions}}"
+            )
+        ],
+    }}'''
 
         default_agent = specs[0][0]
-        return f'''from typing import Literal
+        return f'''from typing import List, Literal
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
-from langgraph.types import Command
 
 
-def supervisor_node(state: WorkflowState) -> Command[Literal[{goto_literals}]]:
-    """Fallback supervisor that emits a simple route instruction."""
+def supervisor_node(state: WorkflowState) -> dict:
+    """Fallback supervisor that emits one or more route instructions."""
     route_map = {{
         {route_map_lines}
     }}
     iterations = state.get("iterations", 0)
     if iterations >= MAX_ITERATIONS:
-        return Command(
-            update={{
-                "next_agent": "FINISH",
-                "instructions": "Maximum iterations reached; synthesize the work so far.",
-                "dispatch_log": ["Supervisor stopped after reaching MAX_ITERATIONS."],
-            }},
-            goto="finish",
-        )
+        return {{
+            "next_agent": "FINISH",
+            "next_agents": ["FINISH"],
+            "instructions": "Maximum iterations reached; synthesize the work so far.",
+            "dispatch_log": ["Supervisor stopped after reaching MAX_ITERATIONS."],
+        }}
     llm = {llm_init}
     response = llm.invoke([
         SystemMessage(
-            content="Reply with AGENT|INSTRUCTIONS where AGENT is one of: {', '.join(label for label, _ in specs)}, FINISH."
+            content="Reply with AGENT[,AGENT...]|INSTRUCTIONS where AGENT is one of: {', '.join(label for label, _ in specs)}, FINISH."
         ),
         HumanMessage(content=f"Latest request: {{state.get('messages', [])[-1].content if state.get('messages') else 'Start the workflow.'}}"),
     ])
 
     raw = response.content.strip()
-    agent_name, _, instructions = raw.partition("|")
-    next_agent = agent_name.strip() or {double_quoted_literal(default_agent)}
-    if next_agent not in route_map:
-        next_agent = {double_quoted_literal(default_agent)}
-    target = route_map[next_agent]
+    agent_names, _, instructions = raw.partition("|")
+    requested_agents = [
+        name.strip()
+        for name in agent_names.split(",")
+        if name.strip()
+    ] or [{double_quoted_literal(default_agent)}]
+    if any(name == "FINISH" for name in requested_agents):
+        next_agents = ["FINISH"]
+    else:
+        next_agents = []
+        for agent_name in requested_agents:
+            if agent_name in route_map and agent_name not in next_agents:
+                next_agents.append(agent_name)
+        if not next_agents:
+            next_agents = [{double_quoted_literal(default_agent)}]
 
-    return Command(
-        update={{
-            "next_agent": next_agent,
-            "instructions": instructions.strip(),
-            "iterations": iterations + 1,
-            "dispatch_log": [f"Supervisor -> {{next_agent}}"],
-            "messages": [AIMessage(content=f"Supervisor selected {{next_agent}}")],
-        }},
-        goto=target,
-    )'''
+    dispatch_targets = ", ".join(next_agents)
+    return {{
+        "next_agent": next_agents[0],
+        "next_agents": next_agents,
+        "instructions": instructions.strip(),
+        "iterations": iterations + (0 if next_agents == ["FINISH"] else 1),
+        "dispatch_log": [f"Supervisor -> {{dispatch_targets}}"],
+        "messages": [AIMessage(content=f"Supervisor selected {{dispatch_targets}}")],
+    }}'''
 
     @staticmethod
     def generate_subagent_code(
@@ -299,9 +313,33 @@ Role:
         return_edges = "\n".join(
             f'workflow.add_edge("{node_name}", "supervisor")' for _, node_name in specs
         )
+        route_map_lines = ",\n        ".join(
+            [
+                f"{double_quoted_literal(label)}: {double_quoted_literal(node_name)}"
+                for label, node_name in specs
+            ]
+            + [
+                f"{double_quoted_literal(node_name)}: {double_quoted_literal(node_name)}"
+                for _, node_name in specs
+            ]
+            + ['"FINISH": "finish"', '"finish": "finish"']
+        )
+        worker_nodes_literal = (
+            "{"
+            + ", ".join(double_quoted_literal(node_name) for _, node_name in specs)
+            + "}"
+        )
+        path_map_entries = ", ".join(
+            [
+                f"{double_quoted_literal(node_name)}: {double_quoted_literal(node_name)}"
+                for _, node_name in specs
+            ]
+            + ['"finish": "finish"']
+        )
 
         return f'''from langgraph.graph import END, START, StateGraph
 from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.types import Send
 
 
 def finish_node(state: WorkflowState) -> dict:
@@ -319,6 +357,29 @@ def finish_node(state: WorkflowState) -> dict:
     }}
 
 
+def supervisor_router(state: WorkflowState):
+    """Fan out to selected specialists or finish when supervision is complete."""
+    route_map = {{
+        {route_map_lines}
+    }}
+    worker_nodes = {worker_nodes_literal}
+    requested_agents = state.get("next_agents") or []
+    if not requested_agents and state.get("next_agent"):
+        requested_agents = [state.get("next_agent")]
+
+    destinations = []
+    for agent_name in requested_agents:
+        target = route_map.get(agent_name)
+        if target == "finish":
+            return "finish"
+        if target in worker_nodes and target not in destinations:
+            destinations.append(target)
+
+    if not destinations:
+        return "finish"
+    return [Send(destination, state) for destination in destinations]
+
+
 workflow = StateGraph(WorkflowState)
 memory = InMemorySaver()
 checkpointer = InMemorySaver()
@@ -328,6 +389,11 @@ workflow.add_node("supervisor", supervisor_node)
 workflow.add_node("finish", finish_node)
 
 workflow.add_edge(START, "supervisor")
+workflow.add_conditional_edges(
+    "supervisor",
+    supervisor_router,
+    {{{path_map_entries}}},
+)
 {return_edges}
 workflow.add_edge("finish", END)
 
@@ -344,9 +410,7 @@ MAX_ITERATIONS = {max_iterations}'''
         """Generate a complete runnable supervisor/subagent example."""
         specs = _agent_specs(subagents)
         if subagent_descriptions is None:
-            subagent_descriptions = {
-                label: f"{label} specialist" for label, _ in specs
-            }
+            subagent_descriptions = {label: f"{label} specialist" for label, _ in specs}
 
         state_code = SubagentsPattern.generate_state_code()
         supervisor_code = SubagentsPattern.generate_supervisor_code(
@@ -388,6 +452,7 @@ def build_initial_state(user_request: str) -> WorkflowState:
         "messages": [HumanMessage(content=user_request)],
         "task_results": {{}},
         "dispatch_log": [],
+        "next_agents": [],
         "iterations": 0,
         "final_output": "",
     }}

--- a/tests/integration/test_pattern_code_generation.py
+++ b/tests/integration/test_pattern_code_generation.py
@@ -48,7 +48,7 @@ async def test_router_pattern_notebook_generation(tmp_path: Path):
     assert "Recent conversation (last {window_size} messages):" in all_code
     assert "TypedDict" in all_code, "TypedDict state not found"
     assert "route_history" in all_code, "Router reducer-backed state field missing"
-    assert "Command" in all_code, "Router should use Command-based routing"
+    assert "RouteDecision" in all_code, "Router should include typed route decisions"
 
     # Verify no empty implementations (no standalone 'pass' statements for nodes)
     # Note: We allow pass in fallback scenarios, but pattern code should not have it

--- a/tests/integration/test_pattern_code_generation.py
+++ b/tests/integration/test_pattern_code_generation.py
@@ -16,7 +16,7 @@ async def test_router_pattern_notebook_generation(tmp_path: Path):
     """Test notebook generation with router pattern."""
 
     # Set BASE_OUTPUT_DIR to allow test output in tmp_path
-    os.environ['BASE_OUTPUT_DIR'] = str(tmp_path.resolve())
+    os.environ["BASE_OUTPUT_DIR"] = str(tmp_path.resolve())
 
     # Generate notebook for router pattern
     artifacts = await generate_artifacts(
@@ -38,7 +38,9 @@ async def test_router_pattern_notebook_generation(tmp_path: Path):
     all_code = "\n\n".join([cell.source for cell in code_cells])
 
     # Verify pattern-specific code generation
-    assert "class WorkflowState(TypedDict, total=False):" in all_code, "State class not found"
+    assert (
+        "class WorkflowState(TypedDict, total=False):" in all_code
+    ), "State class not found"
     assert "route:" in all_code, "Router state field missing"
     assert (
         "def router_node(state: WorkflowState, window_size: int = 5)" in all_code
@@ -54,9 +56,9 @@ async def test_router_pattern_notebook_generation(tmp_path: Path):
     router_related = [s for s in code_sections if "def router_node" in s]
     if router_related:
         # Router node should have actual implementation, not just pass
-        assert "with_structured_output" in all_code or "ChatOpenAI" in all_code, (
-            "Router notebook should include model-backed routing logic"
-        )
+        assert (
+            "with_structured_output" in all_code or "ChatOpenAI" in all_code
+        ), "Router notebook should include model-backed routing logic"
 
     # Verify graph construction
     assert "StateGraph(WorkflowState)" in all_code, "Graph construction missing"
@@ -64,7 +66,9 @@ async def test_router_pattern_notebook_generation(tmp_path: Path):
     assert "compile" in all_code, "Graph compilation missing"
 
     execution_cells = [
-        cell for cell in nb.cells if cell.cell_type == "code" and 'config = {"configurable"' in cell.source
+        cell
+        for cell in nb.cells
+        if cell.cell_type == "code" and 'config = {"configurable"' in cell.source
     ]
     assert execution_cells, "Execution cell missing"
     execution_source = execution_cells[0].source
@@ -78,7 +82,7 @@ async def test_subagents_pattern_notebook_generation(tmp_path: Path):
     """Test notebook generation with subagents pattern."""
 
     # Set BASE_OUTPUT_DIR to allow test output in tmp_path
-    os.environ['BASE_OUTPUT_DIR'] = str(tmp_path.resolve())
+    os.environ["BASE_OUTPUT_DIR"] = str(tmp_path.resolve())
 
     # Generate notebook for subagents pattern
     artifacts = await generate_artifacts(
@@ -102,15 +106,19 @@ async def test_subagents_pattern_notebook_generation(tmp_path: Path):
     # Verify pattern-specific code generation
     assert "TypedDict" in all_code, "TypedDict state not found"
     assert "next_agent:" in all_code, "Supervisor state field 'next_agent' missing"
+    assert "next_agents:" in all_code, "Supervisor state field 'next_agents' missing"
     assert "instructions:" in all_code, "Supervisor state field 'instructions' missing"
-    assert "Command" in all_code, "Supervisor should use Command-based routing"
+    assert "Send" in all_code, "Supervisor should use Send-based fan-out routing"
+    assert "def supervisor_router" in all_code, "Supervisor router missing"
 
     # Verify graph construction
     assert "StateGraph(WorkflowState)" in all_code, "Graph construction missing"
     assert "finish_node" in all_code, "Finish node missing"
 
     execution_cells = [
-        cell for cell in nb.cells if cell.cell_type == "code" and 'config = {"configurable"' in cell.source
+        cell
+        for cell in nb.cells
+        if cell.cell_type == "code" and 'config = {"configurable"' in cell.source
     ]
     assert execution_cells, "Execution cell missing"
     execution_source = execution_cells[0].source
@@ -124,7 +132,7 @@ async def test_tool_code_generation_not_empty(tmp_path: Path):
     """Test that tools have real implementations, not just 'pass' statements."""
 
     # Set BASE_OUTPUT_DIR to allow test output in tmp_path
-    os.environ['BASE_OUTPUT_DIR'] = str(tmp_path.resolve())
+    os.environ["BASE_OUTPUT_DIR"] = str(tmp_path.resolve())
 
     # Generate notebook that should have tools
     artifacts = await generate_artifacts(
@@ -147,12 +155,16 @@ async def test_tool_code_generation_not_empty(tmp_path: Path):
         if "# Tool:" in cell.source or (
             "def " in cell.source and "_tool" in cell.source.lower()
         ):
-            assert "pass" not in cell.source, f"Tool implementation should not contain pass: {cell.source[:200]}"
-            assert "TODO" not in cell.source, f"Tool implementation should not contain TODO: {cell.source[:200]}"
+            assert (
+                "pass" not in cell.source
+            ), f"Tool implementation should not contain pass: {cell.source[:200]}"
+            assert (
+                "TODO" not in cell.source
+            ), f"Tool implementation should not contain TODO: {cell.source[:200]}"
             assert "Implement your tool logic here" not in cell.source
-            assert any(marker in cell.source for marker in meaningful_markers), (
-                f"Tool implementation lacks meaningful logic markers: {cell.source[:200]}"
-            )
+            assert any(
+                marker in cell.source for marker in meaningful_markers
+            ), f"Tool implementation lacks meaningful logic markers: {cell.source[:200]}"
 
     # It's ok if no tools found for some prompts
     # The main check is if tools exist, they should have meaningful content
@@ -163,7 +175,7 @@ async def test_node_code_generation_not_empty(tmp_path: Path):
     """Test that nodes have real implementations or meaningful templates."""
 
     # Set BASE_OUTPUT_DIR to allow test output in tmp_path
-    os.environ['BASE_OUTPUT_DIR'] = str(tmp_path.resolve())
+    os.environ["BASE_OUTPUT_DIR"] = str(tmp_path.resolve())
 
     # Generate notebook
     artifacts = await generate_artifacts(
@@ -185,9 +197,15 @@ async def test_node_code_generation_not_empty(tmp_path: Path):
     for cell in code_cells:
         if "def " in cell.source and "_node(state:" in cell.source:
             node_found = True
-            assert "return state" not in cell.source, f"Node implementation contains stub return: {cell.source[:200]}"
-            assert "pass" not in cell.source, f"Node implementation contains pass: {cell.source[:200]}"
-            assert "TODO: Implement" not in cell.source, f"Node implementation contains TODO placeholder: {cell.source[:200]}"
+            assert (
+                "return state" not in cell.source
+            ), f"Node implementation contains stub return: {cell.source[:200]}"
+            assert (
+                "pass" not in cell.source
+            ), f"Node implementation contains pass: {cell.source[:200]}"
+            assert (
+                "TODO: Implement" not in cell.source
+            ), f"Node implementation contains TODO placeholder: {cell.source[:200]}"
             has_logic = any(
                 keyword in cell.source
                 for keyword in [
@@ -211,7 +229,7 @@ async def test_generated_code_is_syntactically_valid(tmp_path: Path):
     """Test that all generated Python code is syntactically valid."""
 
     # Set BASE_OUTPUT_DIR to allow test output in tmp_path
-    os.environ['BASE_OUTPUT_DIR'] = str(tmp_path.resolve())
+    os.environ["BASE_OUTPUT_DIR"] = str(tmp_path.resolve())
 
     # Generate notebook
     artifacts = await generate_artifacts(
@@ -232,12 +250,15 @@ async def test_generated_code_is_syntactically_valid(tmp_path: Path):
     for i, cell in enumerate(code_cells):
         try:
             # Skip cells with magic commands
-            if cell.source.strip().startswith("!") or cell.source.strip().startswith("%"):
+            if cell.source.strip().startswith("!") or cell.source.strip().startswith(
+                "%"
+            ):
                 continue
 
             # Filter out magic commands from within cells
             clean_source = "\n".join(
-                line for line in cell.source.split("\n")
+                line
+                for line in cell.source.split("\n")
                 if not line.strip().startswith("!") and not line.strip().startswith("%")
             )
 
@@ -254,7 +275,7 @@ async def test_pattern_selection_based_on_prompt(tmp_path: Path):
     """Test that different prompts result in appropriate pattern selection."""
 
     # Set BASE_OUTPUT_DIR to allow test output in tmp_path
-    os.environ['BASE_OUTPUT_DIR'] = str(tmp_path.resolve())
+    os.environ["BASE_OUTPUT_DIR"] = str(tmp_path.resolve())
 
     # Test router pattern selection
     artifacts_router = await generate_artifacts(
@@ -281,7 +302,7 @@ async def test_complete_workflow_has_no_broken_references(tmp_path: Path):
     """Test that generated notebooks have no undefined variable references."""
 
     # Set BASE_OUTPUT_DIR to allow test output in tmp_path
-    os.environ['BASE_OUTPUT_DIR'] = str(tmp_path.resolve())
+    os.environ["BASE_OUTPUT_DIR"] = str(tmp_path.resolve())
 
     # Generate notebook
     artifacts = await generate_artifacts(
@@ -324,7 +345,7 @@ async def test_notebooks_include_execution_section(tmp_path: Path):
     """Test that generated notebooks include complete execution sections."""
 
     # Set BASE_OUTPUT_DIR to allow test output in tmp_path
-    os.environ['BASE_OUTPUT_DIR'] = str(tmp_path.resolve())
+    os.environ["BASE_OUTPUT_DIR"] = str(tmp_path.resolve())
 
     # Generate notebook
     artifacts = await generate_artifacts(

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -356,6 +356,56 @@ async def test_api_generate_stub(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 
 
 @pytest.mark.asyncio
+async def test_api_generate_stub_accepts_dialog_messages_without_legacy_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Dialog requests should derive the legacy prompt from the latest user turn."""
+
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_api_dialog_stub")
+
+    import importlib
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.api.server as server_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(server_module)
+
+    transport = httpx.ASGITransport(app=server_module.app)
+    output_dir = constants_module._BASE_OUTPUT / tmp_path.name
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/generate",
+            json={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Build a router workflow.",
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "Which model and runtime should it use?",
+                    },
+                    {
+                        "role": "user",
+                        "content": "Use gpt-5.4-mini in a portable notebook.",
+                    },
+                ],
+                "mode": "stub",
+                "output_dir": str(output_dir),
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["prompt"] == "Use gpt-5.4-mini in a portable notebook."
+    assert payload["manifest"]["prompt"] == "Use gpt-5.4-mini in a portable notebook."
+
+
+@pytest.mark.asyncio
 async def test_api_generate_stub_accepts_deepagents_agent_type(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/unit/test_cli_api.py
+++ b/tests/unit/test_cli_api.py
@@ -406,6 +406,77 @@ async def test_api_generate_stub_accepts_dialog_messages_without_legacy_prompt(
 
 
 @pytest.mark.asyncio
+async def test_api_generate_stub_prefers_dialog_when_prompt_is_whitespace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Whitespace prompt values should fall back to the latest user dialog turn."""
+
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_api_dialog_prefers_messages")
+
+    import importlib
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.api.server as server_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(server_module)
+
+    transport = httpx.ASGITransport(app=server_module.app)
+    output_dir = constants_module._BASE_OUTPUT / tmp_path.name
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/generate",
+            json={
+                "prompt": "   ",
+                "messages": [
+                    {"role": "assistant", "content": "What should I build?"},
+                    {"role": "user", "content": "Create a concise router workflow."},
+                ],
+                "mode": "stub",
+                "output_dir": str(output_dir),
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["prompt"] == "Create a concise router workflow."
+    assert payload["manifest"]["prompt"] == "Create a concise router workflow."
+
+
+@pytest.mark.asyncio
+async def test_api_generate_rejects_whitespace_only_dialog_message(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("LNF_OUTPUT_BASE", "test_api_dialog_invalid_message")
+
+    import importlib
+    import langgraph_system_generator.constants as constants_module
+    import langgraph_system_generator.notebook.exporters as exporters_module
+    import langgraph_system_generator.api.server as server_module
+
+    importlib.reload(constants_module)
+    importlib.reload(exporters_module)
+    importlib.reload(server_module)
+
+    transport = httpx.ASGITransport(app=server_module.app)
+    output_dir = constants_module._BASE_OUTPUT / tmp_path.name
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/generate",
+            json={
+                "messages": [{"role": "user", "content": "   "}],
+                "mode": "stub",
+                "output_dir": str(output_dir),
+            },
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_api_generate_stub_accepts_deepagents_agent_type(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/unit/test_generator_agents.py
+++ b/tests/unit/test_generator_agents.py
@@ -414,6 +414,70 @@ async def test_requirements_analyst_detects_conflicts_and_missing_inputs(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_requirements_analyst_refines_multi_turn_dialog_with_prior_constraints(
+    monkeypatch,
+):
+    """Dialog analysis should retain prior constraints and add latest-turn details."""
+
+    captured_messages = []
+    monkeypatch.setattr(
+        requirements_analyst,
+        "ChatOpenAI",
+        make_recording_llm(
+            """
+            {
+              "constraints": [
+                {
+                  "type": "runtime",
+                  "value": "Use gpt-5.4-mini",
+                  "priority": 4,
+                  "confidence": 0.86
+                }
+              ],
+              "clarification_questions": [
+                "Should the notebook target Colab or local Jupyter?"
+              ]
+            }
+            """,
+            captured_messages,
+        ),
+    )
+
+    analyst = requirements_analyst.RequirementsAnalyst()
+    prior = [
+        Constraint(
+            type="goal",
+            value="Build a router workflow",
+            priority=5,
+        )
+    ]
+    analysis = await analyst.analyze_dialog(
+        [
+            {"role": "user", "content": "Build a router workflow."},
+            {"role": "assistant", "content": "Which model should it use?"},
+            {"role": "user", "content": "Use gpt-5.4-mini."},
+        ],
+        existing_constraints=prior,
+    )
+
+    assert [constraint.type for constraint in analysis.constraints] == [
+        "goal",
+        "runtime",
+    ]
+    assert analysis.constraints[0].value == "Build a router workflow"
+    assert analysis.constraints[1].value == "Use gpt-5.4-mini"
+    assert analysis.feedback.dialog_turn_count == 3
+    assert analysis.feedback.clarification_questions == [
+        "Should the notebook target Colab or local Jupyter?"
+    ]
+    assert any(
+        "Retained 1 prior" in change for change in analysis.feedback.constraint_changes
+    )
+    assert captured_messages
+    assert "Prior constraints already accepted" in captured_messages[0][1].content
+
+
+@pytest.mark.asyncio
 async def test_requirements_analyst_uses_configured_constraint_type_registry(
     monkeypatch,
 ):

--- a/tests/unit/test_generator_nodes.py
+++ b/tests/unit/test_generator_nodes.py
@@ -73,6 +73,54 @@ async def test_intake_node_returns_constraints():
 
 
 @pytest.mark.asyncio
+async def test_intake_node_uses_dialog_refinement_when_messages_are_present():
+    constraints = [
+        Constraint(type="goal", value="Build a router workflow", priority=5),
+        Constraint(type="runtime", value="Use gpt-5.4-mini", priority=4),
+    ]
+    feedback = RequirementsFeedback(
+        fallback_used=False,
+        dialog_turn_count=2,
+        constraint_changes=["Retained 1 prior constraint(s)."],
+    )
+
+    with patch(
+        "langgraph_system_generator.generator.agents.requirements_analyst.ChatOpenAI",
+        return_value=MagicMock(),
+    ):
+        with patch.object(
+            RequirementsAnalyst,
+            "analyze_dialog",
+            new=AsyncMock(
+                return_value=RequirementsAnalysis(
+                    constraints=constraints,
+                    feedback=feedback,
+                )
+            ),
+        ) as mock_analyze_dialog:
+            result = await intake_node(
+                {
+                    "user_prompt": "Use gpt-5.4-mini.",
+                    "constraints": [constraints[0]],
+                    "requirements_messages": [
+                        {"role": "user", "content": "Build a router workflow."},
+                        {"role": "user", "content": "Use gpt-5.4-mini."},
+                    ],
+                }
+            )
+
+    assert result["constraints"] == constraints
+    assert result["requirements_feedback"].dialog_turn_count == 2
+    mock_analyze_dialog.assert_awaited_once_with(
+        [
+            {"role": "user", "content": "Build a router workflow."},
+            {"role": "user", "content": "Use gpt-5.4-mini."},
+        ],
+        existing_constraints=[constraints[0]],
+    )
+
+
+@pytest.mark.asyncio
 async def test_tooling_plan_node_returns_tools_plan():
     constraints = [Constraint(type="goal", value="Build agents", priority=5)]
     workflow_design = {"nodes": [{"name": "agent", "purpose": "coordinate"}]}

--- a/tests/unit/test_patterns.py
+++ b/tests/unit/test_patterns.py
@@ -48,6 +48,8 @@ class TestRouterPattern:
         assert '"search"' in code
         assert '"analyze"' in code
         assert '"summarize"' in code
+        assert '"fallback"' in code
+        assert "unsupported requests" in code
         assert "with_structured_output" in code
 
     def test_generate_router_node_code_simple(self):
@@ -80,6 +82,7 @@ class TestRouterPattern:
         assert "def route_decision(state: WorkflowState)" in code
         assert "StateGraph(WorkflowState)" in code
         assert 'workflow.add_node("router", router_node)' in code
+        assert 'workflow.add_node("fallback", fallback_node)' in code
         assert "add_conditional_edges" in code
         assert "InMemorySaver()" in code
 
@@ -291,7 +294,8 @@ class TestHybridPattern:
         assert 'workflow.add_edge("worker", "supervisor")' in code
         supervisor_code = HybridPattern.generate_supervisor_code([])
         assert '"worker": "worker"' in supervisor_code
-        assert 'Command[Literal["worker", "finish"]]' in supervisor_code
+        assert "next: List[Literal" in supervisor_code
+        assert "next_agents" in supervisor_code
         assert "researcher" not in code
         assert "reviewer" not in code
 
@@ -355,7 +359,9 @@ class TestDeepAgentsPattern:
 
     def test_example_live_mode_explains_missing_optional_sdk(self, monkeypatch):
         example_path = (
-            Path(__file__).resolve().parents[2] / "examples" / "deepagents_pattern_example.py"
+            Path(__file__).resolve().parents[2]
+            / "examples"
+            / "deepagents_pattern_example.py"
         )
         spec = importlib.util.spec_from_file_location(
             "deepagents_pattern_example_for_test",
@@ -1101,7 +1107,7 @@ def test_router_pattern_emits_typed_state_and_command_routing():
     assert "add_conditional_edges" not in graph_code
 
 
-def test_subagents_pattern_emits_supervisor_command_flow_and_finish_node():
+def test_subagents_pattern_emits_send_fanout_flow_and_finish_node():
     state_code = SubagentsPattern.generate_state_code(
         additional_fields={"priority": "Task priority"}
     )
@@ -1123,7 +1129,8 @@ def test_subagents_pattern_emits_supervisor_command_flow_and_finish_node():
     assert "priority: str" in state_code
 
     assert "SupervisorDecision" in supervisor_code
-    assert "Command" in supervisor_code
+    assert "next: List[Literal" in supervisor_code
+    assert "next_agents" in supervisor_code
     assert "with_structured_output" in supervisor_code
     assert "MAX_ITERATIONS" in supervisor_code
     assert "ChatOpenAI(" in supervisor_code
@@ -1134,8 +1141,45 @@ def test_subagents_pattern_emits_supervisor_command_flow_and_finish_node():
     assert "lookup_context" in tool_agent_code
 
     assert "finish_node" in graph_code
+    assert "from langgraph.types import Send" in graph_code
+    assert "def supervisor_router" in graph_code
+    assert "return [Send(destination, state)" in graph_code
     assert "InMemorySaver" in graph_code
     assert 'workflow.add_edge("researcher", "supervisor")' in graph_code
+
+
+def test_router_pattern_emits_general_fallback_route_contract():
+    router_code = RouterPattern.generate_router_node_code(["weather"])
+    graph_code = RouterPattern.generate_graph_code(["weather"])
+    route_code = RouterPattern.generate_complete_example(["weather"])
+
+    assert 'route: Literal["weather", "fallback"]' in router_code
+    assert "Use the fallback route for greetings" in router_code
+    assert 'workflow.add_node("fallback", fallback_node)' in graph_code
+    assert 'return "fallback"' in graph_code
+    assert "def fallback_node" in route_code
+
+
+def test_critique_loop_can_compile_with_interrupt_before_revise():
+    code = CritiqueLoopPattern.generate_graph_code(require_human_approval=True)
+
+    assert 'interrupt_before=["revise"]' in code
+    assert "checkpointer=checkpointer" in code
+
+
+def test_subagents_pattern_emits_send_based_map_reduce_router():
+    state_code = SubagentsPattern.generate_state_code()
+    supervisor_code = SubagentsPattern.generate_supervisor_code(
+        ["researcher", "writer"]
+    )
+    graph_code = SubagentsPattern.generate_graph_code(["researcher", "writer"])
+
+    assert "next_agents: List[str]" in state_code
+    assert 'next: List[Literal["researcher", "writer", "FINISH"]]' in supervisor_code
+    assert '"next_agents": next_agents' in supervisor_code
+    assert "from langgraph.types import Send" in graph_code
+    assert "workflow.add_conditional_edges(" in graph_code
+    assert "return [Send(destination, state)" in graph_code
 
 
 def test_critique_loop_pattern_emits_structured_judging_and_finalize_path():

--- a/tests/unit/test_patterns.py
+++ b/tests/unit/test_patterns.py
@@ -1093,7 +1093,7 @@ def test_router_pattern_emits_typed_state_and_command_routing():
     assert "route_history" in state_code
     assert "user_id: str" in state_code
 
-    assert "Command" in router_code
+    assert "from langgraph.types import Command" not in router_code
     assert "RouteDecision" in router_code
     assert "with_structured_output" in router_code
     assert "temperature=0" in router_code


### PR DESCRIPTION
## Summary
- closes #60 by adding a generated router fallback/general route across router literals, prompts, graph wiring, notebook composition, and stub assembly
- closes #63 by adding `require_human_approval` critique-loop graph generation with `interrupt_before=["revise"]` and checkpointing
- closes #64 by moving supervisor/subagent and hybrid worker dispatch to Send-based fan-out with `next_agents` state and reducer-backed result accumulation
- closes #202 by adding optional API/intake dialog messages and `RequirementsAnalyst.analyze_dialog(...)` for multi-turn constraint refinement
- refreshes MemoryBank/current plan docs after PR #360 closed generated-output epic #342

## Validation
- `python -m pytest tests/unit/test_patterns.py tests/patterns/test_router.py tests/patterns/test_critique_loops.py -q` (167 passed)
- `python -m pytest tests/unit/test_generator_agents.py tests/unit/test_generator_nodes.py tests/unit/test_cli_api.py --asyncio-mode=auto -q` (115 passed)
- `python -m pytest tests/unit/ --asyncio-mode=auto -q` (646 passed, 4 warnings)
- `python -m pytest tests/integration/test_pattern_code_generation.py --asyncio-mode=auto -q` (8 passed)
- `python -m pytest --asyncio-mode=auto -q` (764 passed, 3 skipped, 4 warnings)
- `python -m pytest tests/unit/test_documentation_coverage.py -q` (5 passed)
- `python -m flake8 src tests --count --select=E9,F63,F7,F82 --show-source --statistics` (0)
- `git diff --check`
- exact conflict-marker scan with `rg -n "^(<<<<<<<|=======|>>>>>>>)"`