### PR TITLE
[codex] Normalize START and END sentinel edges

### DIFF
--- a/src/langgraph_system_generator/generator/agents/graph_designer.py
+++ b/src/langgraph_system_generator/generator/agents/graph_designer.py
@@ -21,6 +21,9 @@ from langgraph_system_generator.generator.graph_design_registry import (
     normalize_graph_design,
     validate_graph_design,
 )
+from langgraph_system_generator.generator.graph_sentinels import (
+    normalize_sentinel_edges,
+)
 from langgraph_system_generator.generator.state import (
     Constraint,
     GraphDesignFeedback,
@@ -99,6 +102,12 @@ class GraphDesigner:
                 "8. entry_point: Starting node\n"
                 "9. compiled_graph_variable: Compiled graph variable name, normally graph\n"
                 "10. checkpointing: Whether to enable checkpointing\n\n"
+                "Sentinel rules:\n"
+                "- Prefer entry_point to represent LangGraph START.\n"
+                "- Prefer a terminal node with no outgoing route to represent LangGraph END.\n"
+                "- Never declare START, __start__, END, or __end__ as nodes.\n"
+                "- Direct START -> node and node -> END edges are accepted as shorthand and normalized.\n"
+                "- START may only be an edge source and END may only be an edge target.\n\n"
                 "For generated tool execution paths, prefer ToolNode for custom StateGraph workflows. "
                 "When a prebuilt agent loop is the better fit, prefer langchain.agents.create_agent; "
                 "treat langgraph.prebuilt.create_react_agent as legacy compatibility, not the default for new designs.\n\n"
@@ -157,8 +166,8 @@ class GraphDesigner:
         try:
             response = await self.llm.ainvoke([design_prompt, user_message])
             payload = extract_json_from_llm_response(response.content)
-            live_result = normalize_graph_design(
-                payload, architecture_type, registration
+            live_result = normalize_sentinel_edges(
+                normalize_graph_design(payload, architecture_type, registration)
             )
             if not live_result.domain_terms:
                 live_result = live_result.model_copy(
@@ -270,10 +279,12 @@ class GraphDesigner:
             architecture=architecture,
             constraints=constraints,
         )
-        fallback_result = normalize_graph_design(
-            fallback_payload,
-            registration.architecture_id,
-            registration,
+        fallback_result = normalize_sentinel_edges(
+            normalize_graph_design(
+                fallback_payload,
+                registration.architecture_id,
+                registration,
+            )
         )
         fallback_issues = validate_graph_design(fallback_result, registration)
         if self._has_blocking_issues(fallback_issues):

--- a/src/langgraph_system_generator/generator/graph_sentinels.py
+++ b/src/langgraph_system_generator/generator/graph_sentinels.py
@@ -19,7 +19,11 @@ def normalize_sentinel_edges(result: GraphDesignResult) -> GraphDesignResult:
     """
 
     entry_point = result.entry_point.strip()
-    node_names = {node.name for node in result.nodes}
+    node_names = {node.name.strip() for node in result.nodes}
+    reserved_nodes = node_names & (START_TARGETS | END_TARGETS)
+    if reserved_nodes:
+        nodes = ", ".join(sorted(reserved_nodes))
+        raise ValueError(f"Sentinel node ids must not be declared: {nodes}.")
     normalized_edges: list[GraphEdgeSpec] = []
     start_targets: set[str] = set()
     terminal_sources: set[str] = set()
@@ -48,7 +52,9 @@ def normalize_sentinel_edges(result: GraphDesignResult) -> GraphDesignResult:
             terminal_sources.add(source)
             continue
 
-        normalized_edges.append(edge)
+        normalized_edges.append(
+            edge.model_copy(update={'source': source, 'target': target})
+        )
 
     if len(start_targets) > 1:
         targets = ", ".join(sorted(start_targets))
@@ -63,9 +69,9 @@ def normalize_sentinel_edges(result: GraphDesignResult) -> GraphDesignResult:
             )
         entry_point = start_target
 
-    outgoing_sources = {edge.source for edge in normalized_edges}
-    outgoing_sources.update(edge.source for edge in result.conditional_edges)
-    outgoing_sources.update(route.source for route in result.command_routes)
+    outgoing_sources = {edge.source.strip() for edge in normalized_edges}
+    outgoing_sources.update(edge.source.strip() for edge in result.conditional_edges)
+    outgoing_sources.update(route.source.strip() for route in result.command_routes)
     ambiguous_terminals = terminal_sources & outgoing_sources
     if ambiguous_terminals:
         nodes = ", ".join(sorted(ambiguous_terminals))

--- a/src/langgraph_system_generator/generator/graph_sentinels.py
+++ b/src/langgraph_system_generator/generator/graph_sentinels.py
@@ -1,0 +1,82 @@
+"""Normalize LangGraph START/END sentinel shorthand in graph designs."""
+
+from __future__ import annotations
+
+from langgraph_system_generator.generator.state import GraphDesignResult, GraphEdgeSpec
+
+START_TARGETS = {"START", "__start__"}
+END_TARGETS = {"END", "__end__"}
+
+
+def normalize_sentinel_edges(result: GraphDesignResult) -> GraphDesignResult:
+    """Convert direct START/END edges into the canonical graph-design schema.
+
+    The graph-design schema represents START with ``entry_point`` and represents
+    END by leaving a terminal node without an outgoing route. Language models
+    often emit the equivalent LangGraph shorthand as direct edges. Accept that
+    syntax at the input boundary, normalize it, and retain strict validation for
+    every real node and route afterward.
+    """
+
+    entry_point = result.entry_point.strip()
+    node_names = {node.name for node in result.nodes}
+    normalized_edges: list[GraphEdgeSpec] = []
+    start_targets: set[str] = set()
+    terminal_sources: set[str] = set()
+
+    for edge in result.edges:
+        source = edge.source.strip()
+        target = edge.target.strip()
+
+        if source in START_TARGETS:
+            if target in START_TARGETS or target in END_TARGETS:
+                raise ValueError(f"Invalid START edge target '{target}'.")
+            start_targets.add(target)
+            continue
+
+        if target in START_TARGETS:
+            raise ValueError("START may only be used as an edge source.")
+
+        if source in END_TARGETS:
+            raise ValueError("END may only be used as an edge target.")
+
+        if target in END_TARGETS:
+            if source not in node_names:
+                raise ValueError(
+                    f"END edge source '{source}' does not match any declared node."
+                )
+            terminal_sources.add(source)
+            continue
+
+        normalized_edges.append(edge)
+
+    if len(start_targets) > 1:
+        targets = ", ".join(sorted(start_targets))
+        raise ValueError(f"Conflicting START edge targets: {targets}.")
+
+    if start_targets:
+        start_target = next(iter(start_targets))
+        if entry_point and entry_point != start_target:
+            raise ValueError(
+                "Conflicting entry points: "
+                f"entry_point='{entry_point}' but START targets '{start_target}'."
+            )
+        entry_point = start_target
+
+    outgoing_sources = {edge.source for edge in normalized_edges}
+    outgoing_sources.update(edge.source for edge in result.conditional_edges)
+    outgoing_sources.update(route.source for route in result.command_routes)
+    ambiguous_terminals = terminal_sources & outgoing_sources
+    if ambiguous_terminals:
+        nodes = ", ".join(sorted(ambiguous_terminals))
+        raise ValueError(
+            "Nodes cannot have an unconditional END edge and another outgoing "
+            f"route: {nodes}."
+        )
+
+    return result.model_copy(
+        update={
+            "entry_point": entry_point,
+            "edges": normalized_edges,
+        }
+    )

--- a/tests/unit/test_graph_sentinels.py
+++ b/tests/unit/test_graph_sentinels.py
@@ -1,0 +1,218 @@
+"""Tests for START/END sentinel-edge normalization."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from langgraph_system_generator.generator.agents.graph_designer import GraphDesigner
+from langgraph_system_generator.generator.graph_sentinels import normalize_sentinel_edges
+from langgraph_system_generator.generator.state import (
+    GraphCommandRouteSpec,
+    GraphConditionalEdgeSpec,
+    GraphDesignResult,
+    GraphEdgeSpec,
+    GraphNodeSpec,
+)
+
+
+class DummyResponse:
+    """Simple LLM response stub."""
+
+    def __init__(self, content: str):
+        self.content = content
+
+
+class StubLLM:
+    """Return one fixed graph-design payload."""
+
+    def __init__(self, payload: dict):
+        self.payload = payload
+
+    async def ainvoke(self, _messages):
+        return DummyResponse(json.dumps(self.payload))
+
+
+def make_result(
+    *,
+    edges: list[GraphEdgeSpec],
+    entry_point: str = "",
+    conditional_edges: list[GraphConditionalEdgeSpec] | None = None,
+    command_routes: list[GraphCommandRouteSpec] | None = None,
+) -> GraphDesignResult:
+    """Build a compact graph result for normalization tests."""
+
+    return GraphDesignResult(
+        architecture_type="router",
+        state_schema={"messages": "Message history"},
+        nodes=[
+            GraphNodeSpec(name="intake", purpose="Accept the task"),
+            GraphNodeSpec(name="finalize", purpose="Finalize the result"),
+            GraphNodeSpec(name="repair", purpose="Repair a failed result"),
+        ],
+        edges=edges,
+        conditional_edges=conditional_edges or [],
+        command_routes=command_routes or [],
+        entry_point=entry_point,
+    )
+
+
+def test_start_edge_sets_entry_point_and_is_removed():
+    result = make_result(edges=[GraphEdgeSpec(**{"from": "START", "to": "intake"})])
+
+    normalized = normalize_sentinel_edges(result)
+
+    assert normalized.entry_point == "intake"
+    assert normalized.edges == []
+
+
+def test_lowercase_langgraph_start_sentinel_is_supported():
+    result = make_result(
+        edges=[GraphEdgeSpec(**{"from": "__start__", "to": "intake"})]
+    )
+
+    normalized = normalize_sentinel_edges(result)
+
+    assert normalized.entry_point == "intake"
+
+
+def test_end_edge_makes_source_terminal_by_removing_edge():
+    result = make_result(
+        entry_point="intake",
+        edges=[
+            GraphEdgeSpec(**{"from": "intake", "to": "finalize"}),
+            GraphEdgeSpec(**{"from": "finalize", "to": "END"}),
+        ],
+    )
+
+    normalized = normalize_sentinel_edges(result)
+
+    assert [(edge.source, edge.target) for edge in normalized.edges] == [
+        ("intake", "finalize")
+    ]
+
+
+def test_conflicting_start_edge_and_entry_point_fails():
+    result = make_result(
+        entry_point="finalize",
+        edges=[GraphEdgeSpec(**{"from": "START", "to": "intake"})],
+    )
+
+    with pytest.raises(ValueError, match="Conflicting entry points"):
+        normalize_sentinel_edges(result)
+
+
+def test_multiple_start_destinations_fail():
+    result = make_result(
+        edges=[
+            GraphEdgeSpec(**{"from": "START", "to": "intake"}),
+            GraphEdgeSpec(**{"from": "__start__", "to": "finalize"}),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Conflicting START edge targets"):
+        normalize_sentinel_edges(result)
+
+
+def test_start_cannot_be_an_edge_target():
+    result = make_result(
+        entry_point="intake",
+        edges=[GraphEdgeSpec(**{"from": "intake", "to": "START"})],
+    )
+
+    with pytest.raises(ValueError, match="START may only be used as an edge source"):
+        normalize_sentinel_edges(result)
+
+
+def test_end_cannot_be_an_edge_source():
+    result = make_result(
+        entry_point="intake",
+        edges=[GraphEdgeSpec(**{"from": "END", "to": "finalize"})],
+    )
+
+    with pytest.raises(ValueError, match="END may only be used as an edge target"):
+        normalize_sentinel_edges(result)
+
+
+def test_unknown_end_edge_source_fails_before_edge_is_removed():
+    result = make_result(
+        entry_point="intake",
+        edges=[GraphEdgeSpec(**{"from": "missing", "to": "END"})],
+    )
+
+    with pytest.raises(ValueError, match="does not match any declared node"):
+        normalize_sentinel_edges(result)
+
+
+def test_unconditional_end_cannot_coexist_with_direct_route():
+    result = make_result(
+        entry_point="intake",
+        edges=[
+            GraphEdgeSpec(**{"from": "intake", "to": "END"}),
+            GraphEdgeSpec(**{"from": "intake", "to": "repair"}),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="another outgoing route"):
+        normalize_sentinel_edges(result)
+
+
+def test_unconditional_end_cannot_coexist_with_conditional_route():
+    result = make_result(
+        entry_point="intake",
+        edges=[GraphEdgeSpec(**{"from": "intake", "to": "END"})],
+        conditional_edges=[
+            GraphConditionalEdgeSpec(
+                **{
+                    "from": "intake",
+                    "condition": "Repair when needed",
+                    "branches": {"repair": "repair", "finish": "END"},
+                }
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="another outgoing route"):
+        normalize_sentinel_edges(result)
+
+
+@pytest.mark.asyncio
+async def test_graph_designer_accepts_direct_start_and_end_shorthand():
+    payload = {
+        "state_schema": {"messages": "Message history"},
+        "nodes": [
+            {"name": "intake", "purpose": "Accept the task", "role": "router"},
+            {"name": "finalize", "purpose": "Finalize the result", "role": "worker"},
+        ],
+        "edges": [
+            {"from": "START", "to": "intake"},
+            {"from": "intake", "to": "finalize"},
+            {"from": "finalize", "to": "END"},
+        ],
+        "conditional_edges": [],
+        "command_routes": [],
+        "tool_reachability": [],
+        "entry_point": "",
+        "compiled_graph_variable": "graph",
+        "checkpointing": True,
+    }
+
+    with patch(
+        "langgraph_system_generator.generator.agents.graph_designer.build_chat_llm",
+        return_value=StubLLM(payload),
+    ):
+        designer = GraphDesigner()
+
+    result = await designer.design_workflow(
+        {"architecture_type": "router", "selected_patterns": {}},
+        [],
+    )
+
+    assert result.feedback.fallback_used is False
+    assert result.entry_point == "intake"
+    assert [(edge.source, edge.target) for edge in result.edges] == [
+        ("intake", "finalize")
+    ]
+    assert result.exports.schema["terminal_nodes"] == ["finalize"]


### PR DESCRIPTION
## What changed

- Added a sentinel-edge normalizer that accepts direct `START -> node` and `node -> END` shorthand from generated graph specifications.
- Converts `START` edges into the canonical `entry_point` and removes unconditional `END` edges so the source becomes a terminal node.
- Preserves strict validation by rejecting conflicting entry points, multiple START destinations, invalid sentinel direction, unknown END sources, and terminal nodes with other outgoing routes.
- Updated the Graph Designer prompt to prefer canonical entry/terminal representations while documenting accepted shorthand.
- Added unit and GraphDesigner integration coverage for normalization and failure cases.

## Why

Live model output can naturally use valid LangGraph syntax such as `add_edge(START, "intake")` and `add_edge("finalize", END)`. The intermediate graph validator previously treated those sentinels as undeclared ordinary nodes, rejected an otherwise valid graph, and replaced it with an unrelated deterministic fallback.

## Impact

Generated graph designs can now use common LangGraph START/END notation without weakening downstream validation or reachability checks.

## Validation

- New Python files and the modified Graph Designer module pass `py_compile` locally.
- Added focused pytest coverage; repository CI should run the full suite on this draft PR.
